### PR TITLE
Add story planning tracker workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,12 +25,21 @@ direction.
 - Read only the automation docs and slice docs relevant to the task.
 - Do not let parallel work edit the same files at the same time.
 - Follow [docs/product/task-workflow.md](docs/product/task-workflow.md) for task execution.
+- Follow [docs/automation/execution-checklist.md](docs/automation/execution-checklist.md) before starting and before reporting completion.
+- Follow [docs/automation/parallelization.md](docs/automation/parallelization.md) when dispatching parallel agents.
+- Use [docs/automation/agent-handoff.md](docs/automation/agent-handoff.md) for task handoff results.
+- Use [docs/automation/conflict-protocol.md](docs/automation/conflict-protocol.md) when scope, architecture, validation, or parallel work conflicts arise.
+- Use [docs/automation/github-projects.md](docs/automation/github-projects.md) when changing GitHub issues, milestones, projects, bugs, or PR tracking state.
 - Follow [docs/standards/bdd-tdd.md](docs/standards/bdd-tdd.md) for behavior changes.
 - Follow [docs/standards/domain-driven-design.md](docs/standards/domain-driven-design.md) for domain boundaries.
 - Follow [docs/standards/tooling.md](docs/standards/tooling.md) when tools or commands change.
 - Stop and ask before dependency changes, destructive Git operations, paid cloud
   actions, secret handling, or changes outside the assigned scope.
-- Commits and pushes happen only when the user asks.
+- Update [docs/plans/active-worktrees.md](docs/plans/active-worktrees.md) when creating, using, PR-opening, merging, or cleaning up worktrees.
+- Keep GitHub Projects as the human-facing source of truth for roadmap, issue,
+  milestone, bug, and PR state once remote tracker access is available.
+- Commits, pushes, and PR creation happen only when the user asks or when a task
+  explicitly grants automatic PR creation after validation.
 
 ## Architecture Principles
 
@@ -57,5 +66,6 @@ Before reporting completion for implementation or tooling tasks:
 
 - update relevant product, status, standards, and automation docs
 - run the cheapest relevant validation from `docs/automation/validation.md`
+- satisfy the relevant definition of done in `docs/automation/definition-of-done.md`
 - report validation evidence
 - mention any tests or validations that could not be run

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help check-tools install-tools print-install-tools validate docs-check scripts-check
+.PHONY: help check-tools install-tools print-install-tools validate docs-check scripts-check github-project-check github-project-summary github-project-hierarchy github-project-active
 
 help:
 	@printf '%s\n' "Available targets:"
@@ -8,6 +8,10 @@ help:
 	@printf '%s\n' "  make validate            Run cheap repository validation"
 	@printf '%s\n' "  make docs-check          Check docs for unfinished placeholders"
 	@printf '%s\n' "  make scripts-check       Syntax-check shell scripts"
+	@printf '%s\n' "  make github-project-check     Verify GitHub CLI auth and project access"
+	@printf '%s\n' "  make github-project-summary   Print GitHub tracker counts"
+	@printf '%s\n' "  make github-project-hierarchy Print epic/story hierarchy"
+	@printf '%s\n' "  make github-project-active    Print in-progress project items"
 
 check-tools:
 	@sh scripts/dev/check-tools.sh
@@ -26,4 +30,16 @@ docs-check:
 scripts-check:
 	@sh -n scripts/dev/check-tools.sh
 	@sh -n scripts/dev/install-tools.sh
+	@sh -n scripts/dev/github-projects.sh
 
+github-project-check:
+	@sh scripts/dev/github-projects.sh check-auth
+
+github-project-summary:
+	@sh scripts/dev/github-projects.sh summary
+
+github-project-hierarchy:
+	@sh scripts/dev/github-projects.sh hierarchy
+
+github-project-active:
+	@sh scripts/dev/github-projects.sh active

--- a/README.md
+++ b/README.md
@@ -64,3 +64,5 @@ introduced.
   UI infrastructure details.
 - Update quickstart, automation, status, product, milestone, and tooling docs
   when a task changes developer workflow or project behavior.
+- Keep GitHub Projects updated for roadmap, issue, milestone, task, bug, and PR
+  state; repo docs keep durable standards and context.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,5 +8,16 @@ Start here for durable project documentation.
 - [architecture](architecture/000-system-overview.md) - system design and runtime shape.
 - [adr](adr/README.md) - architecture decision records.
 - [product](product/user-stories.md) - user stories and milestones.
+- [plans](plans/README.md) - milestone plans, task plans, and planning workflow.
+- [bugs](bugs/README.md) - bug reports and defect tracking.
 - [standards](standards/dotnet.md) - implementation, testing, domain, and tooling standards.
 - [status](status/current-status.md) - current project state, decisions, and work log.
+
+Agent execution guardrails:
+
+- [execution checklist](automation/execution-checklist.md)
+- [parallelization](automation/parallelization.md)
+- [agent handoff](automation/agent-handoff.md)
+- [definition of done](automation/definition-of-done.md)
+- [conflict protocol](automation/conflict-protocol.md)
+- [PR checklist](automation/pr-checklist.md)

--- a/docs/automation/README.md
+++ b/docs/automation/README.md
@@ -11,16 +11,26 @@ Low-token operating entrypoint for AI coding agents and local automation.
 5. [validation.md](validation.md)
 6. [guardrails.md](guardrails.md)
 7. [roles.md](roles.md)
+8. [execution-checklist.md](execution-checklist.md)
+9. [parallelization.md](parallelization.md) when dispatching parallel agents
+10. [agent-handoff.md](agent-handoff.md) before reporting task results
+11. [github-projects.md](github-projects.md) when work changes issues, milestones, or project state
 
 ## Durable References
 
 - [../product/user-stories.md](../product/user-stories.md) - product stories and acceptance themes.
 - [../product/milestones.md](../product/milestones.md) - planned delivery slices.
 - [../product/task-workflow.md](../product/task-workflow.md) - task lifecycle and required doc updates.
+- [../plans/README.md](../plans/README.md) - milestone and task plan structure.
+- [../bugs/README.md](../bugs/README.md) - defect report structure.
 - [../architecture](../architecture) - system design and runtime decisions.
 - [../adr](../adr) - architecture decision records.
 - [../standards](../standards) - implementation standards.
 - [../status/current-status.md](../status/current-status.md) - current project state and next actions.
+- [definition-of-done.md](definition-of-done.md) - completion criteria by work type.
+- [conflict-protocol.md](conflict-protocol.md) - escalation rules for scope, architecture, parallel, and validation conflicts.
+- [pr-checklist.md](pr-checklist.md) - pull request creation and merge checklist.
+- [github-projects.md](github-projects.md) - GitHub Projects tracker model and CLI commands.
 
 Long-form project knowledge lives in product, architecture, ADR, and standards
 documents. Automation docs should stay compact and execution-oriented.

--- a/docs/automation/agent-handoff.md
+++ b/docs/automation/agent-handoff.md
@@ -1,0 +1,62 @@
+# Agent Handoff
+
+Every implementation, review, or bug-fix agent should return a concise handoff.
+
+## Required Handoff Format
+
+```text
+status: completed | blocked | escalation-needed | no-op
+scope:
+  taskId: TASK-<milestone>-<number> | none
+  stories:
+    - USER-STORY-<number>
+  bugs:
+    - BUG-<number>
+ownership:
+  primaryLane: <lane>
+  supportingLanes:
+    - <lane>
+filesChanged:
+  - <path>
+docsUpdated:
+  - <path>
+validation:
+  - command: <command>
+    outcome: passed | failed | not-run
+    notes: <short notes>
+github:
+  project:
+    validated: yes | no | not-applicable
+    evidence: <command/output summary>
+  issues:
+    - <issue/pr URL or none>
+tdd:
+  red: <command/evidence or exception>
+  green: <command/evidence or not-applicable>
+blockers:
+  - <none or details>
+next:
+  - <recommended next action>
+pr:
+  authorized: yes | no
+  url: <url or none>
+  state: not-created | open | merged | blocked
+```
+
+## Escalation Reasons
+
+Use `status: escalation-needed` when:
+
+- target files are missing or stale
+- a task needs files outside its allowed list
+- dependency installation is required
+- a cloud, secret, or paid action is required
+- architecture or contract decisions conflict
+- validation fails for an unclear reason
+- another agent is working in the same file scope
+
+## PR Handoff
+
+If automatic PR creation is authorized and completed, include the PR URL. If it
+is not authorized, set `pr.authorized: no` and report the branch as ready for PR
+only after validation passes.

--- a/docs/automation/commands.md
+++ b/docs/automation/commands.md
@@ -11,7 +11,15 @@
 | `make install-tools` | Install supported Linux host tools after local confirmation. | moderate | no | no |
 | `make print-install-tools` | Print installation commands without running them. | cheap | no | no |
 | `make validate` | Run cheap repository validation. | cheap | no | no |
+| `make github-project-check` | Verify GitHub CLI auth and project access. | cheap | no | no |
+| `make github-project-summary` | Print GitHub Project, issue, milestone, and item counts. | cheap | no | no |
+| `make github-project-hierarchy` | Print epic/story sub-issue hierarchy. | cheap | no | no |
+| `make github-project-active` | Print in-progress GitHub Project items. | cheap | no | no |
 | `npm run docs:check` | Check docs for unfinished placeholders. | cheap | no | no |
+| `npm run github-project:check` | Verify GitHub CLI auth and project access through npm. | cheap | no | no |
+| `npm run github-project:summary` | Print GitHub tracker counts through npm. | cheap | no | no |
+| `npm run github-project:hierarchy` | Print GitHub tracker hierarchy through npm. | cheap | no | no |
+| `npm run github-project:active` | Print in-progress GitHub tracker items through npm. | cheap | no | no |
 | `npm run tools:check` | Verify required Linux development tools through npm. | cheap | no | no |
 
 Add Makefile targets once the runtime scaffold exists. Prefer the cheapest

--- a/docs/automation/conflict-protocol.md
+++ b/docs/automation/conflict-protocol.md
@@ -1,0 +1,40 @@
+# Conflict Protocol
+
+Use this when planned work conflicts with existing docs, task boundaries, or
+parallel execution.
+
+## File Scope Conflict
+
+If a task needs a file outside its target file list:
+
+1. Stop before editing.
+2. Report the missing file path.
+3. Explain why the file is needed.
+4. Ask to update the task scope or split the task.
+
+## Architecture Conflict
+
+If implementation requires changing an ADR or architecture boundary:
+
+1. Stop before implementation.
+2. Identify the conflicting ADR or architecture doc.
+3. Propose the decision that needs to change.
+4. Update ADR/design docs only after approval.
+
+## Parallel Agent Conflict
+
+If another active task owns the same files:
+
+1. Stop the later task.
+2. Report overlapping files and task IDs.
+3. Serialize work or re-slice target files.
+
+## Validation Conflict
+
+If validation fails for an unclear reason:
+
+1. Stop broad implementation.
+2. Capture command and relevant failure lines.
+3. Investigate only within assigned scope.
+4. Escalate if the cause crosses ownership lanes.
+

--- a/docs/automation/definition-of-done.md
+++ b/docs/automation/definition-of-done.md
@@ -1,0 +1,66 @@
+# Definition Of Done
+
+## Story Done
+
+- Acceptance themes are implemented or explicitly deferred.
+- Tests or validation cover the story behavior.
+- Linked GitHub task sub-issues are completed or deferred with rationale.
+- GitHub Project status and relationships reflect the final story state.
+- `docs/product/user-stories.md` status is updated.
+- `docs/product/milestones.md` mapping remains accurate.
+- No open bugs block the story.
+
+## Task Done
+
+- Work stayed inside declared target files or escalation was approved.
+- BDD scenario is confirmed or updated.
+- TDD RED/GREEN evidence is recorded, or exception is documented.
+- Minimal validation passes.
+- Required docs are updated.
+- Handoff result is prepared.
+- GitHub Project task status and relationships are updated.
+- `docs/plans/task-index.md` is updated when local task files change.
+
+## Bug Fix Done
+
+- Bug file exists under `docs/bugs`.
+- Observed and expected behavior are documented.
+- Regression test fails before the fix and passes after, unless exception is approved.
+- Linked stories/tasks are updated if meaning changes.
+- GitHub bug issue and Project status are updated.
+- `docs/bugs/index.md` is updated when local bug files change.
+- Validation evidence is recorded.
+
+## Milestone Done
+
+- All milestone tasks are completed or deferred.
+- Linked stories reflect current status.
+- GitHub milestone, epic sub-issues, dependencies, and Project fields reflect current status.
+- Validation evidence is recorded.
+- Status/work log are updated.
+- Known bugs are filed and non-blocking.
+
+## Architecture Change Done
+
+- ADR is added or updated when a durable decision changes.
+- Architecture docs reflect the decision.
+- Product stories and plans are updated if scope changes.
+- GitHub Project issues/relationships are updated if roadmap scope changes.
+- Validation confirms docs have no unfinished placeholders.
+
+## Tooling Change Done
+
+- `README.md` quickstart is updated if onboarding changes.
+- `docs/standards/tooling.md` is updated.
+- `scripts/dev/check-tools.sh` is updated for required tool detection.
+- `scripts/dev/install-tools.sh` is updated when install guidance changes.
+- `docs/automation/commands.md` and `validation.md` are updated.
+- `make validate` passes.
+
+## GitHub Tracker Change Done
+
+- Native GitHub relationships are used for parent, milestone, and blocked-by state.
+- Issue bodies do not duplicate relationship metadata.
+- Project fields, labels, milestones, and issue relationships are updated.
+- `make github-project-summary` passes.
+- `make github-project-hierarchy` reflects the intended hierarchy.

--- a/docs/automation/execution-checklist.md
+++ b/docs/automation/execution-checklist.md
@@ -1,0 +1,36 @@
+# Execution Checklist
+
+Use this checklist before an agent starts and before it reports completion.
+
+## Before Starting
+
+- [ ] Read `AGENTS.md`.
+- [ ] Read `docs/automation/README.md`.
+- [ ] Read `docs/automation/github-projects.md`.
+- [ ] Identify ownership lane from `docs/automation/roles.md`.
+- [ ] Identify linked GitHub issue, user stories, and milestone.
+- [ ] Check GitHub parent/sub-issue and dependency relationships.
+- [ ] Identify target files.
+- [ ] Identify validation command.
+- [ ] Check `docs/plans/active-worktrees.md` for overlapping work.
+- [ ] Confirm no other parallel task owns the same target files.
+
+## During Work
+
+- [ ] Keep edits inside target files.
+- [ ] Escalate before dependency, cloud, secret, or out-of-scope work.
+- [ ] Follow BDD/TDD for behavior changes.
+- [ ] Update GitHub Projects for issue, status, dependency, PR, or tracker changes.
+- [ ] Update task, story, milestone, status, and bug docs when durable repo context changes.
+- [ ] Record validation evidence.
+
+## Before Reporting Completion
+
+- [ ] Run the cheapest relevant validation.
+- [ ] Run stronger validation if the change touches runtime, contracts, infra, or tooling.
+- [ ] Run `git diff --check`.
+- [ ] Run relevant GitHub tracker validation from `docs/automation/validation.md`.
+- [ ] Update required docs.
+- [ ] Prepare handoff using `docs/automation/agent-handoff.md`.
+- [ ] If PR creation is authorized, complete `docs/automation/pr-checklist.md`.
+- [ ] Report any validation not run and why.

--- a/docs/automation/github-projects.md
+++ b/docs/automation/github-projects.md
@@ -1,0 +1,111 @@
+# GitHub Projects
+
+GitHub Projects is the human-facing source of truth for roadmap tracking.
+Repo-local planning docs remain the durable product and execution context that
+agents read before work.
+
+## Project
+
+- Project: [Media Asset Ingest Roadmap](https://github.com/users/ankit-singhal87/projects/2)
+- Repository: [ankit-singhal87/media-asset-ingest](https://github.com/ankit-singhal87/media-asset-ingest)
+
+## Tracker Model
+
+- GitHub milestones map to `MILESTONE-*` delivery slices.
+- Epic issues map to milestone-level delivery slices.
+- Story issues map to `USER-STORY-*` and are sub-issues of the owning epic.
+- Task issues should be created as sub-issues of the relevant story.
+- Bug issues should use `type:bug`, link to affected stories, and use GitHub
+  dependencies when a bug blocks planned work.
+- GitHub issue dependencies represent blocked-by relationships.
+- Project fields carry `Type`, primary `Lane`, and `Status`; labels carry
+  secondary lanes and searchable metadata.
+- `docs/plans/active-worktrees.md` is only the local active-worktree mirror.
+
+## Hybrid Agent Standard
+
+Agents must keep repo automation docs and GitHub tracker state aligned without
+duplicating relationship metadata in issue bodies.
+
+Use this split:
+
+- GitHub sub-issues: parent epic, story, and task hierarchy.
+- GitHub dependencies: blocked-by relationships.
+- GitHub milestones: delivery slice membership.
+- GitHub Project fields: type, primary lane, status, branch/worktree, target
+  files, and validation metadata.
+- GitHub labels: searchable type/status/lane metadata and secondary lanes.
+- Issue body: problem statement, outcomes or acceptance themes, target
+  components, and implementation notes that are not already native metadata.
+- Repo docs: durable operating rules, standards, architecture, and automation
+  guidance.
+
+Do not add `Parent Epic`, `Dependencies`, `Related Epic`, `Related Milestone`,
+or similar relationship sections to issue bodies unless GitHub lacks a native
+relationship for that specific fact.
+
+When a task changes workflow or tracker behavior:
+
+1. Update the relevant repo docs first.
+2. Update the GitHub Project, issues, milestones, labels, fields, and
+   relationships as needed.
+3. Run a read-only tracker command to verify the remote shape.
+4. Run local validation.
+5. Report both local validation and GitHub verification evidence.
+
+## Current Hierarchy
+
+- #2 `MILESTONE-1: Documentation And Local Foundation`
+- #3 `MILESTONE-2: .NET Solution And Local Runtime`
+  - #26 `USER-STORY-16: Develop With Docker-First Tooling`
+- #4 `MILESTONE-3: Ingest Package Lifecycle`
+  - #11 `USER-STORY-1: Watch Ingest Mount`
+  - #12 `USER-STORY-2: Start Only When Manifest Exists`
+  - #13 `USER-STORY-3: Ingest All Discovered Files`
+  - #14 `USER-STORY-4: Reconcile On Done Marker`
+  - #15 `USER-STORY-5: Classify Media Essences`
+- #5 `MILESTONE-4: Messaging And Outbox`
+  - #16 `USER-STORY-6: Route Work Through ASB Queues`
+  - #18 `USER-STORY-8: Use Transactional Outbox`
+- #6 `MILESTONE-5: Dapr Workflow Orchestration`
+  - #19 `USER-STORY-9: Orchestrate Package Lifecycle With Dapr`
+  - #20 `USER-STORY-10: Support Nested Workflows`
+- #7 `MILESTONE-6: Specialized Agents`
+  - #17 `USER-STORY-7: Process With Specialized Agents`
+- #8 `MILESTONE-7: Observability`
+  - #21 `USER-STORY-11: Record Agent Progress`
+- #9 `MILESTONE-8: Workflow Visualization UI`
+  - #22 `USER-STORY-12: Visualize Workflow Execution`
+  - #23 `USER-STORY-13: Inspect Node Logs`
+  - #24 `USER-STORY-14: Drill Into Nested Workflows`
+  - #25 `USER-STORY-15: Navigate Back From Child Workflows`
+- #10 `MILESTONE-9: Kubernetes And Azure Readiness`
+  - #27 `USER-STORY-17: Deploy To Kubernetes`
+
+## CLI Notes
+
+The GitHub CLI stores the token in `~/.config/gh/hosts.yml` because the local
+credential store is not available in this environment. Do not commit or print
+that file.
+
+```bash
+gh auth status
+make github-project-check
+make github-project-summary
+make github-project-hierarchy
+make github-project-active
+```
+
+Useful commands:
+
+```bash
+gh project view 2 --owner ankit-singhal87
+gh project item-list 2 --owner ankit-singhal87 --limit 100
+gh issue create --project "Media Asset Ingest Roadmap"
+```
+
+Creating or updating GitHub remote tracker state requires network access and a
+GitHub token with `repo` and `project` scopes.
+
+The Make targets are read-only helpers. Write operations still use `gh`
+directly after explicit authorization for remote tracker changes.

--- a/docs/automation/guardrails.md
+++ b/docs/automation/guardrails.md
@@ -17,6 +17,9 @@
   UI infrastructure details.
 - Update status, backlog, milestone, standards, tooling, and automation docs
   when a task changes their meaning.
+- Update GitHub Projects when issue, milestone, task, bug, dependency, worktree,
+  or PR state changes.
+- Do not duplicate GitHub-native relationships in issue descriptions.
 - Update `README.md` quickstart when setup, tools, commands, validation, or
   local runtime behavior changes.
 - If a new required developer tool is introduced, update tooling standards,

--- a/docs/automation/parallelization.md
+++ b/docs/automation/parallelization.md
@@ -1,0 +1,61 @@
+# Parallelization
+
+Parallel agents are allowed only when file ownership is disjoint and task
+dependencies do not require sequential execution.
+
+Use GitHub Projects as the tracker source of truth and
+`docs/plans/active-worktrees.md` as the local coordination mirror for parallel
+Codex processes.
+
+## Safe Parallel Patterns
+
+| Lane | Usually safe with | Avoid parallel edits with |
+| --- | --- | --- |
+| Atlas | Canvas, Beacon, Gauge | Pulse when workflow boundaries are changing |
+| Mount | Canvas, Beacon, Forge | Pulse, Courier, Vault on shared contracts |
+| Pulse | Canvas after API contracts stabilize | Mount, Courier, Vault on workflow contracts |
+| Courier | Canvas, Beacon | Pulse, Vault on message/outbox contracts |
+| Vault | Canvas after API contracts stabilize | Courier, Pulse on persistence contracts |
+| Essence | Canvas, Beacon | Courier on command contracts |
+| Beacon | Most lanes for instrumentation docs | Any lane editing the same observability helpers |
+| Canvas | Backend lanes after API DTOs stabilize | Pulse/Beacon when graph/log APIs are changing |
+| Forge | Atlas, Gauge | Runtime tasks editing the same Makefile/deploy files |
+| Gauge | Most lanes for test plans | Any lane editing the same tests |
+| Shield | Review-only in parallel | Any task requiring active security changes |
+
+## Required Parallel Agent Prompt Data
+
+Each parallel agent must receive:
+
+- task ID
+- linked story IDs
+- ownership lane
+- allowed target files
+- files it must not edit
+- validation command
+- expected handoff format
+- requirement to update `docs/plans/active-worktrees.md`
+- requirement to update GitHub Projects when tracker state changes
+
+## Conflict Protocol
+
+If two agents need the same file:
+
+1. Stop the later task.
+2. Report both task IDs and overlapping files.
+3. Re-slice one task or serialize the tasks.
+4. Update task files if the ownership boundary changes.
+
+Do not merge competing edits manually without a new plan.
+
+## Worktree Lifecycle
+
+1. Create worktree from current `main`.
+2. Add or update the worktree entry in `docs/plans/active-worktrees.md`.
+3. Execute only the assigned task scope.
+4. Update GitHub Project fields for active work, status, target files, and validation when needed.
+5. Mark the local row `Ready For PR` after validation passes.
+6. Create PR when authorized.
+7. Mark the GitHub Project item and local row `PR Open`.
+8. After merge, mark `Merged`, clean up local worktree, then mark `Cleaned Up`
+   in a follow-up cleanup change if needed.

--- a/docs/automation/pr-checklist.md
+++ b/docs/automation/pr-checklist.md
@@ -1,0 +1,54 @@
+# Pull Request Checklist
+
+Use this checklist before creating or merging a pull request.
+
+## Authorization
+
+Agents may create a pull request automatically only when the task, plan, or user
+explicitly authorizes automatic PR creation.
+
+Without that authorization, agents must stop after validation and report the
+branch/worktree as ready for PR.
+
+Automatic PR creation still requires all checks in this file.
+
+## Required
+
+- [ ] Branch is up to date with target branch or conflict-free.
+- [ ] `make validate` passes.
+- [ ] `git diff --check` passes.
+- [ ] GitHub Project item status, fields, labels, milestones, and relationships are updated.
+- [ ] GitHub tracker validation runs when issues, milestones, bugs, or tasks changed.
+- [ ] Product docs, status, and work log are updated when durable repo context changes.
+- [ ] Local task and bug mirrors are updated when local task or bug files change.
+- [ ] ADRs are updated when architecture decisions change.
+- [ ] Quickstart and tooling docs are updated when commands or setup change.
+- [ ] `docs/plans/active-worktrees.md` mirrors the work as `Ready For PR`.
+- [ ] Optional host tool warnings are not treated as failures for Docker-first workflows.
+- [ ] No secrets, `.env`, Terraform state, kubeconfigs, or cloud credentials are committed.
+- [ ] PR description includes summary, validation, risk, and follow-up notes.
+
+## PR Creation Command
+
+Use GitHub CLI after validation and authorization:
+
+```bash
+gh pr create --base main --head <branch> --title "<title>" --body "<body>"
+```
+
+The PR body must include:
+
+- summary
+- linked tasks, stories, and bugs
+- validation commands and outcomes
+- risk
+- follow-up notes
+
+After creating the PR, update GitHub Projects and
+`docs/plans/active-worktrees.md` to `PR Open`.
+
+## Merge Notes
+
+- CI may be disabled for this repository.
+- Cloud validation requires explicit approval.
+- Squash merge is preferred for documentation and planning branches.

--- a/docs/automation/repo-map.md
+++ b/docs/automation/repo-map.md
@@ -20,6 +20,8 @@ Planned structure:
 - `scripts/dev` - local developer bootstrap, checks, and lightweight validation helpers.
 - `docs/automation` - compact agent execution context.
 - `docs/architecture`, `docs/adr`, `docs/product`, `docs/standards` - durable project docs.
+- `docs/plans` - milestone and task planning artifacts.
+- `docs/bugs` - defect reports and bug-fix tracking.
 - `docs/status` - current project status, decisions, and work log.
 - `Makefile` - canonical local command entrypoint.
 - `package.json` - repo-level npm scripts for documentation and tooling checks.

--- a/docs/automation/validation.md
+++ b/docs/automation/validation.md
@@ -7,6 +7,7 @@
 | Automation-doc change | `make validate` | read `AGENTS.md`, task workflow, and automation docs for consistency | no | no | cheap |
 | Standards change | `make validate` | review affected automation docs and task workflow | no | no | cheap |
 | Tooling change | `make validate` and `make check-tools` when host tools are expected | `make print-install-tools` review | no | no | cheap |
+| GitHub tracker change | `make github-project-summary` and `make github-project-hierarchy` | `make github-project-active` plus targeted `gh issue view` or dependency checks | no | no | cheap |
 | .NET code change | focused unit test command once solution exists | full test suite once available | no by default | no | moderate |
 | Docker/Kubernetes change | relevant local smoke test once scripts exist | full local runtime validation | yes | no | moderate |
 | Azure deployment change | static manifest/terraform validation only | manual cloud validation after approval | maybe | yes | paid/approval |

--- a/docs/bugs/README.md
+++ b/docs/bugs/README.md
@@ -1,0 +1,23 @@
+# Bugs
+
+Use this folder for durable defect reports. GitHub Issues/Projects are the
+tracker source of truth for bug status, relationships, and PR state.
+
+Start with [index.md](index.md).
+
+## ID Scheme
+
+- `BUG-1`, `BUG-2`, and so on.
+
+Use [templates/bug-template.md](templates/bug-template.md) for new bug files.
+
+## Agent Rules
+
+Bug fixes must update:
+
+- the GitHub bug issue and Project fields
+- the bug file status
+- [index.md](index.md)
+- linked user stories if acceptance meaning changes in repo docs
+- `docs/status/work-log.md`
+- tests or validation evidence

--- a/docs/bugs/index.md
+++ b/docs/bugs/index.md
@@ -1,0 +1,26 @@
+# Bug Index
+
+Use this index as a local mirror for durable bug documentation. GitHub Issues
+and GitHub Projects are the tracker source of truth for bug status and
+relationships.
+
+## Status Values
+
+- Open
+- In Progress
+- Fixed
+- Verified
+- Deferred
+- Won't Fix
+
+## Bugs
+
+| Bug ID | GitHub issue | Title | Affected lane | Bug file | Local status |
+| --- | --- | --- | --- | --- | --- |
+| None | - | No bugs filed yet | - | - | - |
+
+## Update Rule
+
+Agents must update this index when local bug files are created, renamed, or
+deleted. Update GitHub Issues/Projects for bug status, relationships, and PR
+state changes.

--- a/docs/bugs/templates/bug-template.md
+++ b/docs/bugs/templates/bug-template.md
@@ -1,0 +1,73 @@
+# BUG-<number>: <Title>
+
+## Status
+
+Open
+
+## Linked Work
+
+- User stories:
+  - USER-STORY-<number>
+- Milestones:
+  - MILESTONE-<number>
+- Tasks:
+  - TASK-<milestone>-<number>
+
+## Affected Domains
+
+- <domain>
+
+## Affected Components
+
+- `<path-or-component>`
+
+## Observed Behavior
+
+<what happened>
+
+## Expected Behavior
+
+<what should happen>
+
+## Reproduction
+
+1. <step>
+
+## Regression Test
+
+RED:
+
+```bash
+<command expected to fail before fix>
+```
+
+GREEN:
+
+```bash
+<command expected to pass after fix>
+```
+
+## Fix Notes
+
+- <notes>
+
+## Validation
+
+```bash
+<command>
+```
+
+## Documentation Updates
+
+- `docs/bugs/index.md`
+- `docs/status/work-log.md`
+- <linked story or task docs if meaning changes>
+
+## Closure Checklist
+
+- [ ] Regression test fails before the fix or exception is documented.
+- [ ] Fix implemented.
+- [ ] Regression test passes after the fix.
+- [ ] Linked docs updated.
+- [ ] Bug status updated.
+

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,66 @@
+# Plans
+
+Planning artifacts turn product stories into executable implementation work.
+
+## Structure
+
+- `docs/product/milestones.md` - milestone catalog and story mapping.
+- `docs/product/user-stories.md` - numbered user stories and traceability.
+- `docs/plans/task-index.md` - local task-plan mirror; GitHub Project task issues are the tracker source of truth.
+- `docs/plans/active-worktrees.md` - local active worktree and parallel-agent coordination mirror.
+- `docs/plans/milestones/` - milestone-level implementation plans.
+- `docs/plans/tasks/` - small task files created from milestone plans.
+- `docs/bugs/` - defect reports and bug-fix tracking.
+- `docs/plans/templates/` - copyable plan and task templates.
+
+## ID Scheme
+
+- Milestones: `MILESTONE-1`, `MILESTONE-2`, and so on.
+- User stories: `USER-STORY-1`, `USER-STORY-2`, and so on.
+- Tasks: `TASK-<milestone>-<number>`, for example `TASK-2-1`.
+- Bugs: `BUG-1`, `BUG-2`, and so on.
+
+## Plan Folder Workflow
+
+1. Keep product intent in `docs/product/user-stories.md`.
+2. Map each story to milestone, domain, components, owner lane, and status.
+3. Create a milestone plan in `docs/plans/milestones/` before implementation.
+4. Split milestone plans into task files in `docs/plans/tasks/`.
+5. Track implementation progress in GitHub Projects and mirror durable plan details in task files, milestone plans, product docs, and status docs.
+6. Track defects in GitHub Issues/Projects and mirror durable defect details in `docs/bugs`.
+7. Use `docs/automation/execution-checklist.md`, `definition-of-done.md`, and
+   `agent-handoff.md` during execution.
+8. Update GitHub Projects when issue, milestone, task, bug, or PR state changes.
+9. Update `docs/plans/active-worktrees.md` when working in parallel worktrees.
+
+Use [templates/milestone-plan-template.md](templates/milestone-plan-template.md)
+and [templates/task-template.md](templates/task-template.md) for new plan files.
+
+## Task File Expectations
+
+Each task file should include durable execution context that is not already
+native GitHub metadata:
+
+- task ID
+- linked user story IDs
+- GitHub issue number
+- ownership lane
+- target files
+- BDD scenario or acceptance behavior
+- RED/GREEN/REFACTOR evidence expectations
+- validation command
+- required documentation updates
+- completion checklist
+
+Do not create task files without a clear owning GitHub issue and validation
+path.
+
+## Parallel Execution
+
+Use `docs/automation/parallelization.md` before assigning tasks to parallel
+agents. Parallel tasks must have disjoint target files and clear handoff
+expectations.
+
+Use GitHub Projects as the human-facing tracker for issues, milestones, tasks,
+bugs, and PR state. Use `docs/plans/active-worktrees.md` only as the local
+ledger for active worktrees, branches, target files, and immediate coordination.

--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -19,7 +19,7 @@ mirror.
 
 | Worktree | Branch | GitHub item | Stories | Lane | Target files | Status | PR |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `.worktrees/story-planning` | `docs/story-planning` | #26 | Product planning docs | Atlas | `AGENTS.md`, `README.md`, `docs/product`, `docs/plans`, `docs/bugs`, `docs/automation`, `docs/standards`, `docs/status`, `Makefile`, `package.json`, `scripts/dev` | Ready For PR | Not opened |
+| `.worktrees/story-planning` | `docs/story-planning` | #26 | Product planning docs | Atlas | `AGENTS.md`, `README.md`, `docs/product`, `docs/plans`, `docs/bugs`, `docs/automation`, `docs/standards`, `docs/status`, `Makefile`, `package.json`, `scripts/dev` | PR Open | https://github.com/ankit-singhal87/media-asset-ingest/pull/28 |
 
 ## Update Rule
 

--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -1,0 +1,43 @@
+# Active Worktrees
+
+Use this file to coordinate multiple Codex processes working in parallel.
+GitHub Projects remains the tracker source of truth for issues, milestones,
+tasks, bugs, and PR state; this file is only the local worktree coordination
+mirror.
+
+## Status Values
+
+- Planned
+- Active
+- Blocked
+- Ready For PR
+- PR Open
+- Merged
+- Cleaned Up
+
+## Active Work
+
+| Worktree | Branch | GitHub item | Stories | Lane | Target files | Status | PR |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `.worktrees/story-planning` | `docs/story-planning` | #26 | Product planning docs | Atlas | `AGENTS.md`, `README.md`, `docs/product`, `docs/plans`, `docs/bugs`, `docs/automation`, `docs/standards`, `docs/status`, `Makefile`, `package.json`, `scripts/dev` | Ready For PR | Not opened |
+
+## Update Rule
+
+Agents must update this file when:
+
+- creating a worktree
+- starting a task in a worktree
+- changing target files
+- marking work ready for PR
+- opening a PR
+- merging a PR
+- cleaning up a worktree
+
+Agents must also update GitHub Projects when tracker state changes. Do not use
+this file as the only record of issue, task, bug, milestone, or PR state.
+
+## Parallel Safety Rule
+
+Before starting work in a new worktree, check this file and
+`docs/automation/parallelization.md`. If target files overlap with active work,
+stop and use `docs/automation/conflict-protocol.md`.

--- a/docs/plans/milestones/README.md
+++ b/docs/plans/milestones/README.md
@@ -1,0 +1,16 @@
+# Milestone Plans
+
+Milestone plans will be added here when a milestone is ready for implementation.
+
+Each milestone plan should be named:
+
+```text
+MILESTONE-<number>-<short-name>.md
+```
+
+Example:
+
+```text
+MILESTONE-2-dotnet-solution-local-runtime.md
+```
+

--- a/docs/plans/task-index.md
+++ b/docs/plans/task-index.md
@@ -1,0 +1,25 @@
+# Task Index
+
+Use this index as a local mirror for implementation task files created from
+milestone plans. GitHub Project task issues are the tracker source of truth for
+task status and relationships.
+
+## Status Values
+
+- Planned
+- In Progress
+- Blocked
+- Completed
+- Deferred
+
+## Tasks
+
+| Task ID | GitHub issue | Title | Primary lane | Task file | Local status |
+| --- | --- | --- | --- | --- | --- | --- |
+| None | - | No task files created yet | - | - | - |
+
+## Update Rule
+
+Agents must update this index when local task files are created, renamed, or
+deleted. Update GitHub Projects for task status, parent/sub-issue, dependency,
+and PR state changes.

--- a/docs/plans/tasks/README.md
+++ b/docs/plans/tasks/README.md
@@ -1,0 +1,19 @@
+# Task Plans
+
+Task plans are small executable slices derived from milestone plans.
+
+Each task should be named:
+
+```text
+TASK-<milestone-number>-<task-number>-<short-name>.md
+```
+
+Example:
+
+```text
+TASK-2-1-create-dotnet-solution.md
+```
+
+Keep task scopes narrow enough for one agent to execute without editing outside
+the task's target file list.
+

--- a/docs/plans/templates/milestone-plan-template.md
+++ b/docs/plans/templates/milestone-plan-template.md
@@ -1,0 +1,106 @@
+# MILESTONE-<number>: <Title> Plan
+
+## Status
+
+Planned
+
+## Linked User Stories
+
+- USER-STORY-<number>
+
+## GitHub Tracker
+
+- Milestone: MILESTONE-<number>
+- Epic issue: #<number>
+- Project: Media Asset Ingest Roadmap
+
+## Goal
+
+<one paragraph describing what this milestone delivers>
+
+## Non-Goals
+
+- <explicit non-goal>
+
+## Ownership
+
+Primary lane: <lane>
+
+Supporting lanes:
+
+- <lane>
+
+## Domains
+
+- <domain>
+
+## Components
+
+- `<path-or-planned-component>`
+
+## Dependencies
+
+- Native GitHub blocked-by relationships plus any ADR or external dependency
+  that cannot be represented in GitHub relationships.
+
+## Execution Strategy
+
+Preferred approach: vertical slice
+
+Rationale:
+
+- <why this split creates usable, testable progress>
+
+## Task Breakdown
+
+| Task ID | GitHub issue | Title | Stories | Primary lane | Target files | Local status |
+| --- | --- | --- | --- | --- | --- |
+| TASK-<milestone>-1 | #<number> | <title> | USER-STORY-<number> | <lane> | `<path>` | Planned |
+
+## Validation Strategy
+
+Minimal validation:
+
+```bash
+<command>
+```
+
+Stronger validation:
+
+```bash
+<command>
+```
+
+GitHub tracker validation:
+
+```bash
+make github-project-summary
+make github-project-hierarchy
+```
+
+## Documentation Updates Required
+
+- `docs/status/current-status.md`
+- `docs/status/work-log.md`
+- `docs/product/milestones.md`
+- `docs/product/user-stories.md`
+- `docs/product/backlog.md`
+- `docs/plans/task-index.md`
+- GitHub Project fields, sub-issues, dependencies, and milestone status
+- <other docs>
+
+## Stop Conditions
+
+- Secrets, credentials, cloud billing, or external account access is required.
+- A task needs files outside its declared target file list.
+- A schema, contract, or architecture decision conflicts with existing docs.
+- Validation fails for an unclear reason.
+
+## Definition Of Done
+
+- All planned tasks are complete or explicitly deferred.
+- Linked user stories reflect current status.
+- GitHub Project and issue relationships reflect current status.
+- Validation evidence is recorded.
+- Required documentation updates are complete.
+- Known bugs are filed in `docs/bugs`.

--- a/docs/plans/templates/task-template.md
+++ b/docs/plans/templates/task-template.md
@@ -1,0 +1,132 @@
+# TASK-<milestone>-<number>: <Title>
+
+## Status
+
+Planned
+
+## Linked Work
+
+- GitHub issue: #<number>
+- Milestone: MILESTONE-<number>
+- User stories:
+  - USER-STORY-<number>
+- Bugs:
+  - None
+
+Native GitHub relationships:
+
+- Parent issue: #<number>
+- Blocked by: #<number> or none
+- Blocks: #<number> or none
+
+## Ownership
+
+Primary lane: <lane>
+
+Supporting lanes:
+
+- <lane>
+
+## Target Files
+
+Agents may edit only these files unless they escalate:
+
+- `<path>`
+
+## Investigation Targets
+
+Read before editing:
+
+- GitHub issue #<number> and its parent/sub-issue/dependency relationships.
+- `<path>` - <why it matters>
+
+## BDD Scenario
+
+```gherkin
+Scenario: <behavior>
+  Given <context>
+  When <action>
+  Then <outcome>
+```
+
+## TDD Expectations
+
+RED:
+
+```bash
+<command expected to fail before implementation>
+```
+
+GREEN:
+
+```bash
+<command expected to pass after implementation>
+```
+
+REFACTOR:
+
+- Keep the same command passing after cleanup.
+
+## Implementation Notes
+
+- <specific notes or constraints>
+
+## Validation
+
+Minimal validation:
+
+```bash
+<command>
+```
+
+GitHub tracker validation:
+
+```bash
+make github-project-summary
+make github-project-hierarchy
+```
+
+## Required Documentation Updates
+
+- `docs/plans/task-index.md`
+- `docs/status/work-log.md`
+- <other docs>
+
+## Completion Checklist
+
+- [ ] Scope and ownership lane confirmed.
+- [ ] GitHub issue and Project item checked.
+- [ ] Parent/sub-issue/dependency relationships checked.
+- [ ] Investigation targets reviewed.
+- [ ] BDD scenario confirmed or updated.
+- [ ] Failing test observed before production code, unless exception documented.
+- [ ] Implementation completed within target files.
+- [ ] Validation command run and evidence recorded.
+- [ ] Required docs updated.
+- [ ] GitHub Projects updated when tracker state changed.
+- [ ] Handoff result prepared.
+
+## Handoff Result
+
+```text
+status: completed | blocked | escalation-needed
+taskId: TASK-<milestone>-<number>
+github:
+  issues:
+    - #<number>
+  projectValidation:
+    - <command and evidence>
+stories:
+  - USER-STORY-<number>
+filesChanged:
+  - <path>
+validation:
+  - command: <command>
+    outcome: <pass/fail/not-run>
+docsUpdated:
+  - <path>
+blockers:
+  - <none or details>
+next:
+  - <recommended next action>
+```

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -5,22 +5,21 @@ epic/story granularity; detailed implementation tasks belong in plans.
 
 ## Ready For Planning
 
-- Define local development foundation.
-- Scaffold .NET solution and project boundaries.
-- Define PostgreSQL persistence and outbox foundation.
-- Define Azure Service Bus abstractions and local development strategy.
-- Define Dapr Workflow runtime and package workflow contracts.
+- MILESTONE-2 / USER-STORY-16 / USER-STORY-17: define local development foundation.
+- MILESTONE-2: scaffold .NET solution and project boundaries.
+- MILESTONE-4 / USER-STORY-8: define PostgreSQL persistence and outbox foundation.
+- MILESTONE-4 / USER-STORY-6: define Azure Service Bus abstractions and local development strategy.
+- MILESTONE-5 / USER-STORY-9 / USER-STORY-10: define Dapr Workflow runtime and package workflow contracts.
 
 ## Later
 
-- Implement specialized media agents.
-- Implement workflow graph API.
-- Implement React workflow control plane.
-- Add Kubernetes and Dapr deployment assets.
-- Add Azure deployment documentation.
+- MILESTONE-6 / USER-STORY-7: implement specialized media agents.
+- MILESTONE-8 / USER-STORY-12 / USER-STORY-13: implement workflow graph API.
+- MILESTONE-8 / USER-STORY-14 / USER-STORY-15: implement React workflow control plane.
+- MILESTONE-9 / USER-STORY-17: add Kubernetes and Dapr deployment assets.
+- MILESTONE-9 / USER-STORY-17: add Azure deployment documentation.
 
 ## Update Rule
 
 Agents must update this file when adding, completing, splitting, or deferring
 product-visible work.
-

--- a/docs/product/milestones.md
+++ b/docs/product/milestones.md
@@ -1,72 +1,296 @@
 # Milestones
 
-## Milestone 1: Documentation And Local Foundation
+Milestones are numbered delivery slices. Each milestone maps to user stories,
+primary domains, ownership lanes, and planned components.
 
-- Automation context and guardrails.
-- Architecture overview.
-- ADRs.
-- Product stories.
-- Initial standards.
-- Status, task workflow, and work log.
-- Linux tool check/install guidance.
-- Makefile and npm validation entrypoints.
+## MILESTONE-1: Documentation And Local Foundation
 
-## Milestone 2: .NET Solution And Local Runtime
+Status: Complete
 
-- .NET solution structure.
-- Docker Compose or equivalent local services.
-- PostgreSQL local database.
-- Basic health checks.
+Purpose: Establish the project operating model, architecture decisions, product
+backlog, standards, and Docker-first developer workflow.
 
-## Milestone 3: Ingest Package Lifecycle
+User stories:
 
-- Filesystem watcher.
-- Manifest gating.
-- Package scan.
-- Done marker reconciliation.
-- File classification.
+- USER-STORY-16
+- USER-STORY-17
 
-## Milestone 4: Messaging And Outbox
+Domains:
 
-- PostgreSQL transactional outbox.
-- Outbox dispatcher.
-- Azure Service Bus abstraction.
-- Local broker development strategy.
+- Project operations
+- Developer experience
 
-## Milestone 5: Dapr Workflow Orchestration
+Ownership lanes:
 
-- Package ingest workflow.
-- Child workflow boundaries.
-- Workflow events and signals.
-- Workflow state separation.
+- Atlas
+- Forge
+- Gauge
 
-## Milestone 6: Specialized Agents
+Components:
 
-- Video agent.
-- Audio agent.
-- Text agent.
-- Other/sidecar agent.
-- Proxy creation agent.
+- `AGENTS.md`
+- `docs/automation`
+- `docs/architecture`
+- `docs/adr`
+- `docs/product`
+- `docs/standards`
+- `docs/status`
+- `Makefile`
+- `scripts/dev`
+- `package.json`
 
-## Milestone 7: Observability
+## MILESTONE-2: .NET Solution And Local Runtime
 
-- Structured JSON logs.
-- OpenTelemetry traces.
-- Correlation fields.
-- Business timeline/progress events.
+Status: Planned
 
-## Milestone 8: Workflow Visualization UI
+Purpose: Create the .NET solution, local container runtime, and baseline
+developer commands.
 
-- Workflow graph API.
-- Node status projection.
-- React graph UI.
-- Node details and logs.
-- Nested workflow drilldown and back traversal.
+User stories:
 
-## Milestone 9: Kubernetes And Azure Readiness
+- USER-STORY-16
+- USER-STORY-17
 
-- Kubernetes manifests.
-- Dapr component definitions.
-- Azure Service Bus configuration docs.
-- Azure PostgreSQL configuration docs.
-- Cost-conscious deployment notes.
+Domains:
+
+- Platform
+- Developer experience
+
+Ownership lanes:
+
+- Forge
+- Gauge
+
+Components:
+
+- `src`
+- `deploy/docker`
+- `docker-compose.yml`
+- `Makefile`
+- `scripts/dev`
+
+## MILESTONE-3: Ingest Package Lifecycle
+
+Status: Planned
+
+Purpose: Detect ingest packages, gate work on manifest presence, enumerate real
+files, classify essences, and reconcile on done marker.
+
+User stories:
+
+- USER-STORY-1
+- USER-STORY-2
+- USER-STORY-3
+- USER-STORY-4
+- USER-STORY-5
+
+Domains:
+
+- Ingest package
+- Manifest
+- Done marker
+- Essence classification
+
+Ownership lanes:
+
+- Mount
+- Essence
+- Gauge
+
+Components:
+
+- `src/MediaIngest.Worker.Watcher`
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Persistence`
+- `src/MediaIngest.Tests`
+
+## MILESTONE-4: Messaging And Outbox
+
+Status: Planned
+
+Purpose: Add PostgreSQL transactional outbox and Azure Service Bus command
+routing for agent-owned queues.
+
+User stories:
+
+- USER-STORY-6
+- USER-STORY-8
+
+Domains:
+
+- Messaging
+- Outbox
+- Work item
+
+Ownership lanes:
+
+- Courier
+- Vault
+- Gauge
+
+Components:
+
+- `src/MediaIngest.Worker.Outbox`
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Persistence`
+- `deploy/dapr`
+- `deploy/docker`
+
+## MILESTONE-5: Dapr Workflow Orchestration
+
+Status: Planned
+
+Purpose: Add durable package orchestration with Dapr Workflow, child workflow
+boundaries, signals, and workflow state separation.
+
+User stories:
+
+- USER-STORY-9
+- USER-STORY-10
+
+Domains:
+
+- Workflow instance
+- Workflow node
+- Package lifecycle
+
+Ownership lanes:
+
+- Pulse
+- Vault
+- Gauge
+
+Components:
+
+- `src/MediaIngest.Workflow`
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Persistence`
+- `deploy/dapr`
+
+## MILESTONE-6: Specialized Agents
+
+Status: Planned
+
+Purpose: Add independently scalable processing agents for essence and derived
+media work.
+
+User stories:
+
+- USER-STORY-7
+- USER-STORY-11
+
+Domains:
+
+- Essence processing
+- Work item
+- Agent execution
+
+Ownership lanes:
+
+- Essence
+- Beacon
+- Gauge
+
+Components:
+
+- `src/MediaIngest.Agents.Video`
+- `src/MediaIngest.Agents.Audio`
+- `src/MediaIngest.Agents.Text`
+- `src/MediaIngest.Agents.Other`
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Observability`
+
+## MILESTONE-7: Observability
+
+Status: Planned
+
+Purpose: Add structured logs, OpenTelemetry traces, correlation fields, and
+business timeline events.
+
+User stories:
+
+- USER-STORY-11
+
+Domains:
+
+- Observability
+- Timeline
+- Diagnostics
+
+Ownership lanes:
+
+- Beacon
+- Vault
+- Gauge
+
+Components:
+
+- `src/MediaIngest.Observability`
+- `src/MediaIngest.Persistence`
+- `src/MediaIngest.Contracts`
+
+## MILESTONE-8: Workflow Visualization UI
+
+Status: Planned
+
+Purpose: Add workflow graph APIs and UI for node status, nested workflow
+drilldown, back traversal, and node log/timeline inspection.
+
+User stories:
+
+- USER-STORY-12
+- USER-STORY-13
+- USER-STORY-14
+- USER-STORY-15
+
+Domains:
+
+- Workflow graph
+- Workflow node
+- Package timeline
+- Operator control plane
+
+Ownership lanes:
+
+- Canvas
+- Pulse
+- Beacon
+- Gauge
+
+Components:
+
+- `src/MediaIngest.Api`
+- `web/ingest-control-plane`
+- `src/MediaIngest.Persistence`
+- `src/MediaIngest.Observability`
+
+## MILESTONE-9: Kubernetes And Azure Readiness
+
+Status: Planned
+
+Purpose: Add Kubernetes manifests, Dapr components, and Azure deployment
+documentation without requiring paid cloud execution by default.
+
+User stories:
+
+- USER-STORY-17
+
+Domains:
+
+- Platform
+- Azure deployment
+- Kubernetes runtime
+
+Ownership lanes:
+
+- Forge
+- Shield
+- Beacon
+
+Components:
+
+- `deploy/k8s`
+- `deploy/dapr`
+- `deploy/azure`
+- `docs/architecture`
+- `docs/automation`

--- a/docs/product/task-workflow.md
+++ b/docs/product/task-workflow.md
@@ -7,13 +7,17 @@ Each implementation task should follow:
 1. Confirm scope and ownership lane.
 2. Read `AGENTS.md` and `docs/automation/README.md`.
 3. Read relevant architecture, ADR, product, and standards docs.
-4. Write or identify a BDD scenario for user-visible behavior.
-5. Write a failing test before production code.
-6. Implement the smallest change that passes.
-7. Refactor while tests stay green.
-8. Run the validation command from `docs/automation/validation.md`.
-9. Update impacted docs.
-10. Report validation evidence.
+4. Read `docs/automation/execution-checklist.md`.
+5. Read or create the relevant GitHub issue and Project item.
+6. Confirm GitHub parent/sub-issue and dependency relationships.
+7. Write or identify a BDD scenario for user-visible behavior.
+8. Write a failing test before production code.
+9. Implement the smallest change that passes.
+10. Refactor while tests stay green.
+11. Run the validation command from `docs/automation/validation.md`.
+12. Update impacted docs and GitHub Projects.
+13. Prepare handoff using `docs/automation/agent-handoff.md`.
+14. Report local validation and GitHub tracker verification evidence.
 
 ## Required Documentation Updates
 
@@ -24,6 +28,12 @@ Before a task is complete, update the relevant files:
 - `docs/product/backlog.md` when work is added, completed, split, or deferred.
 - `docs/product/milestones.md` when milestone scope or progress changes.
 - `docs/product/user-stories.md` when acceptance meaning changes.
+- `docs/plans` when milestone plans or task plans are added, split, renamed, or deleted.
+- `docs/plans/task-index.md` when local task files are added, renamed, or deleted.
+- `docs/plans/active-worktrees.md` when worktree, branch, status, target files, or PR state changes.
+- GitHub Projects when issue, milestone, bug, task, worktree, or PR state changes.
+- `docs/bugs` when durable defect documentation is added, renamed, or deleted.
+- `docs/bugs/index.md` when local bug files are added, renamed, or deleted.
 - `README.md` quickstart when onboarding, setup, commands, or validation changes.
 - `docs/adr` when an architectural decision changes.
 - `docs/standards/tooling.md` when a required development tool changes.
@@ -41,4 +51,6 @@ Bug fixes must include:
 - a failing regression test first, unless the user approves an exception
 - the fix
 - validation evidence
-- any status or work-log update
+- a GitHub issue with `type:bug`
+- a `docs/bugs/BUG-<number>-<title>.md` entry
+- any status, work-log, story, or milestone update

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -1,96 +1,642 @@
 # User Stories
 
-## Ingest Foundation
+User stories are numbered and mapped to milestones, domains, components, and
+ownership lanes. Keep detailed implementation tasks in `docs/plans/tasks`.
 
-### Watch ingest mount
+## Traceability Summary
+
+| ID | Title | Milestone | Domain | Primary lane | Status |
+| --- | --- | --- | --- | --- | --- |
+| USER-STORY-1 | Watch ingest mount | MILESTONE-3 | Ingest package | Mount | Planned |
+| USER-STORY-2 | Start only when manifest exists | MILESTONE-3 | Manifest | Mount | Planned |
+| USER-STORY-3 | Ingest all discovered files | MILESTONE-3 | Ingest package | Mount | Planned |
+| USER-STORY-4 | Reconcile on done marker | MILESTONE-3 | Done marker | Mount | Planned |
+| USER-STORY-5 | Classify media essences | MILESTONE-3 | Essence classification | Essence | Planned |
+| USER-STORY-6 | Route work through ASB queues | MILESTONE-4 | Messaging | Courier | Planned |
+| USER-STORY-7 | Process with specialized agents | MILESTONE-6 | Agent execution | Essence | Planned |
+| USER-STORY-8 | Use transactional outbox | MILESTONE-4 | Outbox | Courier | Planned |
+| USER-STORY-9 | Orchestrate package lifecycle with Dapr | MILESTONE-5 | Workflow | Pulse | Planned |
+| USER-STORY-10 | Support nested workflows | MILESTONE-5 | Workflow | Pulse | Planned |
+| USER-STORY-11 | Record agent progress | MILESTONE-6, MILESTONE-7 | Observability | Beacon | Planned |
+| USER-STORY-12 | Visualize workflow execution | MILESTONE-8 | Workflow UI | Canvas | Planned |
+| USER-STORY-13 | Inspect node logs | MILESTONE-8 | Workflow UI | Canvas | Planned |
+| USER-STORY-14 | Drill into nested workflows | MILESTONE-8 | Workflow UI | Canvas | Planned |
+| USER-STORY-15 | Navigate back from child workflows | MILESTONE-8 | Workflow UI | Canvas | Planned |
+| USER-STORY-16 | Develop with Docker-first tooling | MILESTONE-1, MILESTONE-2 | Developer experience | Forge | In Progress |
+| USER-STORY-17 | Deploy to Kubernetes | MILESTONE-2, MILESTONE-9 | Platform | Forge | Planned |
+
+## USER-STORY-1: Watch Ingest Mount
 
 As an ingest operator, I want the system to monitor a configured mounted
 directory, so that new media packages are detected automatically.
 
+Milestone: MILESTONE-3
+
+Domains:
+
+- Ingest package
+- Filesystem mount
+
+Ownership lanes:
+
+- Mount
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Worker.Watcher`
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Tests`
+
 Acceptance themes:
 
-- Path is configuration-driven.
+- Watch path is configuration-driven.
 - Local development can use local filesystem storage.
 - Production storage backing is hidden behind the mount.
+- Package discovery emits durable business state or commands.
 
-### Start only when manifest exists
+Dependencies:
+
+- MILESTONE-2 local runtime foundation.
+
+## USER-STORY-2: Start Only When Manifest Exists
 
 As an ingest producer, I want ingest to start only after `manifest.json` exists,
 so that incomplete package directories are not processed prematurely.
 
-### Ingest all discovered files
+Milestone: MILESTONE-3
+
+Domains:
+
+- Manifest
+- Ingest package
+
+Ownership lanes:
+
+- Mount
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Worker.Watcher`
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Persistence`
+- `src/MediaIngest.Tests`
+
+Acceptance themes:
+
+- Package directory without `manifest.json` is observed but not processed.
+- Package work starts after `manifest.json` appears.
+- Manifest is treated as metadata and a start signal.
+
+Dependencies:
+
+- USER-STORY-1
+
+## USER-STORY-3: Ingest All Discovered Files
 
 As a MAM operator, I want the system to ingest every file physically present in
 the package directory, so that incorrect manifests do not cause files to be
 skipped.
 
-### Reconcile on done marker
+Milestone: MILESTONE-3
+
+Domains:
+
+- Ingest package
+- Discovered file
+- Manifest validation
+
+Ownership lanes:
+
+- Mount
+- Essence
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Worker.Watcher`
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Persistence`
+- `src/MediaIngest.Tests`
+
+Acceptance themes:
+
+- Directory scan is source of truth for file presence.
+- Files omitted from manifest are still ingested.
+- Manifest references to missing files create warnings, not skipped real files.
+
+Dependencies:
+
+- USER-STORY-2
+
+## USER-STORY-4: Reconcile On Done Marker
 
 As an ingest operator, I want the system to rescan a package when the done marker
 appears, so that late-arriving files are not missed.
 
-## Routing And Agents
+Milestone: MILESTONE-3
 
-### Classify media essences
+Domains:
+
+- Done marker
+- Reconciliation
+- Ingest package
+
+Ownership lanes:
+
+- Mount
+- Pulse
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Worker.Watcher`
+- `src/MediaIngest.Workflow`
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Persistence`
+
+Acceptance themes:
+
+- Work may begin before done marker exists.
+- Done marker triggers final package rescan.
+- Late files are enqueued before package finalization.
+
+Dependencies:
+
+- USER-STORY-3
+- USER-STORY-9
+
+## USER-STORY-5: Classify Media Essences
 
 As an ingest system, I want to classify discovered files by essence type, so
 that video, audio, text, and sidecar files can be routed to specialized agents.
 
-### Route work through ASB queues
+Milestone: MILESTONE-3
+
+Domains:
+
+- Essence classification
+- Discovered file
+- Work item
+
+Ownership lanes:
+
+- Essence
+- Courier
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Persistence`
+- `src/MediaIngest.Agents.Other`
+- `src/MediaIngest.Tests`
+
+Acceptance themes:
+
+- `.mov`, `.mxf`, and `.mp4` classify as video/source.
+- `.srt`, `.txt`, and `.vtt` classify as text.
+- `.mp3` and `.wav` classify as audio.
+- Unknown files classify as other.
+
+Dependencies:
+
+- USER-STORY-3
+
+## USER-STORY-6: Route Work Through ASB Queues
 
 As a platform engineer, I want file processing commands routed to named Azure
 Service Bus queues, so that each specialized agent only consumes work it owns.
 
-### Process with specialized agents
+Milestone: MILESTONE-4
+
+Domains:
+
+- Messaging
+- Work item
+
+Ownership lanes:
+
+- Courier
+- Essence
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Worker.Outbox`
+- `deploy/dapr`
+- `deploy/docker`
+
+Acceptance themes:
+
+- Each command has a specific destination queue.
+- Agents consume only their assigned queues.
+- Queue names are documented and stable.
+
+Dependencies:
+
+- USER-STORY-5
+- USER-STORY-8
+
+## USER-STORY-7: Process With Specialized Agents
 
 As an operator, I want specialized agents for video, audio, text, proxy, and
 other processing, so that each processing concern can scale and fail
 independently.
 
-## Reliability And Workflow
+Milestone: MILESTONE-6
 
-### Use transactional outbox
+Domains:
+
+- Agent execution
+- Essence processing
+- Work item
+
+Ownership lanes:
+
+- Essence
+- Beacon
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Agents.Video`
+- `src/MediaIngest.Agents.Audio`
+- `src/MediaIngest.Agents.Text`
+- `src/MediaIngest.Agents.Other`
+- `src/MediaIngest.Contracts`
+
+Acceptance themes:
+
+- Agent handlers are idempotent.
+- Agent failures are recorded in business state.
+- Agents can emit downstream work when allowed by workflow design.
+
+Dependencies:
+
+- USER-STORY-6
+- USER-STORY-9
+
+## USER-STORY-8: Use Transactional Outbox
 
 As a backend engineer, I want state changes and outbound messages committed
 atomically, so that ingest work is not lost when services crash.
 
-### Orchestrate package lifecycle with Dapr
+Milestone: MILESTONE-4
+
+Domains:
+
+- Outbox
+- Persistence
+- Messaging
+
+Ownership lanes:
+
+- Courier
+- Vault
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Persistence`
+- `src/MediaIngest.Worker.Outbox`
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Tests`
+
+Acceptance themes:
+
+- Business state and outbox messages commit in one transaction.
+- Outbox dispatcher publishes decided messages.
+- Dispatcher does not make domain routing decisions.
+- Repeated dispatcher runs are safe.
+
+Dependencies:
+
+- MILESTONE-2 local runtime foundation.
+
+## USER-STORY-9: Orchestrate Package Lifecycle With Dapr
 
 As an ingest operator, I want a durable workflow per ingest package, so that
 package progress survives crashes and can coordinate asynchronous agents.
 
-### Support nested workflows
+Milestone: MILESTONE-5
+
+Domains:
+
+- Workflow instance
+- Package lifecycle
+
+Ownership lanes:
+
+- Pulse
+- Courier
+- Vault
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Workflow`
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Persistence`
+- `deploy/dapr`
+
+Acceptance themes:
+
+- A package gets a durable workflow instance.
+- Workflow coordinates scan, classification, processing, reconciliation, and finalization.
+- Workflow runtime state is separate from business state.
+
+Dependencies:
+
+- USER-STORY-8
+
+## USER-STORY-10: Support Nested Workflows
 
 As a workflow operator, I want package workflows to drill into child workflows,
 so that complex ingest processing remains understandable.
 
-## Observability And UI
+Milestone: MILESTONE-5
 
-### Record agent progress
+Domains:
+
+- Child workflow
+- Workflow graph
+
+Ownership lanes:
+
+- Pulse
+- Canvas
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Workflow`
+- `src/MediaIngest.Contracts`
+- `src/MediaIngest.Persistence`
+
+Acceptance themes:
+
+- Parent workflows can start meaningful child workflows.
+- Child workflows have stable identifiers and parent references.
+- Workflow state can be projected for UI drilldown later.
+
+Dependencies:
+
+- USER-STORY-9
+
+## USER-STORY-11: Record Agent Progress
 
 As an operator, I want each agent to record business progress and structured
 logs with `workflowInstanceId`, so that processing can be audited and
 correlated.
 
-### Visualize workflow execution
+Milestone: MILESTONE-6, MILESTONE-7
+
+Domains:
+
+- Observability
+- Timeline
+- Agent execution
+
+Ownership lanes:
+
+- Beacon
+- Essence
+- Vault
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Observability`
+- `src/MediaIngest.Persistence`
+- `src/MediaIngest.Contracts`
+- specialized agent projects
+
+Acceptance themes:
+
+- Logs include workflow and work item correlation fields.
+- Business timeline records agent state transitions.
+- UI status does not depend on log scraping.
+
+Dependencies:
+
+- USER-STORY-7
+
+## USER-STORY-12: Visualize Workflow Execution
 
 As an operator, I want to see workflow nodes change color by status, so that I
 can quickly understand what is pending, running, failed, or complete.
 
-### Inspect node logs
+Milestone: MILESTONE-8
+
+Domains:
+
+- Workflow graph
+- Operator UI
+
+Ownership lanes:
+
+- Canvas
+- Pulse
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Api`
+- `web/ingest-control-plane`
+- `src/MediaIngest.Persistence`
+
+Acceptance themes:
+
+- Graph is rendered from a graph DTO, not a bitmap.
+- Node colors come from business state.
+- Pending, running, succeeded, failed, waiting, skipped, and cancelled states are distinguishable.
+
+Dependencies:
+
+- USER-STORY-10
+- USER-STORY-11
+
+## USER-STORY-13: Inspect Node Logs
 
 As an operator, I want to click a workflow node and view its logs and timeline,
 so that I can diagnose failures without searching raw logs manually.
 
-### Drill into nested workflows
+Milestone: MILESTONE-8
 
-As an operator, I want to drill into child workflow graphs and navigate back to
-parent workflows, so that nested processing remains explorable.
+Domains:
 
-## Platform
+- Workflow node
+- Timeline
+- Logs
 
-### Deploy to Kubernetes
+Ownership lanes:
+
+- Canvas
+- Beacon
+- Vault
+
+Components involved:
+
+- `src/MediaIngest.Api`
+- `web/ingest-control-plane`
+- `src/MediaIngest.Observability`
+- `src/MediaIngest.Persistence`
+
+Acceptance themes:
+
+- Node details show business timeline entries.
+- Logs are filtered by workflow and node correlation fields.
+- Failure context is visible without raw log search.
+
+Dependencies:
+
+- USER-STORY-11
+- USER-STORY-12
+
+## USER-STORY-14: Drill Into Nested Workflows
+
+As an operator, I want to drill into child workflow graphs, so that nested
+processing remains explorable.
+
+Milestone: MILESTONE-8
+
+Domains:
+
+- Child workflow
+- Workflow graph
+- Operator UI
+
+Ownership lanes:
+
+- Canvas
+- Pulse
+- Gauge
+
+Components involved:
+
+- `src/MediaIngest.Api`
+- `web/ingest-control-plane`
+- `src/MediaIngest.Persistence`
+
+Acceptance themes:
+
+- Parent graph nodes can link to child workflow graphs.
+- Child graph view preserves parent context.
+- Nested workflow status is visible at parent and child levels.
+
+Dependencies:
+
+- USER-STORY-10
+- USER-STORY-12
+
+## USER-STORY-15: Navigate Back From Child Workflows
+
+As an operator, I want to navigate back from child workflows to parent workflows,
+so that drilldown exploration is reversible.
+
+Milestone: MILESTONE-8
+
+Domains:
+
+- Workflow navigation
+- Operator UI
+
+Ownership lanes:
+
+- Canvas
+- Pulse
+
+Components involved:
+
+- `src/MediaIngest.Api`
+- `web/ingest-control-plane`
+
+Acceptance themes:
+
+- UI supports back traversal from child to parent workflow.
+- Navigation preserves selected package context.
+- Direct links to child workflow views remain possible.
+
+Dependencies:
+
+- USER-STORY-14
+
+## USER-STORY-16: Develop With Docker-First Tooling
+
+As a developer, I want a Docker-first Linux development workflow, so that I can
+work on the repository without installing every runtime SDK on the host.
+
+Milestone: MILESTONE-1, MILESTONE-2
+
+Domains:
+
+- Developer experience
+- Tooling
+
+Ownership lanes:
+
+- Forge
+- Gauge
+
+Components involved:
+
+- `README.md`
+- `Makefile`
+- `package.json`
+- `scripts/dev`
+- `docs/standards/tooling.md`
+- `docs/automation`
+
+Acceptance themes:
+
+- Required host tools stay minimal.
+- Optional host tools are documented.
+- Make targets expose canonical workflows.
+- Agents update quickstart and tooling docs when workflow changes.
+
+Dependencies:
+
+- None
+
+## USER-STORY-17: Deploy To Kubernetes
 
 As a platform engineer, I want all services containerized and deployable to
 Kubernetes, so that the system matches a cloud-native Azure runtime model.
+
+Milestone: MILESTONE-2, MILESTONE-9
+
+Domains:
+
+- Kubernetes runtime
+- Azure deployment
+- Platform
+
+Ownership lanes:
+
+- Forge
+- Shield
+- Beacon
+
+Components involved:
+
+- `deploy/docker`
+- `deploy/k8s`
+- `deploy/dapr`
+- `deploy/azure`
+- `docs/architecture`
+- `docs/automation`
+
+Acceptance themes:
+
+- Services are containerized.
+- Kubernetes manifests or Helm assets are documented.
+- Azure deployment guidance avoids paid actions by default.
+- Cloud execution requires explicit approval.
+
+Dependencies:
+
+- MILESTONE-2 local runtime foundation.
 

--- a/docs/standards/tooling.md
+++ b/docs/standards/tooling.md
@@ -12,6 +12,10 @@ Use:
 - `make check-tools` to verify host tools.
 - `make install-tools` to install or print installation guidance for host tools.
 - `make validate` for cheap repository validation.
+- `make github-project-check` to verify GitHub CLI auth and Project access.
+- `make github-project-summary` to summarize tracker counts.
+- `make github-project-hierarchy` to verify epic/story hierarchy.
+- `make github-project-active` to list active tracker items.
 - `npm run docs:check` for docs placeholder checks.
 - `npm run tools:check` for host tool checks through npm.
 

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -3,7 +3,7 @@
 ## Project State
 
 - Phase: planning and repository foundation.
-- Current branch: `docs/initial-plans`.
+- Current branch: `docs/story-planning`.
 - Current focus: durable project documentation, automation guidance, standards,
   and toolchain bootstrap.
 
@@ -20,16 +20,43 @@
 - Linux tool check/install scripts created.
 - Makefile and npm validation entrypoints created.
 - README quickstart added with Linux-first and Docker-first guidance.
+- Milestones and user stories assigned stable IDs.
+- Planning and bug folder structure created.
+- Agent execution templates, indexes, checklists, handoff, parallelization, and
+  conflict guidance created.
+- Active worktree tracking and PR authorization rules created.
+- GitHub Projects roadmap created with milestone epics and numbered user-story
+  issues.
+- GitHub issue hierarchy, dependencies, issue bodies, and Project fields
+  refined.
+- Read-only GitHub tracker helper commands added for agent verification.
+- Local task, bug, worktree, checklist, and definition-of-done docs aligned with
+  the GitHub Projects tracker model.
 
-## In Progress
+## Ready For Review
 
-- Documentation review and validation.
+- Product traceability, parallel worktree documentation, and GitHub Projects
+  tracker setup are validated and ready for commit/PR when authorized.
 
 ## Next
 
 - Review and refine documentation.
 - Commit planning foundation after user approval.
 - Create implementation plan for local foundation.
+
+## Known Agent Execution Gaps
+
+- GitHub Project write helpers are intentionally manual `gh` calls; agents have
+  read-only Make helpers but no safe scripted creator/updater for task and bug
+  issues yet.
+- Project custom fields are populated for current issues, but helper scripts do
+  not verify required field completeness across all items.
+- Task and bug templates now reference GitHub issues, but no implementation task
+  issues have been created under story issues yet.
+- There is no automated check that issue bodies avoid duplicated relationship
+  metadata.
+- There is no standardized PR creation helper that updates GitHub Project fields
+  and `docs/plans/active-worktrees.md` together.
 
 ## Update Rule
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -5,13 +5,30 @@ messages or paste command output unless it explains a decision.
 
 ## 2026-05-03
 
-- Created planning worktree `docs/initial-plans`.
+- Created planning worktree `docs/story-planning`.
 - Added architecture, ADR, product, automation, and standards documentation.
 - Added repository operating model for status, task workflow, and toolchain checks.
 - Added BDD/TDD, DDD, and tooling standards.
 - Added Linux development tool check/install scripts.
 - Added Makefile and package.json entrypoints for validation.
 - Added README quickstart and Docker-first tooling direction.
+- Added milestone and user story IDs with domain/component/lane mappings.
+- Added `docs/plans` and `docs/bugs` folder structures.
+- Added task/bug templates, indexes, execution checklist, handoff format,
+  definition of done, parallelization rules, PR checklist, and conflict protocol.
+- Added active worktree tracking and automatic PR authorization rules for
+  parallel Codex execution.
+- Created GitHub Project `Media Asset Ingest Roadmap`, GitHub milestones,
+  milestone epic issues, user-story issues, and tracker labels.
+- Added GitHub sub-issue hierarchy, blocked-by dependencies, richer issue
+  bodies, and populated Project fields for type, lane, and status.
+- Removed duplicated relationship metadata from GitHub issue bodies and added
+  read-only Make/npm helpers for GitHub tracker verification.
+- Cleaned local plan, bug, worktree, checklist, and definition-of-done docs so
+  GitHub Projects is the tracker source of truth and repo docs are durable
+  context/mirrors.
+- Tightened PR checklist and active worktree mirror after GitHub Projects
+  cleanup.
 
 ## Update Rule
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "description": "Cloud-native media asset ingest backend planning and repository tooling.",
   "scripts": {
     "docs:check": "node scripts/dev/check-docs.mjs",
+    "github-project:active": "sh scripts/dev/github-projects.sh active",
+    "github-project:check": "sh scripts/dev/github-projects.sh check-auth",
+    "github-project:hierarchy": "sh scripts/dev/github-projects.sh hierarchy",
+    "github-project:summary": "sh scripts/dev/github-projects.sh summary",
     "tools:check": "sh scripts/dev/check-tools.sh"
   },
   "devDependencies": {}
 }
-

--- a/scripts/dev/github-projects.sh
+++ b/scripts/dev/github-projects.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+set -eu
+
+OWNER=${GITHUB_PROJECT_OWNER:-ankit-singhal87}
+REPO=${GITHUB_PROJECT_REPO:-ankit-singhal87/media-asset-ingest}
+PROJECT_NUMBER=${GITHUB_PROJECT_NUMBER:-2}
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dev/github-projects.sh <command>
+
+Commands:
+  check-auth       Verify GitHub CLI auth and project access.
+  summary          Print project, milestone, issue, and item counts.
+  hierarchy        Print epic sub-issue hierarchy.
+  active           Print in-progress project items.
+
+Environment overrides:
+  GITHUB_PROJECT_OWNER
+  GITHUB_PROJECT_REPO
+  GITHUB_PROJECT_NUMBER
+
+Write operations are intentionally not wrapped here. Agents should use gh
+directly after reading docs/automation/github-projects.md and after explicit
+authorization for remote tracker changes.
+USAGE
+}
+
+require_gh() {
+  if ! command -v gh >/dev/null 2>&1; then
+    printf '%s\n' "gh is required. Run make check-tools for guidance." >&2
+    exit 1
+  fi
+}
+
+check_auth() {
+  gh auth status
+  gh project view "$PROJECT_NUMBER" --owner "$OWNER" --format json --jq '.title'
+}
+
+summary() {
+  printf 'project: '
+  gh project view "$PROJECT_NUMBER" --owner "$OWNER" --format json --jq '.title + " (" + .url + ")"'
+  printf 'project_items: '
+  gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --limit 200 --format json --jq '.items | length'
+  printf 'issues: '
+  gh issue list --repo "$REPO" --state all --limit 200 --json number --jq 'length'
+  printf 'milestones: '
+  gh api "repos/$REPO/milestones" --paginate --jq 'length'
+}
+
+hierarchy() {
+  gh issue list --repo "$REPO" --state all --label type:epic --limit 100 \
+    --json number,title --jq '.[] | [.number, .title] | @tsv' |
+  while IFS="$(printf '\t')" read -r number title; do
+    printf '#%s %s\n' "$number" "$title"
+    gh api "repos/$REPO/issues/$number/sub_issues" \
+      -H 'X-GitHub-Api-Version: 2026-03-10' \
+      --jq '.[] | "  - #\(.number) \(.title)"'
+  done
+}
+
+active() {
+  gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --limit 200 --format json \
+    --jq '.items[] | select(.status == "In Progress") | "#\(.content.number) \(.title)"'
+}
+
+require_gh
+
+case "${1:-}" in
+  check-auth)
+    check_auth
+    ;;
+  summary)
+    summary
+    ;;
+  hierarchy)
+    hierarchy
+    ;;
+  active)
+    active
+    ;;
+  -h|--help|help|"")
+    usage
+    ;;
+  *)
+    printf 'Unknown command: %s\n\n' "$1" >&2
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Adds numbered milestone/user-story planning docs, task and bug planning structure, and agent execution checklists.
- Adds GitHub Projects as the human-facing tracker source of truth with local mirror docs and read-only Make/npm helpers.
- Updates automation, tooling, status, and workflow guidance for hybrid repo/GitHub tracker execution.

## Validation
- make validate
- git diff --check
- make github-project-summary
- make github-project-hierarchy
- make github-project-active

## Risk
- Docs/tooling-only change; no runtime code or cloud resources.
- GitHub Project tracker state was created and verified outside the repo commit.

## Follow-up
- Add safe GitHub tracker write helpers for task/bug issue creation.
- Add tracker lint for required Project fields and issue-body relationship duplication.
- Add a PR helper that updates GitHub Project state and active-worktrees together.