### PR TITLE
USER-STORY-16: Reduce Project tracker lookups

### DIFF
--- a/docs/automation/github-projects.md
+++ b/docs/automation/github-projects.md
@@ -89,6 +89,10 @@ sh scripts/dev/github-projects.sh set-status 30 "In Progress"
 sh scripts/dev/github-projects.sh set-type 30 Task
 sh scripts/dev/github-projects.sh set-lane 30 Forge
 sh scripts/dev/github-projects.sh set-text 30 "Worktree / Branch" "TASK-2-1 / .worktrees/TASK-2-1"
+sh scripts/dev/github-projects.sh set-task-fields 30 Forge "In Progress" \
+  "TASK-2-1 / .worktrees/TASK-2-1" \
+  "MediaIngest.sln; src; tests" \
+  "make test-dotnet; make validate; git diff --check"
 sh scripts/dev/github-projects.sh add-sub-issue 26 30
 sh scripts/dev/github-projects.sh add-blocked-by 31 30
 sh scripts/dev/github-projects.sh audit-fields
@@ -123,6 +127,8 @@ Agent rules:
 - Run Project writes only at task boundaries: start, blocked, ready for PR, PR
   opened, merged, or cleanup.
 - Batch all fields for one issue before moving to the next issue.
+- Prefer `set-task-fields` over repeated `set-type`, `set-lane`, `set-status`,
+  and `set-text` calls for task setup.
 - Prefer one coordinating agent to perform tracker audits and bulk Project
   cleanup after parallel agents finish their local validation.
 - If GitHub returns a GraphQL rate-limit error, stop Project operations and

--- a/scripts/dev/github-projects.sh
+++ b/scripts/dev/github-projects.sh
@@ -21,6 +21,7 @@ Commands:
   set-type         Set GitHub Project Type for an issue.
   set-lane         Set GitHub Project Lane for an issue.
   set-text         Set a GitHub Project text field for an issue.
+  set-task-fields  Set common task Project fields in one serialized call.
   add-sub-issue    Add a native GitHub sub-issue relationship.
   add-blocked-by   Add a native GitHub blocked-by dependency.
 
@@ -127,26 +128,86 @@ lint_issue_bodies() {
 }
 
 project_id() {
-  gh project view "$PROJECT_NUMBER" --owner "$OWNER" --format json --jq '.id'
+  if [ -z "${PROJECT_ID_CACHE:-}" ]; then
+    PROJECT_ID_CACHE=$(gh project view "$PROJECT_NUMBER" --owner "$OWNER" --format json --jq '.id')
+  fi
+  printf '%s\n' "$PROJECT_ID_CACHE"
 }
 
 project_item_id_for_issue() {
   issue_number=$1
-  gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --limit 200 --format json \
-    --jq ".items[] | select(.content.number == $issue_number) | .id"
+  cache_var="PROJECT_ITEM_ID_${issue_number}"
+  eval "cached=\${$cache_var:-}"
+  if [ -z "$cached" ]; then
+    cached=$(
+      gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --limit 200 --format json \
+        --jq ".items[] | select(.content.number == $issue_number) | .id"
+    )
+    eval "$cache_var=\$cached"
+  fi
+  printf '%s\n' "$cached"
 }
 
 project_field_id() {
   field_name=$1
-  gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json \
-    --jq ".fields[] | select(.name == \"$field_name\") | .id"
+  case "$field_name" in
+    Type) cache_var=PROJECT_FIELD_TYPE ;;
+    Lane) cache_var=PROJECT_FIELD_LANE ;;
+    Status) cache_var=PROJECT_FIELD_STATUS ;;
+    "Worktree / Branch") cache_var=PROJECT_FIELD_WORKTREE ;;
+    "Target Files") cache_var=PROJECT_FIELD_TARGET_FILES ;;
+    Validation) cache_var=PROJECT_FIELD_VALIDATION ;;
+    PR) cache_var=PROJECT_FIELD_PR ;;
+    *)
+      printf 'Unsupported cached Project field: %s\n' "$field_name" >&2
+      exit 2
+      ;;
+  esac
+
+  eval "cached=\${$cache_var:-}"
+  if [ -z "$cached" ]; then
+    cached=$(
+      gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json \
+        --jq ".fields[] | select(.name == \"$field_name\") | .id"
+    )
+    eval "$cache_var=\$cached"
+  fi
+  printf '%s\n' "$cached"
 }
 
 project_option_id() {
   field_name=$1
   option_name=$2
-  gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json \
-    --jq ".fields[] | select(.name == \"$field_name\") | .options[] | select(.name == \"$option_name\") | .id"
+  case "$field_name:$option_name" in
+    Type:Task) cache_var=PROJECT_OPTION_TYPE_TASK ;;
+    Status:"In Progress") cache_var=PROJECT_OPTION_STATUS_IN_PROGRESS ;;
+    Status:"PR Open") cache_var=PROJECT_OPTION_STATUS_PR_OPEN ;;
+    Lane:Atlas) cache_var=PROJECT_OPTION_LANE_ATLAS ;;
+    Lane:Mount) cache_var=PROJECT_OPTION_LANE_MOUNT ;;
+    Lane:Pulse) cache_var=PROJECT_OPTION_LANE_PULSE ;;
+    Lane:Courier) cache_var=PROJECT_OPTION_LANE_COURIER ;;
+    Lane:Vault) cache_var=PROJECT_OPTION_LANE_VAULT ;;
+    Lane:Essence) cache_var=PROJECT_OPTION_LANE_ESSENCE ;;
+    Lane:Beacon) cache_var=PROJECT_OPTION_LANE_BEACON ;;
+    Lane:Canvas) cache_var=PROJECT_OPTION_LANE_CANVAS ;;
+    Lane:Forge) cache_var=PROJECT_OPTION_LANE_FORGE ;;
+    Lane:Gauge) cache_var=PROJECT_OPTION_LANE_GAUGE ;;
+    Lane:Shield) cache_var=PROJECT_OPTION_LANE_SHIELD ;;
+    *)
+      printf 'Unsupported cached Project option: %s=%s\n' "$field_name" "$option_name" >&2
+      exit 2
+      ;;
+  esac
+
+  eval "cached=\${$cache_var:-}"
+  if [ -z "$cached" ]; then
+    cached=$(
+      gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json \
+        --jq ".fields[] | select(.name == \"$field_name\") | .options[] | select(.name == \"$option_name\") | .id"
+    )
+    eval "$cache_var=\$cached"
+  fi
+  printf '%s\n' "$cached"
 }
 
 require_arg() {
@@ -200,6 +261,22 @@ set_text_field() {
     --id "$item" \
     --field-id "$field" \
     --text "$text_value"
+}
+
+set_task_fields() {
+  issue_number=$1
+  lane=$2
+  status=$3
+  worktree_branch=$4
+  target_files=$5
+  validation=$6
+
+  set_single_select_field "$issue_number" "Type" "Task"
+  set_single_select_field "$issue_number" "Lane" "$lane"
+  set_single_select_field "$issue_number" "Status" "$status"
+  set_text_field "$issue_number" "Worktree / Branch" "$worktree_branch"
+  set_text_field "$issue_number" "Target Files" "$target_files"
+  set_text_field "$issue_number" "Validation" "$validation"
 }
 
 mark_active_worktree_pr_open() {
@@ -327,6 +404,15 @@ case "${1:-}" in
     require_arg "${3:-}" "field-name"
     require_arg "${4:-}" "text"
     set_text_field "$2" "$3" "$4"
+    ;;
+  set-task-fields)
+    require_arg "${2:-}" "issue-number"
+    require_arg "${3:-}" "lane"
+    require_arg "${4:-}" "status"
+    require_arg "${5:-}" "worktree-branch"
+    require_arg "${6:-}" "target-files"
+    require_arg "${7:-}" "validation"
+    set_task_fields "$2" "$3" "$4" "$5" "$6" "$7"
     ;;
   add-sub-issue)
     require_arg "${2:-}" "parent-issue-number"

--- a/scripts/dev/test-github-projects.sh
+++ b/scripts/dev/test-github-projects.sh
@@ -39,20 +39,46 @@ case "$args" in
   *"project field-list 2 --owner ankit-singhal87"*".name == \"Status\""*".options[]"*".name == \"PR Open\""*)
     printf '%s\n' "PR_OPEN"
     ;;
+  *"project field-list 2 --owner ankit-singhal87"*".name == \"Type\""*".options[]"*".name == \"Task\""*)
+    printf '%s\n' "TYPE_TASK"
+    ;;
+  *"project field-list 2 --owner ankit-singhal87"*".name == \"Lane\""*".options[]"*".name == \"Forge\""*)
+    printf '%s\n' "LANE_FORGE"
+    ;;
   *"project field-list 2 --owner ankit-singhal87"*".name == \"Status\""*".id")
     printf '%s\n' "STATUS_FIELD"
     ;;
+  *"project field-list 2 --owner ankit-singhal87"*".name == \"Type\""*".id")
+    printf '%s\n' "TYPE_FIELD"
+    ;;
+  *"project field-list 2 --owner ankit-singhal87"*".name == \"Lane\""*".id")
+    printf '%s\n' "LANE_FIELD"
+    ;;
   *"project field-list 2 --owner ankit-singhal87"*".name == \"Worktree / Branch\""*".id")
     printf '%s\n' "WORKTREE_FIELD"
+    ;;
+  *"project field-list 2 --owner ankit-singhal87"*".name == \"Target Files\""*".id")
+    printf '%s\n' "TARGET_FILES_FIELD"
+    ;;
+  *"project field-list 2 --owner ankit-singhal87"*".name == \"Validation\""*".id")
+    printf '%s\n' "VALIDATION_FIELD"
     ;;
   *"project field-list 2 --owner ankit-singhal87"*".name == \"PR\""*".id")
     printf '%s\n' "PR_FIELD"
     ;;
   "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id STATUS_FIELD --single-select-option-id STATUS_IN_PROGRESS")
     ;;
+  "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id TYPE_FIELD --single-select-option-id TYPE_TASK")
+    ;;
+  "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id LANE_FIELD --single-select-option-id LANE_FORGE")
+    ;;
   "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id STATUS_FIELD --single-select-option-id PR_OPEN")
     ;;
   "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id WORKTREE_FIELD --text TASK-2-1 / .worktrees/TASK-2-1")
+    ;;
+  "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id TARGET_FILES_FIELD --text src; tests")
+    ;;
+  "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id VALIDATION_FIELD --text make validate")
     ;;
   "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id PR_FIELD --text https://github.com/ankit-singhal87/media-asset-ingest/pull/30")
     ;;
@@ -90,6 +116,10 @@ PATH="$fake_bin:$PATH" GH_TEST_LOG="$log_file" \
   sh scripts/dev/github-projects.sh set-text 30 "Worktree / Branch" "TASK-2-1 / .worktrees/TASK-2-1"
 
 PATH="$fake_bin:$PATH" GH_TEST_LOG="$log_file" \
+  sh scripts/dev/github-projects.sh set-task-fields \
+    30 Forge "In Progress" "TASK-2-1 / .worktrees/TASK-2-1" "src; tests" "make validate"
+
+PATH="$fake_bin:$PATH" GH_TEST_LOG="$log_file" \
   sh scripts/dev/github-projects.sh add-sub-issue 26 30 >/dev/null
 
 PATH="$fake_bin:$PATH" GH_TEST_LOG="$log_file" \
@@ -120,7 +150,11 @@ PATH="$fake_bin:$PATH" GH_TEST_LOG="$log_file" GH_TEST_BODY="$body_file" \
     "$active_worktrees_file" >/dev/null
 
 grep -F "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id STATUS_FIELD --single-select-option-id STATUS_IN_PROGRESS" "$log_file" >/dev/null
+grep -F "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id TYPE_FIELD --single-select-option-id TYPE_TASK" "$log_file" >/dev/null
+grep -F "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id LANE_FIELD --single-select-option-id LANE_FORGE" "$log_file" >/dev/null
 grep -F "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id WORKTREE_FIELD --text TASK-2-1 / .worktrees/TASK-2-1" "$log_file" >/dev/null
+grep -F "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id TARGET_FILES_FIELD --text src; tests" "$log_file" >/dev/null
+grep -F "project item-edit --project-id PROJECT_ID --id ITEM_30 --field-id VALIDATION_FIELD --text make validate" "$log_file" >/dev/null
 grep -F "repos/ankit-singhal87/media-asset-ingest/issues/26/sub_issues" "$log_file" >/dev/null
 grep -F "sub_issue_id=4372284132" "$log_file" >/dev/null
 grep -F "repos/ankit-singhal87/media-asset-ingest/issues/31/dependencies/blocked_by" "$log_file" >/dev/null


### PR DESCRIPTION
# USER-STORY-16: Reduce Project tracker lookups

  ## Summary

  - Adds in-process caching for GitHub Project IDs, item IDs, field IDs, and option IDs in
  `scripts/dev/github-projects.sh`.
  - Adds `set-task-fields` so agents can set common task Project fields in one serialized helper
  invocation.
  - Updates fake-`gh` regression coverage and documents the preferred batched helper usage.

  ## Validation

  - `make validate` passed.
  - `git diff --check` passed.

  ## Risk

  Low. This only changes local tracker automation helpers and docs. GitHub Project writes should
  still be run serially because Projects use the shared GraphQL rate-limit budget.

  ## Notes

  Refs #26
