### PR TITLE
Document ingest architecture foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.worktrees/
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# Agent Guidance
+
+Start with [docs/automation/README.md](docs/automation/README.md) for compact
+automation guidance. Use [docs/product/user-stories.md](docs/product/user-stories.md)
+and [docs/architecture/000-system-overview.md](docs/architecture/000-system-overview.md)
+for product and architecture background unless the user explicitly changes
+direction.
+
+## Scope Boundaries
+
+- This repository is a portfolio-grade cloud-native .NET media asset ingest
+  backend.
+- Cloud target is Azure only.
+- The planned runtime is Docker containers on Kubernetes with Dapr Workflow,
+  Azure Service Bus, PostgreSQL, and a transactional outbox.
+- No load balancers, paid cloud actions, or production deployment are required
+  for the initial planning and local foundation.
+- Do not add `codex-workflows`, `.codex/agents`, or repo-local `.agents/skills`
+  unless the user explicitly adopts that workflow later.
+
+## Agent Execution Rules
+
+- Keep edits inside the requested scope and relevant ownership lane.
+- Do not full-scan the repo unless targeted context is insufficient.
+- Read only the automation docs and slice docs relevant to the task.
+- Do not let parallel work edit the same files at the same time.
+- Follow [docs/product/task-workflow.md](docs/product/task-workflow.md) for task execution.
+- Follow [docs/standards/bdd-tdd.md](docs/standards/bdd-tdd.md) for behavior changes.
+- Follow [docs/standards/domain-driven-design.md](docs/standards/domain-driven-design.md) for domain boundaries.
+- Follow [docs/standards/tooling.md](docs/standards/tooling.md) when tools or commands change.
+- Stop and ask before dependency changes, destructive Git operations, paid cloud
+  actions, secret handling, or changes outside the assigned scope.
+- Commits and pushes happen only when the user asks.
+
+## Architecture Principles
+
+- Treat the ingest mount as a plain filesystem path from application code.
+- Require `manifest.json` before package work starts.
+- Treat the manifest as metadata and a start signal, not the authoritative file
+  list.
+- Ingest every file physically present in the package directory.
+- Use Dapr Workflow for package orchestration and Azure Service Bus queues for
+  work distribution to specialized agents.
+- Keep PostgreSQL as the business source of truth.
+- Keep Dapr workflow runtime state separate from business state.
+- Use structured logs, OpenTelemetry traces, and business timeline events.
+
+## Secrets
+
+- Never commit secrets, credentials, private keys, tokens, `.env`, Terraform
+  state, generated kubeconfigs, or cloud subscription details.
+- Keep placeholders in examples; real values stay outside the repository.
+
+## Completion Checklist
+
+Before reporting completion for implementation or tooling tasks:
+
+- update relevant product, status, standards, and automation docs
+- run the cheapest relevant validation from `docs/automation/validation.md`
+- report validation evidence
+- mention any tests or validations that could not be run

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: help check-tools install-tools print-install-tools validate docs-check scripts-check
+
+help:
+	@printf '%s\n' "Available targets:"
+	@printf '%s\n' "  make check-tools         Verify required Linux development tools"
+	@printf '%s\n' "  make install-tools       Install supported Linux development tools"
+	@printf '%s\n' "  make print-install-tools Print manual installation commands"
+	@printf '%s\n' "  make validate            Run cheap repository validation"
+	@printf '%s\n' "  make docs-check          Check docs for unfinished placeholders"
+	@printf '%s\n' "  make scripts-check       Syntax-check shell scripts"
+
+check-tools:
+	@sh scripts/dev/check-tools.sh
+
+install-tools:
+	@sh scripts/dev/install-tools.sh
+
+print-install-tools:
+	@sh scripts/dev/install-tools.sh --print-only
+
+validate: docs-check scripts-check
+
+docs-check:
+	@npm run docs:check
+
+scripts-check:
+	@sh -n scripts/dev/check-tools.sh
+	@sh -n scripts/dev/install-tools.sh
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
 # media-asset-ingest
+
 Cloud-native media ingestion backend using Azure, messaging, observability, and identity patterns.
+
+See [docs/README.md](docs/README.md) for architecture, product planning,
+automation guidance, and ADRs.
+
+## Quickstart
+
+This repository is Linux-first and Docker-first. The default developer setup
+keeps host installs small and runs application/runtime tooling in containers
+where practical.
+
+### 1. Check host tools
+
+```bash
+make check-tools
+```
+
+Required host tools are intentionally minimal:
+
+- `bash`
+- `git`
+- `make`
+- `curl`
+- `jq`
+- `node`
+- `npm`
+- `docker`
+
+Optional tools such as `dotnet`, `kubectl`, `helm`, `dapr`, and `az` are useful
+for direct host workflows, but the preferred project direction is to expose
+containerized Makefile targets for those workflows as implementation begins.
+
+### 2. Install or print tool guidance
+
+```bash
+make print-install-tools
+```
+
+To run the interactive Linux installer:
+
+```bash
+make install-tools
+```
+
+The installer does not log in to Azure or create paid cloud resources.
+
+### 3. Validate the repository
+
+```bash
+make validate
+```
+
+At this stage validation checks documentation and shell script syntax. Runtime
+build/test targets will be added as the .NET solution and containers are
+introduced.
+
+## Development Model
+
+- Use BDD to frame user-visible behavior.
+- Use TDD for behavior changes and bug fixes.
+- Keep domain behavior independent of Dapr, Azure Service Bus, PostgreSQL, and
+  UI infrastructure details.
+- Update quickstart, automation, status, product, milestone, and tooling docs
+  when a task changes developer workflow or project behavior.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Documentation
+
+Start here for durable project documentation.
+
+## Sections
+
+- [automation](automation/README.md) - compact AI agent and local automation context.
+- [architecture](architecture/000-system-overview.md) - system design and runtime shape.
+- [adr](adr/README.md) - architecture decision records.
+- [product](product/user-stories.md) - user stories and milestones.
+- [standards](standards/dotnet.md) - implementation, testing, domain, and tooling standards.
+- [status](status/current-status.md) - current project state, decisions, and work log.

--- a/docs/adr/ADR-0001-use-azure-service-bus.md
+++ b/docs/adr/ADR-0001-use-azure-service-bus.md
@@ -1,0 +1,25 @@
+# ADR-0001: Use Azure Service Bus
+
+## Status
+
+Accepted
+
+## Context
+
+The system needs durable asynchronous command routing between package
+orchestration and specialized agents. Cloud target is Azure only.
+
+## Decision
+
+Use Azure Service Bus for brokered messaging.
+
+Commands use named queues. Topics can be added later when event fan-out becomes
+necessary.
+
+## Consequences
+
+- The production broker is Azure-native and managed.
+- Agents can scale independently by queue.
+- RabbitMQ is deferred because it would require self-management on AKS or a
+  third-party managed service.
+

--- a/docs/adr/ADR-0002-use-postgresql.md
+++ b/docs/adr/ADR-0002-use-postgresql.md
@@ -1,0 +1,23 @@
+# ADR-0002: Use PostgreSQL
+
+## Status
+
+Accepted
+
+## Context
+
+The system needs durable ingest state, auditability, and a transactional outbox.
+
+## Decision
+
+Use PostgreSQL for business state and the transactional outbox. Local
+development uses a PostgreSQL container. Azure production targets Azure Database
+for PostgreSQL Flexible Server.
+
+## Consequences
+
+- Outbox dispatch can use transactional writes with business state.
+- Business state remains queryable for the control plane UI.
+- Cosmos DB is deferred because the relational ingest/audit/outbox model is a
+  better v1 fit.
+

--- a/docs/adr/ADR-0003-use-dapr-workflow.md
+++ b/docs/adr/ADR-0003-use-dapr-workflow.md
@@ -1,0 +1,25 @@
+# ADR-0003: Use Dapr Workflow
+
+## Status
+
+Accepted
+
+## Context
+
+The system needs durable workflow orchestration for long-running media package
+ingest. It should remain Kubernetes-native, cost-conscious, and friendly to .NET
+workers.
+
+## Decision
+
+Use Dapr Workflow for package-level orchestration.
+
+## Consequences
+
+- Workflow definitions are code-first.
+- Dapr runtime state is stored separately from business state.
+- Temporal is deferred because paid managed service cost or heavier self-hosting
+  is not ideal for this portfolio project.
+- Camunda is deferred because BPMN/DMN visual authoring adds cost and
+  operational weight that is not required for v1.
+

--- a/docs/adr/ADR-0004-use-message-centric-orchestration.md
+++ b/docs/adr/ADR-0004-use-message-centric-orchestration.md
@@ -1,0 +1,23 @@
+# ADR-0004: Use Message-Centric Orchestration
+
+## Status
+
+Accepted
+
+## Context
+
+The system will have multiple specialized agents. Agents should process messages
+only from their respective queues.
+
+## Decision
+
+Use Dapr Workflow as the package coordination brain and Azure Service Bus as the
+work distribution backbone.
+
+## Consequences
+
+- Agents remain independently deployable and scalable.
+- Queue names define ownership boundaries.
+- The outbox remains central to reliable command/event publication.
+- Dapr activities are used selectively; agent work is primarily message-driven.
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,9 @@
+# Architecture Decision Records
+
+Accepted decisions:
+
+- [ADR-0001: Use Azure Service Bus](ADR-0001-use-azure-service-bus.md)
+- [ADR-0002: Use PostgreSQL](ADR-0002-use-postgresql.md)
+- [ADR-0003: Use Dapr Workflow](ADR-0003-use-dapr-workflow.md)
+- [ADR-0004: Use Message-Centric Orchestration](ADR-0004-use-message-centric-orchestration.md)
+

--- a/docs/architecture/000-system-overview.md
+++ b/docs/architecture/000-system-overview.md
@@ -1,0 +1,47 @@
+# System Overview
+
+## Purpose
+
+Media Asset Ingest is a portfolio-grade cloud-native .NET backend for ingesting
+media asset packages from a mounted filesystem path, coordinating asynchronous
+processing through workflows and queues, and exposing operational visibility
+through a workflow graph UI.
+
+## Target Architecture
+
+- Runtime: Docker containers on Kubernetes.
+- Cloud: Azure only.
+- Orchestration: Dapr Workflow.
+- Messaging: Azure Service Bus.
+- Persistence: PostgreSQL.
+- Reliability: transactional outbox.
+- Observability: structured JSON logs, OpenTelemetry traces, and business
+  progress/timeline state.
+- UI: workflow graph control plane with nested workflow drilldown and node logs.
+
+## Core Flow
+
+1. A watcher monitors a configured directory such as `/mnt/ingest`.
+2. Each immediate child directory is treated as an ingest package.
+3. Work starts only after `manifest.json` exists.
+4. The package scanner enumerates every file physically present in the directory.
+5. The classifier maps files to essence/work categories.
+6. The package workflow emits commands through the outbox to Azure Service Bus.
+7. Specialized agents consume only their assigned queues.
+8. Agents record business progress and logs with shared correlation fields.
+9. The done marker triggers reconciliation for late files.
+10. The package workflow finalizes after required work completes.
+
+## Key Separation
+
+Dapr Workflow coordinates package state transitions. Azure Service Bus distributes
+work. Agents execute specialized processing. PostgreSQL stores business truth.
+Dapr stores workflow runtime state in its own state store.
+
+## Deferred Decisions
+
+- Production mount backing: Azure Files, Blob CSI, or another Azure-backed option.
+- Exact relational schema.
+- Exact UI framework details beyond graph rendering requirements.
+- Full Azure deployment and cost profile.
+

--- a/docs/architecture/001-ingest-lifecycle.md
+++ b/docs/architecture/001-ingest-lifecycle.md
@@ -1,0 +1,39 @@
+# Ingest Lifecycle
+
+## Package Discovery
+
+The watcher monitors a configured filesystem path. Application code treats the
+path as a plain mounted directory. Local development can use a bind mount; Azure
+production can later bind the same path to Azure-backed storage.
+
+## Start Conditions
+
+An ingest package is not eligible for work until `manifest.json` exists. The
+manifest is a start signal and metadata source, not the authoritative list of
+files to ingest.
+
+## File Enumeration
+
+The scanner must ingest every file physically present in the package directory.
+If the manifest omits a file, the file is still ingested and marked as
+discovered. If the manifest references a missing file, that is a validation
+warning rather than a reason to skip real files.
+
+## Done Marker
+
+A zero-byte done marker indicates upload completion. The system may begin
+processing before the marker appears. When the marker appears, reconciliation
+rescans the directory, enqueues late files, and allows package finalization once
+all required work reaches a terminal state.
+
+## Essence Categories
+
+Initial categories:
+
+- video/source: `.mov`, `.mxf`, `.mp4`
+- text: `.srt`, `.txt`, `.vtt`
+- audio: `.mp3`, `.wav`
+- other: unknown sidecars or future essence types
+
+Classification rules should be easy to extend without rewriting workflow logic.
+

--- a/docs/architecture/002-workflow-orchestration.md
+++ b/docs/architecture/002-workflow-orchestration.md
@@ -1,0 +1,50 @@
+# Workflow Orchestration
+
+## Decision
+
+Use Dapr Workflow for durable package-level orchestration.
+
+## Workflow Style
+
+Use message-centric orchestration. Dapr coordinates lifecycle decisions, waits,
+timers, child workflows, and finalization. Azure Service Bus queues distribute
+actual work to independent agents.
+
+## Root Workflow
+
+The root workflow is `PackageIngestWorkflow`. It owns the package lifecycle:
+
+1. manifest detected
+2. package scan requested
+3. file classification requested
+4. work commands emitted
+5. agent completion events observed
+6. done marker observed or awaited
+7. reconciliation requested
+8. package finalized
+
+## Child Workflows
+
+Child workflows are allowed for meaningful lifecycle chunks:
+
+- package scan
+- file classification
+- essence group processing
+- proxy creation
+- reconciliation
+- finalization
+
+Do not make every tiny operation its own workflow. Use child workflows when the
+boundary improves clarity, retry behavior, or UI drilldown.
+
+## Parallelism
+
+Dapr Workflow supports fan-out/fan-in. A package workflow may start multiple
+child workflows or activities in parallel and wait for all required work to
+finish before reconciliation or finalization.
+
+## State Boundary
+
+Dapr workflow runtime state is not business truth. Business status, timeline,
+and audit state must be recorded in PostgreSQL application tables.
+

--- a/docs/architecture/003-messaging-and-outbox.md
+++ b/docs/architecture/003-messaging-and-outbox.md
@@ -1,0 +1,39 @@
+# Messaging And Outbox
+
+## Messaging
+
+Use Azure Service Bus. Commands are routed to named queues. Topics can be added
+later for integration events that need fan-out.
+
+Initial queues:
+
+- `ingest.package.scan`
+- `ingest.package.reconcile`
+- `ingest.package.finalize`
+- `ingest.file.video`
+- `ingest.file.audio`
+- `ingest.file.text`
+- `ingest.file.other`
+
+Agents consume only their assigned queues.
+
+## Outbox
+
+Use a transactional outbox in PostgreSQL. Business state changes and outbound
+messages are committed in the same transaction. A dedicated outbox dispatcher
+publishes pending messages to Azure Service Bus.
+
+## Responsibility Split
+
+- Domain/application logic decides which message should be sent and which queue
+  it targets.
+- The outbox dispatcher publishes already-decided messages.
+- The dispatcher does not classify files or make domain routing decisions.
+
+## Reliability Requirements
+
+- Messages must be idempotent.
+- Consumers must tolerate at-least-once delivery.
+- Dispatcher leasing must allow more than one dispatcher instance safely.
+- Poison/dead-letter behavior must be observable.
+

--- a/docs/architecture/004-observability-and-ui.md
+++ b/docs/architecture/004-observability-and-ui.md
@@ -1,0 +1,63 @@
+# Observability And Workflow UI
+
+## Observability Layers
+
+Use three layers:
+
+1. Structured JSON logs for diagnostics.
+2. OpenTelemetry traces for distributed correlation.
+3. PostgreSQL business state and timeline events for UI and audit.
+
+Logs are not the source of truth for UI status.
+
+## Correlation Fields
+
+Every service and agent should include:
+
+- `workflowInstanceId`
+- `packageId`
+- `fileId`
+- `workItemId`
+- `nodeId`
+- `agentType`
+- `queueName`
+- `correlationId`
+- `causationId`
+- `traceId`
+- `spanId`
+
+## Workflow UI
+
+The UI renders a graph model, not a generated bitmap. Nodes represent workflow
+steps, child workflows, or work items. Edges represent execution flow and
+dependencies.
+
+Node states:
+
+- pending: grey
+- queued: light grey or outlined
+- running: blue
+- succeeded: green
+- failed: red
+- waiting: amber
+- skipped: muted
+- cancelled: dark grey
+
+## Drilldown
+
+Nested workflows must support drilldown and back traversal. A user can enter a
+child workflow graph, inspect nodes, then return to the parent workflow graph.
+
+## Node Details
+
+Clicking a node should show:
+
+- business timeline entries
+- agent logs filtered by correlation fields
+- work item metadata
+- queue/message identifiers where available
+- trace link or trace identifiers where available
+
+The UI should initially poll APIs for graph state. SignalR can be added later
+for live updates.
+

--- a/docs/automation/README.md
+++ b/docs/automation/README.md
@@ -1,0 +1,26 @@
+# Automation Guide
+
+Low-token operating entrypoint for AI coding agents and local automation.
+
+## Read Order
+
+1. [context.md](context.md)
+2. [constraints.md](constraints.md)
+3. [repo-map.md](repo-map.md)
+4. [commands.md](commands.md)
+5. [validation.md](validation.md)
+6. [guardrails.md](guardrails.md)
+7. [roles.md](roles.md)
+
+## Durable References
+
+- [../product/user-stories.md](../product/user-stories.md) - product stories and acceptance themes.
+- [../product/milestones.md](../product/milestones.md) - planned delivery slices.
+- [../product/task-workflow.md](../product/task-workflow.md) - task lifecycle and required doc updates.
+- [../architecture](../architecture) - system design and runtime decisions.
+- [../adr](../adr) - architecture decision records.
+- [../standards](../standards) - implementation standards.
+- [../status/current-status.md](../status/current-status.md) - current project state and next actions.
+
+Long-form project knowledge lives in product, architecture, ADR, and standards
+documents. Automation docs should stay compact and execution-oriented.

--- a/docs/automation/commands.md
+++ b/docs/automation/commands.md
@@ -1,0 +1,21 @@
+# Commands
+
+| Command | Purpose | Cost | Docker | Cloud |
+| --- | --- | --- | --- | --- |
+| `git status --short` | Check working tree state. | cheap | no | no |
+| `git worktree list` | Show active worktrees. | cheap | no | no |
+| `rg "<term>" docs` | Targeted documentation search. | cheap | no | no |
+| `find docs -maxdepth 3 -type f -print` | List documentation files. | cheap | no | no |
+| `make help` | List canonical project commands. | cheap | no | no |
+| `make check-tools` | Verify required Linux development tools and report optional tools. | cheap | no | no |
+| `make install-tools` | Install supported Linux host tools after local confirmation. | moderate | no | no |
+| `make print-install-tools` | Print installation commands without running them. | cheap | no | no |
+| `make validate` | Run cheap repository validation. | cheap | no | no |
+| `npm run docs:check` | Check docs for unfinished placeholders. | cheap | no | no |
+| `npm run tools:check` | Verify required Linux development tools through npm. | cheap | no | no |
+
+Add Makefile targets once the runtime scaffold exists. Prefer the cheapest
+relevant validation command first.
+
+When a task adds a canonical command, update this file and
+`docs/automation/validation.md` when validation behavior changes.

--- a/docs/automation/constraints.md
+++ b/docs/automation/constraints.md
@@ -1,0 +1,15 @@
+# Agent Constraints
+
+- Do not add, print, commit, or infer secrets, tokens, private keys, `.env`,
+  Terraform state, or kubeconfigs.
+- Do not perform paid Azure actions without explicit approval.
+- Do not claim production readiness.
+- Do not introduce non-Azure cloud services into the target architecture.
+- Do not add `codex-workflows`, `.codex/agents`, or `.agents/skills` unless the
+  user explicitly asks.
+- Do not change standard LICENSE text.
+- Do not implement behavior unless the task explicitly asks for implementation.
+- Do not pollute human docs with agent chatter.
+- Keep automation docs compact; put durable explanations in architecture,
+  product, ADR, or standards docs.
+

--- a/docs/automation/context.md
+++ b/docs/automation/context.md
@@ -1,0 +1,16 @@
+# Agent Context
+
+- Portfolio-grade cloud-native .NET backend for media asset ingest.
+- Cloud target: Azure only.
+- Runtime target: Docker containers on Kubernetes, initially without load balancers.
+- Orchestration: Dapr Workflow.
+- Messaging: Azure Service Bus queues for commands, topics later when fan-out events are needed.
+- Data: PostgreSQL for business state and transactional outbox.
+- Dapr state: separate PostgreSQL-backed state store for workflow runtime data.
+- Ingest source: configured filesystem path such as `/mnt/ingest`.
+- Local dev mount: local directory bind-mounted into containers.
+- Production mount: Azure-backed storage decision deferred; app code sees a plain path.
+- UI direction: workflow graph visualization with nested workflow drilldown and node logs.
+- Development process: BDD for behavior framing, TDD for implementation, DDD for domain boundaries.
+- Tooling process: Linux-first, Docker-first, Makefile entrypoints, npm for
+  repo-level checks, and shell scripts for host tool detection/installation guidance.

--- a/docs/automation/guardrails.md
+++ b/docs/automation/guardrails.md
@@ -1,0 +1,23 @@
+# Guardrails
+
+- Keep diffs focused; avoid broad rewrites.
+- Avoid unrelated formatting churn.
+- Do not upgrade or add dependencies without a task-specific reason and approval where needed.
+- Do not generate or commit secrets.
+- Do not invent production-readiness claims.
+- Do not add non-Azure cloud dependencies to the target architecture.
+- Do not add large docs without updating the relevant index or read order.
+- Keep human and agent documentation lanes separate.
+- Preserve useful existing docs; move or summarize only when clearly misplaced, stale, duplicate, or unsafe.
+- Prefer durable business state over log scraping for UI behavior.
+- Use `workflowInstanceId`, `packageId`, `fileId`, `workItemId`, and `nodeId`
+  consistently when designing logs, traces, and UI projections.
+- Follow BDD/TDD for behavior changes unless the user approves an exception.
+- Keep domain behavior independent of Dapr, Azure Service Bus, PostgreSQL, and
+  UI infrastructure details.
+- Update status, backlog, milestone, standards, tooling, and automation docs
+  when a task changes their meaning.
+- Update `README.md` quickstart when setup, tools, commands, validation, or
+  local runtime behavior changes.
+- If a new required developer tool is introduced, update tooling standards,
+  detection, installation guidance, commands, and validation before completion.

--- a/docs/automation/repo-map.md
+++ b/docs/automation/repo-map.md
@@ -1,0 +1,28 @@
+# Repository Map
+
+Planned structure:
+
+- `src/MediaIngest.Api` - API for the ingest control plane UI.
+- `src/MediaIngest.Worker.Watcher` - filesystem package watcher.
+- `src/MediaIngest.Worker.Outbox` - transactional outbox dispatcher.
+- `src/MediaIngest.Workflow` - Dapr workflow definitions and orchestration contracts.
+- `src/MediaIngest.Agents.Video` - video/source essence agent.
+- `src/MediaIngest.Agents.Audio` - audio essence agent.
+- `src/MediaIngest.Agents.Text` - text essence agent.
+- `src/MediaIngest.Agents.Other` - fallback and sidecar agent.
+- `src/MediaIngest.Contracts` - command, event, and DTO contracts.
+- `src/MediaIngest.Persistence` - PostgreSQL persistence and outbox support.
+- `src/MediaIngest.Observability` - logging, tracing, and correlation helpers.
+- `web/ingest-control-plane` - workflow visualization UI.
+- `deploy/docker` - container build and local runtime assets.
+- `deploy/k8s` - Kubernetes manifests or Helm assets.
+- `deploy/dapr` - Dapr components and configuration.
+- `scripts/dev` - local developer bootstrap, checks, and lightweight validation helpers.
+- `docs/automation` - compact agent execution context.
+- `docs/architecture`, `docs/adr`, `docs/product`, `docs/standards` - durable project docs.
+- `docs/status` - current project status, decisions, and work log.
+- `Makefile` - canonical local command entrypoint.
+- `package.json` - repo-level npm scripts for documentation and tooling checks.
+
+The current repository is still in planning/foundation state. Do not assume the
+planned source tree exists until implementation begins.

--- a/docs/automation/roles.md
+++ b/docs/automation/roles.md
@@ -1,0 +1,69 @@
+# Ownership Lanes
+
+Named lanes describe repository ownership boundaries. They are not separate
+services unless implementation docs say so.
+
+## Rules
+
+- Use the narrowest lane that owns the files or behavior being changed.
+- Give production-adjacent work an explicit path list, validation command, and stop condition.
+- Do not let parallel work edit the same files at the same time.
+- Escalate if a task crosses lanes without an architecture or plan update.
+
+## Stop Conditions
+
+Stop and report instead of improvising when work needs:
+
+- Secrets, credentials, cloud billing, or external account access.
+- Destructive Git operations.
+- Schema or contract decisions that affect multiple phases.
+- Changes outside the assigned path list.
+- A failing validation command with an unclear cause.
+- Product or architecture decisions that conflict with current docs.
+
+## Lane Roster
+
+### Atlas - Architecture
+
+Owns system shape, ADRs, service boundaries, workflow boundaries, and non-functional requirements.
+
+### Mount - Ingest Watcher
+
+Owns filesystem mount watching, package detection, manifest detection, and done marker detection.
+
+### Pulse - Workflow
+
+Owns Dapr Workflow orchestration, child workflow structure, workflow events, and graph projection semantics.
+
+### Courier - Messaging And Outbox
+
+Owns Azure Service Bus routing, command/event contracts at the broker boundary, and outbox dispatch behavior.
+
+### Vault - Persistence
+
+Owns PostgreSQL persistence, business state, audit/timeline storage, and data access boundaries.
+
+### Essence - Media Agents
+
+Owns video, audio, text, sidecar, proxy, metadata, QC, and other specialized agents.
+
+### Beacon - Observability
+
+Owns structured logs, OpenTelemetry traces, correlation fields, metrics, and diagnostics.
+
+### Canvas - Workflow UI
+
+Owns the ingest control plane UI, workflow graph rendering, nested workflow drilldown, and node log views.
+
+### Forge - Platform
+
+Owns Docker, local runtime, Kubernetes, Dapr components, Azure deployment docs, and host tooling.
+
+### Gauge - QA
+
+Owns test strategy, integration tests, smoke tests, and validation evidence.
+
+### Shield - Security
+
+Owns secrets policy, identity boundaries, container safety, and cloud security review.
+

--- a/docs/automation/validation.md
+++ b/docs/automation/validation.md
@@ -1,0 +1,16 @@
+# Validation Matrix
+
+| Change type | Minimal validation | Stronger validation | Docker? | Cloud? | Cost |
+| --- | --- | --- | --- | --- | --- |
+| Docs-only change | `make docs-check` | markdown lint when tooling exists | no | no | cheap |
+| Architecture/ADR change | targeted term search for contradictory decisions | review affected ADRs and architecture docs together | no | no | cheap |
+| Automation-doc change | `make validate` | read `AGENTS.md`, task workflow, and automation docs for consistency | no | no | cheap |
+| Standards change | `make validate` | review affected automation docs and task workflow | no | no | cheap |
+| Tooling change | `make validate` and `make check-tools` when host tools are expected | `make print-install-tools` review | no | no | cheap |
+| .NET code change | focused unit test command once solution exists | full test suite once available | no by default | no | moderate |
+| Docker/Kubernetes change | relevant local smoke test once scripts exist | full local runtime validation | yes | no | moderate |
+| Azure deployment change | static manifest/terraform validation only | manual cloud validation after approval | maybe | yes | paid/approval |
+
+Do not run expensive Docker or cloud validation for docs-only edits.
+
+Agents must report validation commands and outcomes before claiming completion.

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -1,0 +1,26 @@
+# Backlog
+
+Backlog items should reference user stories and milestones. Keep this file at
+epic/story granularity; detailed implementation tasks belong in plans.
+
+## Ready For Planning
+
+- Define local development foundation.
+- Scaffold .NET solution and project boundaries.
+- Define PostgreSQL persistence and outbox foundation.
+- Define Azure Service Bus abstractions and local development strategy.
+- Define Dapr Workflow runtime and package workflow contracts.
+
+## Later
+
+- Implement specialized media agents.
+- Implement workflow graph API.
+- Implement React workflow control plane.
+- Add Kubernetes and Dapr deployment assets.
+- Add Azure deployment documentation.
+
+## Update Rule
+
+Agents must update this file when adding, completing, splitting, or deferring
+product-visible work.
+

--- a/docs/product/milestones.md
+++ b/docs/product/milestones.md
@@ -1,0 +1,72 @@
+# Milestones
+
+## Milestone 1: Documentation And Local Foundation
+
+- Automation context and guardrails.
+- Architecture overview.
+- ADRs.
+- Product stories.
+- Initial standards.
+- Status, task workflow, and work log.
+- Linux tool check/install guidance.
+- Makefile and npm validation entrypoints.
+
+## Milestone 2: .NET Solution And Local Runtime
+
+- .NET solution structure.
+- Docker Compose or equivalent local services.
+- PostgreSQL local database.
+- Basic health checks.
+
+## Milestone 3: Ingest Package Lifecycle
+
+- Filesystem watcher.
+- Manifest gating.
+- Package scan.
+- Done marker reconciliation.
+- File classification.
+
+## Milestone 4: Messaging And Outbox
+
+- PostgreSQL transactional outbox.
+- Outbox dispatcher.
+- Azure Service Bus abstraction.
+- Local broker development strategy.
+
+## Milestone 5: Dapr Workflow Orchestration
+
+- Package ingest workflow.
+- Child workflow boundaries.
+- Workflow events and signals.
+- Workflow state separation.
+
+## Milestone 6: Specialized Agents
+
+- Video agent.
+- Audio agent.
+- Text agent.
+- Other/sidecar agent.
+- Proxy creation agent.
+
+## Milestone 7: Observability
+
+- Structured JSON logs.
+- OpenTelemetry traces.
+- Correlation fields.
+- Business timeline/progress events.
+
+## Milestone 8: Workflow Visualization UI
+
+- Workflow graph API.
+- Node status projection.
+- React graph UI.
+- Node details and logs.
+- Nested workflow drilldown and back traversal.
+
+## Milestone 9: Kubernetes And Azure Readiness
+
+- Kubernetes manifests.
+- Dapr component definitions.
+- Azure Service Bus configuration docs.
+- Azure PostgreSQL configuration docs.
+- Cost-conscious deployment notes.

--- a/docs/product/task-workflow.md
+++ b/docs/product/task-workflow.md
@@ -1,0 +1,44 @@
+# Task Workflow
+
+## Required Flow
+
+Each implementation task should follow:
+
+1. Confirm scope and ownership lane.
+2. Read `AGENTS.md` and `docs/automation/README.md`.
+3. Read relevant architecture, ADR, product, and standards docs.
+4. Write or identify a BDD scenario for user-visible behavior.
+5. Write a failing test before production code.
+6. Implement the smallest change that passes.
+7. Refactor while tests stay green.
+8. Run the validation command from `docs/automation/validation.md`.
+9. Update impacted docs.
+10. Report validation evidence.
+
+## Required Documentation Updates
+
+Before a task is complete, update the relevant files:
+
+- `docs/status/current-status.md` when phase, focus, next action, or milestone state changes.
+- `docs/status/work-log.md` for meaningful completed work or bug fixes.
+- `docs/product/backlog.md` when work is added, completed, split, or deferred.
+- `docs/product/milestones.md` when milestone scope or progress changes.
+- `docs/product/user-stories.md` when acceptance meaning changes.
+- `README.md` quickstart when onboarding, setup, commands, or validation changes.
+- `docs/adr` when an architectural decision changes.
+- `docs/standards/tooling.md` when a required development tool changes.
+- `scripts/dev/check-tools.sh` when a required tool must be detected.
+- `scripts/dev/install-tools.sh` when a required tool should be installable.
+- `docs/automation/commands.md` when a canonical command is added or changed.
+- `docs/automation/validation.md` when validation expectations change.
+
+## Bug Fixes
+
+Bug fixes must include:
+
+- the observed behavior
+- the expected behavior
+- a failing regression test first, unless the user approves an exception
+- the fix
+- validation evidence
+- any status or work-log update

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -1,0 +1,96 @@
+# User Stories
+
+## Ingest Foundation
+
+### Watch ingest mount
+
+As an ingest operator, I want the system to monitor a configured mounted
+directory, so that new media packages are detected automatically.
+
+Acceptance themes:
+
+- Path is configuration-driven.
+- Local development can use local filesystem storage.
+- Production storage backing is hidden behind the mount.
+
+### Start only when manifest exists
+
+As an ingest producer, I want ingest to start only after `manifest.json` exists,
+so that incomplete package directories are not processed prematurely.
+
+### Ingest all discovered files
+
+As a MAM operator, I want the system to ingest every file physically present in
+the package directory, so that incorrect manifests do not cause files to be
+skipped.
+
+### Reconcile on done marker
+
+As an ingest operator, I want the system to rescan a package when the done marker
+appears, so that late-arriving files are not missed.
+
+## Routing And Agents
+
+### Classify media essences
+
+As an ingest system, I want to classify discovered files by essence type, so
+that video, audio, text, and sidecar files can be routed to specialized agents.
+
+### Route work through ASB queues
+
+As a platform engineer, I want file processing commands routed to named Azure
+Service Bus queues, so that each specialized agent only consumes work it owns.
+
+### Process with specialized agents
+
+As an operator, I want specialized agents for video, audio, text, proxy, and
+other processing, so that each processing concern can scale and fail
+independently.
+
+## Reliability And Workflow
+
+### Use transactional outbox
+
+As a backend engineer, I want state changes and outbound messages committed
+atomically, so that ingest work is not lost when services crash.
+
+### Orchestrate package lifecycle with Dapr
+
+As an ingest operator, I want a durable workflow per ingest package, so that
+package progress survives crashes and can coordinate asynchronous agents.
+
+### Support nested workflows
+
+As a workflow operator, I want package workflows to drill into child workflows,
+so that complex ingest processing remains understandable.
+
+## Observability And UI
+
+### Record agent progress
+
+As an operator, I want each agent to record business progress and structured
+logs with `workflowInstanceId`, so that processing can be audited and
+correlated.
+
+### Visualize workflow execution
+
+As an operator, I want to see workflow nodes change color by status, so that I
+can quickly understand what is pending, running, failed, or complete.
+
+### Inspect node logs
+
+As an operator, I want to click a workflow node and view its logs and timeline,
+so that I can diagnose failures without searching raw logs manually.
+
+### Drill into nested workflows
+
+As an operator, I want to drill into child workflow graphs and navigate back to
+parent workflows, so that nested processing remains explorable.
+
+## Platform
+
+### Deploy to Kubernetes
+
+As a platform engineer, I want all services containerized and deployable to
+Kubernetes, so that the system matches a cloud-native Azure runtime model.
+

--- a/docs/standards/bdd-tdd.md
+++ b/docs/standards/bdd-tdd.md
@@ -1,0 +1,48 @@
+# BDD And TDD Standards
+
+## BDD
+
+User-visible behavior starts with a scenario. Scenarios may live in product docs,
+test names, Gherkin files, or test fixtures depending on the implementation
+slice.
+
+Good scenarios use domain language:
+
+```gherkin
+Scenario: Ingest starts when a manifest appears
+  Given an ingest package directory exists
+  And the package contains manifest.json
+  When the watcher scans the ingest mount
+  Then a package workflow is started
+  And the package files are scanned for classification
+```
+
+## TDD
+
+Production behavior changes require a failing test first.
+
+Required cycle:
+
+1. RED: write a focused failing test.
+2. Verify RED: run it and confirm the expected failure.
+3. GREEN: write the smallest implementation.
+4. Verify GREEN: run the test and confirm it passes.
+5. REFACTOR: clean up while tests remain green.
+
+Agents must report RED/GREEN evidence when implementing features or bug fixes.
+
+## Exceptions
+
+TDD exceptions require explicit user approval or a documented reason in the task
+result. Acceptable exceptions include documentation-only changes, generated
+files, and tooling scripts where command-level validation is the primary proof.
+
+## Completion Rule
+
+A feature, behavior change, or bug fix is not complete until:
+
+- acceptance behavior is described
+- tests or validation prove the behavior
+- impacted docs are updated
+- validation evidence is reported
+

--- a/docs/standards/domain-driven-design.md
+++ b/docs/standards/domain-driven-design.md
@@ -1,0 +1,48 @@
+# Domain-Driven Design Standards
+
+## Domain Language
+
+Use consistent terms:
+
+- ingest package
+- manifest
+- done marker
+- essence
+- source/master video
+- sidecar
+- work item
+- agent
+- workflow instance
+- workflow node
+- package timeline
+
+## Boundaries
+
+Keep domain behavior separate from infrastructure.
+
+- Domain/application code decides package lifecycle and routing intent.
+- Infrastructure adapters talk to Dapr, Azure Service Bus, PostgreSQL, filesystems, and logging backends.
+- Agents own specialized processing capabilities.
+- UI projections read business state, not Dapr runtime internals or raw logs.
+
+## Aggregates And Concepts
+
+Initial domain concepts:
+
+- Ingest package: one subdirectory under the ingest mount.
+- Discovered file: one file physically present in a package.
+- Work item: one processing request for a file or package.
+- Workflow node: one UI-visible step in a workflow graph.
+- Timeline event: business-facing record of something that happened.
+
+Exact persistence schemas are deferred, but implementation should preserve these
+conceptual boundaries.
+
+## Rules
+
+- Do not leak Azure Service Bus or Dapr types into domain model names.
+- Do not make manifest file lists authoritative.
+- Do not store UI status only in logs.
+- Do not make workflow runtime state the business source of truth.
+- Keep idempotency explicit at message and agent boundaries.
+

--- a/docs/standards/dotnet.md
+++ b/docs/standards/dotnet.md
@@ -1,0 +1,28 @@
+# .NET Standards
+
+## Direction
+
+Use modern .NET worker services and APIs with clear boundaries between workflow,
+messaging, persistence, agents, and observability.
+
+## Principles
+
+- Prefer explicit contracts for commands, events, and API DTOs.
+- Keep agents focused on one processing capability.
+- Keep workflow code orchestration-focused; do not hide business state only in
+  workflow runtime data.
+- Make message handlers idempotent.
+- Use dependency injection for infrastructure boundaries.
+- Use structured logging with correlation fields.
+- Prefer focused tests around domain behavior, message handling, and persistence
+  boundaries.
+- Follow [BDD and TDD standards](bdd-tdd.md) for behavior changes.
+- Follow [DDD standards](domain-driven-design.md) for domain boundaries.
+
+## Naming
+
+- Use `workflowInstanceId` for Dapr workflow instance correlation.
+- Use `packageId` for ingest package identity.
+- Use `fileId` for discovered file identity.
+- Use `workItemId` for processing work identity.
+- Use `nodeId` for workflow graph node identity.

--- a/docs/standards/tooling.md
+++ b/docs/standards/tooling.md
@@ -1,0 +1,78 @@
+# Tooling Standards
+
+## Supported Development Platform
+
+Linux is the supported developer workstation platform for this repository.
+Ubuntu/Debian are the first-class installation target for bootstrap scripts.
+
+## Canonical Entrypoints
+
+Use:
+
+- `make check-tools` to verify host tools.
+- `make install-tools` to install or print installation guidance for host tools.
+- `make validate` for cheap repository validation.
+- `npm run docs:check` for docs placeholder checks.
+- `npm run tools:check` for host tool checks through npm.
+
+## Tooling Strategy
+
+Prefer Docker-first development. Keep host installs small and run application
+SDKs or cloud CLIs in containers where this keeps setup repeatable.
+
+Host-native installs are allowed when they improve day-to-day development, but
+they should be optional unless the workflow cannot work reliably in containers.
+
+## Required Host Tools
+
+Initial required tools:
+
+- `bash`
+- `git`
+- `make`
+- `curl`
+- `jq`
+- `node`
+- `npm`
+- `docker`
+
+## Optional Host Tools
+
+These tools may be installed locally, but project Makefile targets should prefer
+containerized equivalents where practical:
+
+- `dotnet`
+- `kubectl`
+- `helm`
+- `dapr`
+- `az`
+
+Notes:
+
+- .NET SDK: prefer SDK containers for build/test targets; host install is optional.
+- Azure CLI: prefer the official Azure CLI container or manual host install; login
+  remains manual either way.
+- kubectl/Helm/Dapr: host installs are convenient, but deployment-oriented
+  targets can use a project tools container later.
+
+## Adding Tools
+
+If a task introduces a new required development tool, agents must update:
+
+- `README.md` quickstart when the developer onboarding path changes
+- this file
+- `scripts/dev/check-tools.sh`
+- `scripts/dev/install-tools.sh` when automated installation is appropriate
+- `docs/automation/commands.md` if the tool adds a canonical command
+- `docs/automation/validation.md` if validation behavior changes
+- `package.json` scripts if the tool is part of repo-level npm automation
+
+## Installation Rules
+
+- Installation scripts must not perform cloud login.
+- Installation scripts must not create paid cloud resources.
+- Installation scripts may use `sudo` only after the developer intentionally
+  runs them locally.
+- Prefer explicit package sources and version-aware commands.
+- If a tool cannot be installed safely by script, print manual instructions.
+- Prefer containerized tool execution for heavyweight SDKs and cloud CLIs.

--- a/docs/standards/typescript-react.md
+++ b/docs/standards/typescript-react.md
@@ -1,0 +1,19 @@
+# TypeScript And React Standards
+
+## Direction
+
+The workflow control plane UI should be operational, dense, and clear. Avoid a
+marketing-style landing page. The first screen should help an operator inspect
+ingest packages and workflow state.
+
+## Principles
+
+- Render workflow graphs from API-provided graph DTOs.
+- Do not query logs as the source of node status.
+- Use business state for graph colors and timeline.
+- Keep node detail views focused on timeline, logs, identifiers, and failure
+  context.
+- Support nested workflow drilldown and back traversal.
+- Prefer accessible color states with labels or icons where status ambiguity is
+  possible.
+

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -1,0 +1,37 @@
+# Current Status
+
+## Project State
+
+- Phase: planning and repository foundation.
+- Current branch: `docs/initial-plans`.
+- Current focus: durable project documentation, automation guidance, standards,
+  and toolchain bootstrap.
+
+## Completed
+
+- Initial architecture direction selected.
+- Azure Service Bus selected for messaging.
+- PostgreSQL selected for business state and outbox.
+- Dapr Workflow selected for orchestration.
+- Message-centric orchestration selected.
+- Automation docs and ownership lanes created.
+- Product stories and milestones created.
+- BDD/TDD, DDD, and tooling standards created.
+- Linux tool check/install scripts created.
+- Makefile and npm validation entrypoints created.
+- README quickstart added with Linux-first and Docker-first guidance.
+
+## In Progress
+
+- Documentation review and validation.
+
+## Next
+
+- Review and refine documentation.
+- Commit planning foundation after user approval.
+- Create implementation plan for local foundation.
+
+## Update Rule
+
+Agents must update this file when a task changes the project phase, active
+milestone, completed work, current focus, or next action.

--- a/docs/status/decision-log.md
+++ b/docs/status/decision-log.md
@@ -1,0 +1,17 @@
+# Decision Log
+
+This file records short operational decisions that do not need a full ADR.
+Architecture-significant decisions belong in `docs/adr`.
+
+## Decisions
+
+- Use `docs/automation` for low-token agent context.
+- Avoid `codex-workflows` for now; use Superpowers and repo-local automation docs.
+- Keep `.codex/agents` and `.agents/skills` out of the repo unless explicitly adopted later.
+- Use Linux as the supported development workstation assumption.
+
+## Update Rule
+
+Agents must add an entry here when a decision affects workflow, tooling,
+documentation structure, or development process but does not justify a full ADR.
+

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -1,0 +1,19 @@
+# Work Log
+
+Use this log for concise human-readable progress notes. Do not duplicate commit
+messages or paste command output unless it explains a decision.
+
+## 2026-05-03
+
+- Created planning worktree `docs/initial-plans`.
+- Added architecture, ADR, product, automation, and standards documentation.
+- Added repository operating model for status, task workflow, and toolchain checks.
+- Added BDD/TDD, DDD, and tooling standards.
+- Added Linux development tool check/install scripts.
+- Added Makefile and package.json entrypoints for validation.
+- Added README quickstart and Docker-first tooling direction.
+
+## Update Rule
+
+Agents should add a dated bullet when completing a meaningful task, fixing a
+bug, changing development workflow, or adding a new tool requirement.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "media-asset-ingest",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cloud-native media asset ingest backend planning and repository tooling.",
+  "scripts": {
+    "docs:check": "node scripts/dev/check-docs.mjs",
+    "tools:check": "sh scripts/dev/check-tools.sh"
+  },
+  "devDependencies": {}
+}
+

--- a/scripts/dev/check-docs.mjs
+++ b/scripts/dev/check-docs.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const roots = ['AGENTS.md', 'README.md', 'docs'];
+const patterns = [
+  { pattern: /\bTODO\b/g, allow: ['docs/automation/validation.md'] },
+  { pattern: /\bTBD\b/g, allow: ['docs/automation/validation.md'] },
+  { pattern: /\bFIXME\b/g, allow: [] },
+  { pattern: /<placeholder>/g, allow: [] }
+];
+
+function listFiles(path) {
+  const stat = statSync(path);
+  if (stat.isFile()) {
+    return [path];
+  }
+
+  return readdirSync(path).flatMap((entry) => listFiles(join(path, entry)));
+}
+
+const files = roots.flatMap((root) => listFiles(root));
+const findings = [];
+
+for (const file of files) {
+  const text = readFileSync(file, 'utf8');
+  const lines = text.split(/\r?\n/);
+
+  for (const { pattern, allow } of patterns) {
+    if (allow.includes(file)) {
+      continue;
+    }
+
+    lines.forEach((line, index) => {
+      pattern.lastIndex = 0;
+      if (pattern.test(line)) {
+        findings.push(`${file}:${index + 1}: ${line}`);
+      }
+    });
+  }
+}
+
+if (findings.length > 0) {
+  console.error('Unfinished documentation markers found:');
+  for (const finding of findings) {
+    console.error(finding);
+  }
+  process.exit(1);
+}
+
+console.log('Documentation placeholder check passed.');
+

--- a/scripts/dev/check-tools.sh
+++ b/scripts/dev/check-tools.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -u
+
+required_tools="
+bash
+git
+make
+curl
+jq
+node
+npm
+docker
+"
+
+optional_tools="
+dotnet
+kubectl
+helm
+dapr
+az
+"
+
+missing=0
+optional_missing=0
+
+check_tool() {
+  tool="$1"
+  label="$2"
+
+  if command -v "$tool" >/dev/null 2>&1; then
+    path=$(command -v "$tool")
+    version=$("$tool" --version 2>/dev/null | head -n 1 || true)
+    if [ -n "$version" ]; then
+      printf 'ok       %-8s %-8s %s (%s)\n' "$label" "$tool" "$path" "$version"
+    else
+      printf 'ok       %-8s %-8s %s\n' "$label" "$tool" "$path"
+    fi
+  else
+    printf 'missing  %-8s %-8s\n' "$label" "$tool"
+    return 1
+  fi
+}
+
+printf '%s\n' "Checking required development tools..."
+
+for tool in $required_tools; do
+  if ! check_tool "$tool" "required"; then
+    missing=1
+  fi
+done
+
+if [ "$missing" -ne 0 ]; then
+  printf '\n%s\n' "One or more tools are missing."
+  printf '%s\n' "Run: make install-tools"
+  exit 1
+fi
+
+printf '\n%s\n' "Checking optional host tools..."
+
+for tool in $optional_tools; do
+  if ! check_tool "$tool" "optional"; then
+    optional_missing=1
+  fi
+done
+
+if [ "$optional_missing" -ne 0 ]; then
+  printf '\n%s\n' "Optional tools are missing. This is acceptable for Docker-first workflows."
+  printf '%s\n' "Run: make print-install-tools for manual guidance."
+fi
+
+printf '\n%s\n' "Required development tools are available."

--- a/scripts/dev/install-tools.sh
+++ b/scripts/dev/install-tools.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -eu
+
+if [ "$(uname -s)" != "Linux" ]; then
+  printf '%s\n' "This bootstrap script supports Linux only."
+  exit 1
+fi
+
+if [ -r /etc/os-release ]; then
+  . /etc/os-release
+else
+  printf '%s\n' "Cannot detect Linux distribution because /etc/os-release is missing."
+  exit 1
+fi
+
+case "${ID:-}" in
+  ubuntu|debian)
+    ;;
+  *)
+    printf 'Unsupported distribution: %s\n' "${PRETTY_NAME:-unknown}"
+    printf '%s\n' "Install the tools listed in docs/standards/tooling.md manually."
+    exit 1
+    ;;
+esac
+
+if [ "${1:-}" = "--print-only" ]; then
+  mode="print"
+else
+  mode="install"
+fi
+
+print_manual_notes() {
+  cat <<'EOF'
+
+Manual follow-up may still be required:
+- Docker may require adding your user to the docker group and starting a new shell.
+- Azure CLI requires `az login` before cloud use.
+- Dapr requires `dapr init` before local Dapr runtime use.
+- kubectl requires a kubeconfig before cluster access.
+- This script does not create paid Azure resources.
+EOF
+}
+
+print_commands() {
+  cat <<'EOF'
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg lsb-release apt-transport-https make jq nodejs npm
+
+# Optional .NET SDK:
+# Prefer SDK containers through Makefile targets once available. Install
+# locally only if you want host-native dotnet commands.
+
+# Docker CLI installation:
+# Follow Docker Engine apt repository instructions if your distro package is too old.
+
+# Optional kubectl:
+curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+rm -f kubectl
+
+# Optional Helm:
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# Optional Dapr CLI:
+curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | /bin/bash
+
+# Optional Azure CLI:
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+EOF
+}
+
+if [ "$mode" = "print" ]; then
+  print_commands
+  print_manual_notes
+  exit 0
+fi
+
+printf '%s\n' "This script installs Linux host tools for this repository."
+printf '%s\n' "It may use sudo for system packages and CLI installation."
+printf '%s\n' "It will not log in to Azure or create cloud resources."
+printf '%s\n' "The project prefers Docker-first workflows; heavyweight SDK/CLI host installs are optional."
+printf '%s' "Continue? [y/N] "
+read -r answer
+
+case "$answer" in
+  y|Y|yes|YES)
+    ;;
+  *)
+    printf '%s\n' "Installation cancelled."
+    exit 0
+    ;;
+esac
+
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg lsb-release apt-transport-https make jq nodejs npm
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+  sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+  rm -f kubectl
+fi
+
+if ! command -v helm >/dev/null 2>&1; then
+  curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+fi
+
+if ! command -v dapr >/dev/null 2>&1; then
+  curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | /bin/bash
+fi
+
+if ! command -v az >/dev/null 2>&1; then
+  curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+fi
+
+cat <<'EOF'
+
+Scripted bootstrap complete for supported host tools.
+
+If dotnet or docker are still missing, install them from their official
+Linux package repositories or use the future containerized Makefile targets, then rerun:
+  make check-tools
+EOF
+
+print_manual_notes


### PR DESCRIPTION
## Summary
- Adds agent automation guidance, ownership lanes, guardrails, and validation rules.
- Documents the initial Azure-native media ingest architecture, ADRs, milestones, and user stories.
- Adds Docker-first Linux quickstart, BDD/TDD/DDD standards, and lightweight tooling checks.

## Validation
- make validate
- make check-tools
- git diff --check

## Notes
- CI is disabled for this repository, so no GitHub Actions checks are expected.
- Optional host tools dotnet, kubectl, helm, dapr, and az are intentionally optional for Docker-first workflows.