### PR TITLE
USER-STORY-16: Add docs link and git conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ direction.
 - Use [docs/automation/agent-handoff.md](docs/automation/agent-handoff.md) for task handoff results.
 - Use [docs/automation/conflict-protocol.md](docs/automation/conflict-protocol.md) when scope, architecture, validation, or parallel work conflicts arise.
 - Use [docs/automation/github-projects.md](docs/automation/github-projects.md) when changing GitHub issues, milestones, projects, bugs, or PR tracking state.
+- Use [docs/automation/git-conventions.md](docs/automation/git-conventions.md) before creating branches, commits, or PRs.
 - Follow [docs/standards/bdd-tdd.md](docs/standards/bdd-tdd.md) for behavior changes.
 - Follow [docs/standards/domain-driven-design.md](docs/standards/domain-driven-design.md) for domain boundaries.
 - Follow [docs/standards/tooling.md](docs/standards/tooling.md) when tools or commands change.
@@ -38,6 +39,8 @@ direction.
 - Update [docs/plans/active-worktrees.md](docs/plans/active-worktrees.md) when creating, using, PR-opening, merging, or cleaning up worktrees.
 - Keep GitHub Projects as the human-facing source of truth for roadmap, issue,
   milestone, bug, and PR state once remote tracker access is available.
+- Start branch names, commit subjects, and PR titles with the lowest-level
+  available work identifier: task ID, bug ID, then story ID.
 - Commits, pushes, and PR creation happen only when the user asks or when a task
   explicitly grants automatic PR creation after validation.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help check-tools install-tools print-install-tools validate docs-check scripts-check github-project-check github-project-summary github-project-hierarchy github-project-active
+.PHONY: help check-tools install-tools print-install-tools validate docs-check docs-fix scripts-check github-project-check github-project-summary github-project-hierarchy github-project-active
 
 help:
 	@printf '%s\n' "Available targets:"
@@ -7,6 +7,7 @@ help:
 	@printf '%s\n' "  make print-install-tools Print manual installation commands"
 	@printf '%s\n' "  make validate            Run cheap repository validation"
 	@printf '%s\n' "  make docs-check          Check docs for unfinished placeholders"
+	@printf '%s\n' "  make docs-fix            Apply safe docs formatting fixes"
 	@printf '%s\n' "  make scripts-check       Syntax-check shell scripts"
 	@printf '%s\n' "  make github-project-check     Verify GitHub CLI auth and project access"
 	@printf '%s\n' "  make github-project-summary   Print GitHub tracker counts"
@@ -26,6 +27,9 @@ validate: docs-check scripts-check
 
 docs-check:
 	@npm run docs:check
+
+docs-fix:
+	@npm run docs:fix
 
 scripts-check:
 	@sh -n scripts/dev/check-tools.sh

--- a/docs/adr/ADR-0001-use-azure-service-bus.md
+++ b/docs/adr/ADR-0001-use-azure-service-bus.md
@@ -22,4 +22,3 @@ necessary.
 - Agents can scale independently by queue.
 - RabbitMQ is deferred because it would require self-management on AKS or a
   third-party managed service.
-

--- a/docs/adr/ADR-0002-use-postgresql.md
+++ b/docs/adr/ADR-0002-use-postgresql.md
@@ -20,4 +20,3 @@ for PostgreSQL Flexible Server.
 - Business state remains queryable for the control plane UI.
 - Cosmos DB is deferred because the relational ingest/audit/outbox model is a
   better v1 fit.
-

--- a/docs/adr/ADR-0003-use-dapr-workflow.md
+++ b/docs/adr/ADR-0003-use-dapr-workflow.md
@@ -22,4 +22,3 @@ Use Dapr Workflow for package-level orchestration.
   is not ideal for this portfolio project.
 - Camunda is deferred because BPMN/DMN visual authoring adds cost and
   operational weight that is not required for v1.
-

--- a/docs/adr/ADR-0004-use-message-centric-orchestration.md
+++ b/docs/adr/ADR-0004-use-message-centric-orchestration.md
@@ -20,4 +20,3 @@ work distribution backbone.
 - Queue names define ownership boundaries.
 - The outbox remains central to reliable command/event publication.
 - Dapr activities are used selectively; agent work is primarily message-driven.
-

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,4 +6,3 @@ Accepted decisions:
 - [ADR-0002: Use PostgreSQL](ADR-0002-use-postgresql.md)
 - [ADR-0003: Use Dapr Workflow](ADR-0003-use-dapr-workflow.md)
 - [ADR-0004: Use Message-Centric Orchestration](ADR-0004-use-message-centric-orchestration.md)
-

--- a/docs/architecture/000-system-overview.md
+++ b/docs/architecture/000-system-overview.md
@@ -44,4 +44,3 @@ Dapr stores workflow runtime state in its own state store.
 - Exact relational schema.
 - Exact UI framework details beyond graph rendering requirements.
 - Full Azure deployment and cost profile.
-

--- a/docs/architecture/001-ingest-lifecycle.md
+++ b/docs/architecture/001-ingest-lifecycle.md
@@ -36,4 +36,3 @@ Initial categories:
 - other: unknown sidecars or future essence types
 
 Classification rules should be easy to extend without rewriting workflow logic.
-

--- a/docs/architecture/002-workflow-orchestration.md
+++ b/docs/architecture/002-workflow-orchestration.md
@@ -47,4 +47,3 @@ finish before reconciliation or finalization.
 
 Dapr workflow runtime state is not business truth. Business status, timeline,
 and audit state must be recorded in PostgreSQL application tables.
-

--- a/docs/architecture/003-messaging-and-outbox.md
+++ b/docs/architecture/003-messaging-and-outbox.md
@@ -36,4 +36,3 @@ publishes pending messages to Azure Service Bus.
 - Consumers must tolerate at-least-once delivery.
 - Dispatcher leasing must allow more than one dispatcher instance safely.
 - Poison/dead-letter behavior must be observable.
-

--- a/docs/architecture/004-observability-and-ui.md
+++ b/docs/architecture/004-observability-and-ui.md
@@ -60,4 +60,3 @@ Clicking a node should show:
 
 The UI should initially poll APIs for graph state. SignalR can be added later
 for live updates.
-

--- a/docs/automation/README.md
+++ b/docs/automation/README.md
@@ -15,6 +15,7 @@ Low-token operating entrypoint for AI coding agents and local automation.
 9. [parallelization.md](parallelization.md) when dispatching parallel agents
 10. [agent-handoff.md](agent-handoff.md) before reporting task results
 11. [github-projects.md](github-projects.md) when work changes issues, milestones, or project state
+12. [git-conventions.md](git-conventions.md) before creating branches, commits, or PRs
 
 ## Durable References
 
@@ -23,14 +24,15 @@ Low-token operating entrypoint for AI coding agents and local automation.
 - [../product/task-workflow.md](../product/task-workflow.md) - task lifecycle and required doc updates.
 - [../plans/README.md](../plans/README.md) - milestone and task plan structure.
 - [../bugs/README.md](../bugs/README.md) - defect report structure.
-- [../architecture](../architecture) - system design and runtime decisions.
+- [../architecture/000-system-overview.md](../architecture/000-system-overview.md) - system design and runtime decisions.
 - [../adr](../adr) - architecture decision records.
-- [../standards](../standards) - implementation standards.
+- [../standards/dotnet.md](../standards/dotnet.md) - implementation standards entrypoint.
 - [../status/current-status.md](../status/current-status.md) - current project state and next actions.
 - [definition-of-done.md](definition-of-done.md) - completion criteria by work type.
 - [conflict-protocol.md](conflict-protocol.md) - escalation rules for scope, architecture, parallel, and validation conflicts.
 - [pr-checklist.md](pr-checklist.md) - pull request creation and merge checklist.
 - [github-projects.md](github-projects.md) - GitHub Projects tracker model and CLI commands.
+- [git-conventions.md](git-conventions.md) - branch, commit, and PR naming conventions.
 
 Long-form project knowledge lives in product, architecture, ADR, and standards
 documents. Automation docs should stay compact and execution-oriented.

--- a/docs/automation/commands.md
+++ b/docs/automation/commands.md
@@ -11,11 +11,13 @@
 | `make install-tools` | Install supported Linux host tools after local confirmation. | moderate | no | no |
 | `make print-install-tools` | Print installation commands without running them. | cheap | no | no |
 | `make validate` | Run cheap repository validation. | cheap | no | no |
+| `make docs-fix` | Apply safe documentation formatting fixes before committing. | cheap | no | no |
 | `make github-project-check` | Verify GitHub CLI auth and project access. | cheap | no | no |
 | `make github-project-summary` | Print GitHub Project, issue, milestone, and item counts. | cheap | no | no |
 | `make github-project-hierarchy` | Print epic/story sub-issue hierarchy. | cheap | no | no |
 | `make github-project-active` | Print in-progress GitHub Project items. | cheap | no | no |
 | `npm run docs:check` | Check docs for unfinished placeholders. | cheap | no | no |
+| `npm run docs:fix` | Apply safe docs formatting fixes. | cheap | no | no |
 | `npm run github-project:check` | Verify GitHub CLI auth and project access through npm. | cheap | no | no |
 | `npm run github-project:summary` | Print GitHub tracker counts through npm. | cheap | no | no |
 | `npm run github-project:hierarchy` | Print GitHub tracker hierarchy through npm. | cheap | no | no |

--- a/docs/automation/conflict-protocol.md
+++ b/docs/automation/conflict-protocol.md
@@ -37,4 +37,3 @@ If validation fails for an unclear reason:
 2. Capture command and relevant failure lines.
 3. Investigate only within assigned scope.
 4. Escalate if the cause crosses ownership lanes.
-

--- a/docs/automation/constraints.md
+++ b/docs/automation/constraints.md
@@ -12,4 +12,3 @@
 - Do not pollute human docs with agent chatter.
 - Keep automation docs compact; put durable explanations in architecture,
   product, ADR, or standards docs.
-

--- a/docs/automation/git-conventions.md
+++ b/docs/automation/git-conventions.md
@@ -1,0 +1,77 @@
+# Git Conventions
+
+Use Git names that keep local work, GitHub issues, pull requests, and commits
+easy to correlate.
+
+## Branch Names
+
+Start branch names with the lowest-level work item identifier available:
+
+1. `TASK-<milestone>-<number>-<short-slug>` for implementation task issues.
+2. `BUG-<number>-<short-slug>` for bug fixes.
+3. `USER-STORY-<number>-<short-slug>` only when no task or bug issue exists yet.
+
+Examples:
+
+```text
+TASK-2-1-create-dotnet-solution
+BUG-1-fix-manifest-watch-race
+USER-STORY-16-link-and-commit-standards
+```
+
+## Commit Messages
+
+Start commit subjects with the same lowest-level identifier used by the branch.
+Use the GitHub issue number in the commit body so GitHub links the commit to the
+issue.
+
+```text
+TASK-2-1: Add solution skeleton
+
+Refs #31
+```
+
+Use `Refs #<issue>` for incremental commits and `Closes #<issue>` only when the
+commit or pull request completes the issue.
+
+## Pull Requests
+
+PR titles should start with the same identifier:
+
+```text
+TASK-2-1: Add solution skeleton
+```
+
+PR bodies must include linked issue references:
+
+```text
+Refs #31
+Closes #31
+```
+
+Use `Closes` only for the lowest-level task or bug issue the PR completes.
+Reference parent stories or epics with `Refs` unless they are truly completed by
+the PR.
+
+## Before Committing
+
+Run safe docs fixes and validation before committing documentation changes:
+
+```bash
+make docs-fix
+make validate
+git diff --check
+```
+
+## Identifier Choice
+
+Prefer the most specific item:
+
+- Task issue beats story issue.
+- Bug issue beats story issue.
+- Story issue is acceptable for planning or standards work before task issues
+  exist.
+
+This keeps GitHub's branch, commit, and pull request links close to the work
+actually being completed while still preserving story traceability through
+native GitHub parent/sub-issue relationships.

--- a/docs/automation/pr-checklist.md
+++ b/docs/automation/pr-checklist.md
@@ -15,6 +15,8 @@ Automatic PR creation still requires all checks in this file.
 ## Required
 
 - [ ] Branch is up to date with target branch or conflict-free.
+- [ ] Branch name, commit subject, and PR title follow `docs/automation/git-conventions.md`.
+- [ ] `make docs-fix` was run when docs formatting/link checks reported fixable issues.
 - [ ] `make validate` passes.
 - [ ] `git diff --check` passes.
 - [ ] GitHub Project item status, fields, labels, milestones, and relationships are updated.

--- a/docs/automation/roles.md
+++ b/docs/automation/roles.md
@@ -66,4 +66,3 @@ Owns test strategy, integration tests, smoke tests, and validation evidence.
 ### Shield - Security
 
 Owns secrets policy, identity boundaries, container safety, and cloud security review.
-

--- a/docs/automation/validation.md
+++ b/docs/automation/validation.md
@@ -2,7 +2,7 @@
 
 | Change type | Minimal validation | Stronger validation | Docker? | Cloud? | Cost |
 | --- | --- | --- | --- | --- | --- |
-| Docs-only change | `make docs-check` | markdown lint when tooling exists | no | no | cheap |
+| Docs-only change | `make docs-check` | `make docs-fix` before committing when formatting/link checks fail | no | no | cheap |
 | Architecture/ADR change | targeted term search for contradictory decisions | review affected ADRs and architecture docs together | no | no | cheap |
 | Automation-doc change | `make validate` | read `AGENTS.md`, task workflow, and automation docs for consistency | no | no | cheap |
 | Standards change | `make validate` | review affected automation docs and task workflow | no | no | cheap |

--- a/docs/bugs/templates/bug-template.md
+++ b/docs/bugs/templates/bug-template.md
@@ -70,4 +70,3 @@ GREEN:
 - [ ] Regression test passes after the fix.
 - [ ] Linked docs updated.
 - [ ] Bug status updated.
-

--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -19,7 +19,8 @@ mirror.
 
 | Worktree | Branch | GitHub item | Stories | Lane | Target files | Status | PR |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `.worktrees/story-planning` | `docs/story-planning` | #26 | Product planning docs | Atlas | `AGENTS.md`, `README.md`, `docs/product`, `docs/plans`, `docs/bugs`, `docs/automation`, `docs/standards`, `docs/status`, `Makefile`, `package.json`, `scripts/dev` | PR Open | https://github.com/ankit-singhal87/media-asset-ingest/pull/28 |
+| `.worktrees/story-planning` | `docs/story-planning` | #26 | Product planning docs | Atlas | `AGENTS.md`, `README.md`, `docs/product`, `docs/plans`, `docs/bugs`, `docs/automation`, `docs/standards`, `docs/status`, `Makefile`, `package.json`, `scripts/dev` | Merged | https://github.com/ankit-singhal87/media-asset-ingest/pull/28 |
+| `.worktrees/link-and-commit-standards` | `USER-STORY-16-link-and-commit-standards` | #26 | USER-STORY-16 | Forge | `AGENTS.md`, `docs/automation`, `docs/product/task-workflow.md`, `docs/status`, `docs/standards/tooling.md`, `Makefile`, `package.json`, `scripts/dev/check-docs.mjs` | Ready For PR | Not opened |
 
 ## Update Rule
 

--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -20,7 +20,7 @@ mirror.
 | Worktree | Branch | GitHub item | Stories | Lane | Target files | Status | PR |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `.worktrees/story-planning` | `docs/story-planning` | #26 | Product planning docs | Atlas | `AGENTS.md`, `README.md`, `docs/product`, `docs/plans`, `docs/bugs`, `docs/automation`, `docs/standards`, `docs/status`, `Makefile`, `package.json`, `scripts/dev` | Merged | https://github.com/ankit-singhal87/media-asset-ingest/pull/28 |
-| `.worktrees/link-and-commit-standards` | `USER-STORY-16-link-and-commit-standards` | #26 | USER-STORY-16 | Forge | `AGENTS.md`, `docs/automation`, `docs/product/task-workflow.md`, `docs/status`, `docs/standards/tooling.md`, `Makefile`, `package.json`, `scripts/dev/check-docs.mjs` | Ready For PR | Not opened |
+| `.worktrees/link-and-commit-standards` | `USER-STORY-16-link-and-commit-standards` | #26 | USER-STORY-16 | Forge | `AGENTS.md`, `docs/automation`, `docs/product/task-workflow.md`, `docs/status`, `docs/standards/tooling.md`, `Makefile`, `package.json`, `scripts/dev/check-docs.mjs` | PR Open | https://github.com/ankit-singhal87/media-asset-ingest/pull/29 |
 
 ## Update Rule
 

--- a/docs/plans/milestones/README.md
+++ b/docs/plans/milestones/README.md
@@ -13,4 +13,3 @@ Example:
 ```text
 MILESTONE-2-dotnet-solution-local-runtime.md
 ```
-

--- a/docs/plans/tasks/README.md
+++ b/docs/plans/tasks/README.md
@@ -16,4 +16,3 @@ TASK-2-1-create-dotnet-solution.md
 
 Keep task scopes narrow enough for one agent to execute without editing outside
 the task's target file list.
-

--- a/docs/product/task-workflow.md
+++ b/docs/product/task-workflow.md
@@ -8,16 +8,18 @@ Each implementation task should follow:
 2. Read `AGENTS.md` and `docs/automation/README.md`.
 3. Read relevant architecture, ADR, product, and standards docs.
 4. Read `docs/automation/execution-checklist.md`.
-5. Read or create the relevant GitHub issue and Project item.
-6. Confirm GitHub parent/sub-issue and dependency relationships.
-7. Write or identify a BDD scenario for user-visible behavior.
-8. Write a failing test before production code.
-9. Implement the smallest change that passes.
-10. Refactor while tests stay green.
-11. Run the validation command from `docs/automation/validation.md`.
-12. Update impacted docs and GitHub Projects.
-13. Prepare handoff using `docs/automation/agent-handoff.md`.
-14. Report local validation and GitHub tracker verification evidence.
+5. Read `docs/automation/git-conventions.md`.
+6. Read or create the relevant GitHub issue and Project item.
+7. Confirm GitHub parent/sub-issue and dependency relationships.
+8. Use a branch name that starts with the lowest-level work identifier.
+9. Write or identify a BDD scenario for user-visible behavior.
+10. Write a failing test before production code.
+11. Implement the smallest change that passes.
+12. Refactor while tests stay green.
+13. Run the validation command from `docs/automation/validation.md`.
+14. Update impacted docs and GitHub Projects.
+15. Prepare handoff using `docs/automation/agent-handoff.md`.
+16. Report local validation and GitHub tracker verification evidence.
 
 ## Required Documentation Updates
 

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -639,4 +639,3 @@ Acceptance themes:
 Dependencies:
 
 - MILESTONE-2 local runtime foundation.
-

--- a/docs/standards/bdd-tdd.md
+++ b/docs/standards/bdd-tdd.md
@@ -45,4 +45,3 @@ A feature, behavior change, or bug fix is not complete until:
 - tests or validation prove the behavior
 - impacted docs are updated
 - validation evidence is reported
-

--- a/docs/standards/domain-driven-design.md
+++ b/docs/standards/domain-driven-design.md
@@ -45,4 +45,3 @@ conceptual boundaries.
 - Do not store UI status only in logs.
 - Do not make workflow runtime state the business source of truth.
 - Keep idempotency explicit at message and agent boundaries.
-

--- a/docs/standards/tooling.md
+++ b/docs/standards/tooling.md
@@ -12,11 +12,13 @@ Use:
 - `make check-tools` to verify host tools.
 - `make install-tools` to install or print installation guidance for host tools.
 - `make validate` for cheap repository validation.
+- `make docs-fix` to apply safe docs formatting fixes before committing.
 - `make github-project-check` to verify GitHub CLI auth and Project access.
 - `make github-project-summary` to summarize tracker counts.
 - `make github-project-hierarchy` to verify epic/story hierarchy.
 - `make github-project-active` to list active tracker items.
 - `npm run docs:check` for docs placeholder checks.
+- `npm run docs:fix` for safe docs formatting fixes.
 - `npm run tools:check` for host tool checks through npm.
 
 ## Tooling Strategy

--- a/docs/standards/typescript-react.md
+++ b/docs/standards/typescript-react.md
@@ -16,4 +16,3 @@ ingest packages and workflow state.
 - Support nested workflow drilldown and back traversal.
 - Prefer accessible color states with labels or icons where status ambiguity is
   possible.
-

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -3,7 +3,7 @@
 ## Project State
 
 - Phase: planning and repository foundation.
-- Current branch: `docs/story-planning`.
+- Current branch: `USER-STORY-16-link-and-commit-standards`.
 - Current focus: durable project documentation, automation guidance, standards,
   and toolchain bootstrap.
 
@@ -32,17 +32,17 @@
 - Read-only GitHub tracker helper commands added for agent verification.
 - Local task, bug, worktree, checklist, and definition-of-done docs aligned with
   the GitHub Projects tracker model.
+- Markdown link validation, safe docs fix commands, and Git branch/commit/PR
+  naming conventions are being added under USER-STORY-16.
 
 ## Ready For Review
 
-- Product traceability, parallel worktree documentation, and GitHub Projects
-  tracker setup are validated and ready for commit/PR when authorized.
+- Link and commit standards cleanup is validated and ready for PR when
+  authorized.
 
 ## Next
 
-- Review and refine documentation.
-- Commit planning foundation after user approval.
-- Create implementation plan for local foundation.
+- Create PR for `USER-STORY-16-link-and-commit-standards` after user approval.
 
 ## Known Agent Execution Gaps
 

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -37,12 +37,11 @@
 
 ## Ready For Review
 
-- Link and commit standards cleanup is validated and ready for PR when
-  authorized.
+- Link and commit standards cleanup is validated in PR #29.
 
 ## Next
 
-- Create PR for `USER-STORY-16-link-and-commit-standards` after user approval.
+- Merge PR #29 after checks complete.
 
 ## Known Agent Execution Gaps
 

--- a/docs/status/decision-log.md
+++ b/docs/status/decision-log.md
@@ -14,4 +14,3 @@ Architecture-significant decisions belong in `docs/adr`.
 
 Agents must add an entry here when a decision affects workflow, tooling,
 documentation structure, or development process but does not justify a full ADR.
-

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -5,6 +5,10 @@ messages or paste command output unless it explains a decision.
 
 ## 2026-05-03
 
+- Added Markdown link validation and Git naming conventions for branch, commit,
+  and PR traceability.
+- Added `make docs-fix` / `npm run docs:fix` for safe documentation formatting
+  cleanup before commits.
 - Created planning worktree `docs/story-planning`.
 - Added architecture, ADR, product, automation, and standards documentation.
 - Added repository operating model for status, task workflow, and toolchain checks.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Cloud-native media asset ingest backend planning and repository tooling.",
   "scripts": {
     "docs:check": "node scripts/dev/check-docs.mjs",
+    "docs:fix": "node scripts/dev/check-docs.mjs --fix",
     "github-project:active": "sh scripts/dev/github-projects.sh active",
     "github-project:check": "sh scripts/dev/github-projects.sh check-auth",
     "github-project:hierarchy": "sh scripts/dev/github-projects.sh hierarchy",

--- a/scripts/dev/check-docs.mjs
+++ b/scripts/dev/check-docs.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join, normalize } from 'node:path';
 
 const roots = ['AGENTS.md', 'README.md', 'docs'];
+const fix = process.argv.includes('--fix');
 const patterns = [
   { pattern: /\bTODO\b/g, allow: ['docs/automation/validation.md'] },
   { pattern: /\bTBD\b/g, allow: ['docs/automation/validation.md'] },
@@ -21,9 +22,29 @@ function listFiles(path) {
 
 const files = roots.flatMap((root) => listFiles(root));
 const findings = [];
+const markdownLinks = /\[[^\]]+\]\(([^)]+)\)/g;
+
+function normalizeMarkdown(text) {
+  const normalized = text
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+$/gm, '')
+    .replace(/\n*$/, '\n');
+
+  return normalized;
+}
 
 for (const file of files) {
-  const text = readFileSync(file, 'utf8');
+  let text = readFileSync(file, 'utf8');
+  const normalized = normalizeMarkdown(text);
+  if (normalized !== text) {
+    if (fix) {
+      writeFileSync(file, normalized, 'utf8');
+      text = normalized;
+    } else {
+      findings.push(`${file}: markdown formatting is not normalized; run npm run docs:fix`);
+    }
+  }
+
   const lines = text.split(/\r?\n/);
 
   for (const { pattern, allow } of patterns) {
@@ -38,15 +59,46 @@ for (const file of files) {
       }
     });
   }
+
+  if (file.endsWith('.md')) {
+    for (const match of text.matchAll(markdownLinks)) {
+      let target = match[1].trim();
+      if (
+        !target ||
+        target.startsWith('#') ||
+        /^[a-z][a-z0-9+.-]*:/i.test(target)
+      ) {
+        continue;
+      }
+
+      target = target.split('#')[0];
+      if (!target) {
+        continue;
+      }
+
+      const resolved = normalize(join(dirname(file), target));
+      if (!existsSync(resolved)) {
+        findings.push(`${file}: broken markdown link ${match[1]}`);
+        continue;
+      }
+
+      if (statSync(resolved).isDirectory() && !existsSync(join(resolved, 'README.md'))) {
+        findings.push(`${file}: directory markdown link lacks README ${match[1]}`);
+      }
+    }
+  }
 }
 
 if (findings.length > 0) {
-  console.error('Unfinished documentation markers found:');
+  console.error('Documentation checks failed:');
   for (const finding of findings) {
     console.error(finding);
   }
   process.exit(1);
 }
 
-console.log('Documentation placeholder check passed.');
-
+if (fix) {
+  console.log('Documentation fixes applied.');
+} else {
+  console.log('Documentation checks passed.');
+}


### PR DESCRIPTION
Summary:
- Adds docs link validation and safe docs formatting fixes through existing Node tooling.
- Adds Git branch, commit, and PR naming conventions for story/task traceability.
- Wires Make/npm commands and automation docs for pre-commit docs cleanup.

Validation:
- make validate
- git diff --check
- make github-project-active

Refs #26