### PR TITLE
USER-STORY-16: Add agent tooling accelerators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .worktrees/
+.cache/
 
 # .NET build output
 **/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
-.PHONY: help check-tools install-tools print-install-tools validate test-dotnet docs-check docs-fix scripts-check github-projects-script-test github-project-check github-project-summary github-project-hierarchy github-project-active github-project-audit-fields github-issue-body-lint
+.PHONY: help agent-preflight check-tools install-tools install-optional-tools print-install-tools print-install-optional-tools validate validate-docs validate-automation test-dotnet test-dotnet-foundation test-dotnet-contracts test-dotnet-watcher test-dotnet-persistence test-dotnet-outbox test-dotnet-workflow test-dotnet-observability docs-check docs-fix scripts-check github-projects-script-test github-project-check github-project-summary github-project-hierarchy github-project-active github-project-audit-fields github-issue-body-lint
 
 help:
 	@printf '%s\n' "Available targets:"
+	@printf '%s\n' "  make agent-preflight     Print local agent startup context"
 	@printf '%s\n' "  make check-tools         Verify required Linux development tools"
 	@printf '%s\n' "  make install-tools       Install supported Linux development tools"
+	@printf '%s\n' "  make install-optional-tools Install optional local runtime/cloud CLIs"
 	@printf '%s\n' "  make print-install-tools Print manual installation commands"
+	@printf '%s\n' "  make print-install-optional-tools Print optional tool install commands"
 	@printf '%s\n' "  make validate            Run cheap repository validation"
+	@printf '%s\n' "  make validate-docs       Run docs validation only"
+	@printf '%s\n' "  make validate-automation Run automation script validation only"
 	@printf '%s\n' "  make test-dotnet         Build and smoke-test the .NET solution"
+	@printf '%s\n' "  make test-dotnet-*       Run a focused .NET smoke target"
 	@printf '%s\n' "  make docs-check          Check docs for unfinished placeholders"
 	@printf '%s\n' "  make docs-fix            Apply safe docs formatting fixes"
 	@printf '%s\n' "  make scripts-check       Syntax-check shell scripts"
@@ -18,19 +24,53 @@ help:
 	@printf '%s\n' "  make github-project-audit-fields Verify required Project fields"
 	@printf '%s\n' "  make github-issue-body-lint   Check issue bodies for duplicated relationships"
 
+agent-preflight:
+	@sh scripts/dev/agent-preflight.sh
+
 check-tools:
 	@sh scripts/dev/check-tools.sh
 
 install-tools:
 	@sh scripts/dev/install-tools.sh
 
+install-optional-tools:
+	@sh scripts/dev/install-optional-tools.sh
+
 print-install-tools:
 	@sh scripts/dev/install-tools.sh --print-only
 
+print-install-optional-tools:
+	@sh scripts/dev/install-optional-tools.sh --print-only
+
 validate: docs-check scripts-check github-projects-script-test test-dotnet
+
+validate-docs: docs-check
+
+validate-automation: scripts-check github-projects-script-test
 
 test-dotnet:
 	@sh scripts/dev/test-dotnet.sh
+
+test-dotnet-foundation:
+	@sh scripts/dev/test-dotnet.sh foundation
+
+test-dotnet-contracts:
+	@sh scripts/dev/test-dotnet.sh contracts
+
+test-dotnet-watcher:
+	@sh scripts/dev/test-dotnet.sh watcher
+
+test-dotnet-persistence:
+	@sh scripts/dev/test-dotnet.sh persistence
+
+test-dotnet-outbox:
+	@sh scripts/dev/test-dotnet.sh outbox
+
+test-dotnet-workflow:
+	@sh scripts/dev/test-dotnet.sh workflow
+
+test-dotnet-observability:
+	@sh scripts/dev/test-dotnet.sh observability
 
 docs-check:
 	@npm run docs:check
@@ -41,6 +81,8 @@ docs-fix:
 scripts-check:
 	@sh -n scripts/dev/check-tools.sh
 	@sh -n scripts/dev/install-tools.sh
+	@sh -n scripts/dev/install-optional-tools.sh
+	@sh -n scripts/dev/agent-preflight.sh
 	@sh -n scripts/dev/test-dotnet.sh
 	@sh -n scripts/dev/github-projects.sh
 	@sh -n scripts/dev/test-github-projects.sh

--- a/docs/automation/commands.md
+++ b/docs/automation/commands.md
@@ -7,11 +7,23 @@
 | `rg "<term>" docs` | Targeted documentation search. | cheap | no | no |
 | `find docs -maxdepth 3 -type f -print` | List documentation files. | cheap | no | no |
 | `make help` | List canonical project commands. | cheap | no | no |
+| `make agent-preflight` | Print local startup context, worktrees, tool status, and validation targets. | cheap | no | no |
 | `make check-tools` | Verify required Linux development tools and report optional tools. | cheap | no | no |
 | `make install-tools` | Install supported Linux host tools after local confirmation. | moderate | no | no |
+| `make install-optional-tools` | Install optional host runtime and cloud CLIs after local confirmation. | moderate | no | no |
 | `make print-install-tools` | Print installation commands without running them. | cheap | no | no |
+| `make print-install-optional-tools` | Print optional host tool installation commands without running them. | cheap | no | no |
 | `make validate` | Run cheap repository validation. | cheap | no | no |
+| `make validate-docs` | Run documentation validation only. | cheap | no | no |
+| `make validate-automation` | Run shell syntax checks and GitHub helper wrapper tests. | cheap | no | no |
 | `make test-dotnet` | Build and smoke-test the .NET solution using host `dotnet` or the .NET SDK container. | moderate | yes when host `dotnet` is unavailable | no |
+| `make test-dotnet-foundation` | Run the foundation smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
+| `make test-dotnet-contracts` | Run the contracts smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
+| `make test-dotnet-watcher` | Run the ingest watcher smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
+| `make test-dotnet-persistence` | Run the persistence smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
+| `make test-dotnet-outbox` | Run the outbox worker smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
+| `make test-dotnet-workflow` | Run the workflow smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
+| `make test-dotnet-observability` | Run the observability smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
 | `make docs-fix` | Apply safe documentation formatting fixes before committing. | cheap | no | no |
 | `make github-projects-script-test` | Test GitHub tracker helper wrappers without network. | cheap | no | no |
 | `make github-project-check` | Verify GitHub CLI auth and project access. | cheap | no | no |
@@ -23,6 +35,7 @@
 | `npm run docs:check` | Check docs for unfinished placeholders. | cheap | no | no |
 | `npm run docs:fix` | Apply safe docs formatting fixes. | cheap | no | no |
 | `npm run dotnet:test` | Build and smoke-test the .NET solution through npm. | moderate | yes when host `dotnet` is unavailable | no |
+| `npm run dotnet:test:<target>` | Run a focused .NET smoke test target. | cheap | yes when host `dotnet` is unavailable | no |
 | `npm run github-project:check` | Verify GitHub CLI auth and project access through npm. | cheap | no | no |
 | `npm run github-project:summary` | Print GitHub tracker counts through npm. | cheap | no | no |
 | `npm run github-project:hierarchy` | Print GitHub tracker hierarchy through npm. | cheap | no | no |
@@ -31,6 +44,7 @@
 | `npm run github-project:issue-body-lint` | Check issue body relationship metadata through npm. | cheap | no | no |
 | `npm run github-project:script-test` | Test GitHub tracker helper wrappers through npm. | cheap | no | no |
 | `npm run tools:check` | Verify required Linux development tools through npm. | cheap | no | no |
+| `npm run tools:print-install:optional` | Print optional host tool installation commands through npm. | cheap | no | no |
 
 Add Makefile targets once the runtime scaffold exists. Prefer the cheapest
 relevant validation command first.

--- a/docs/automation/validation.md
+++ b/docs/automation/validation.md
@@ -4,11 +4,11 @@
 | --- | --- | --- | --- | --- | --- |
 | Docs-only change | `make docs-check` | `make docs-fix` before committing when formatting/link checks fail | no | no | cheap |
 | Architecture/ADR change | targeted term search for contradictory decisions | review affected ADRs and architecture docs together | no | no | cheap |
-| Automation-doc change | `make validate` | read `AGENTS.md`, task workflow, and automation docs for consistency | no | no | cheap |
-| Standards change | `make validate` | review affected automation docs and task workflow | no | no | cheap |
+| Automation-doc change | `make validate-automation` and `make docs-check` | `make validate`, then read `AGENTS.md`, task workflow, and automation docs for consistency | no | no | cheap |
+| Standards change | `make docs-check` and the relevant focused validation target | `make validate` and review affected automation docs and task workflow | no | no | cheap |
 | Tooling change | `make validate` and `make check-tools` when host tools are expected | `make print-install-tools` review | no | no | cheap |
 | GitHub tracker change | `make github-project-summary` and `make github-project-active` | targeted `gh issue view`, `make github-project-hierarchy` only when parent/child navigation changed | no | no | cheap |
-| .NET code change | `make test-dotnet` | `make validate` | yes when host `dotnet` is unavailable | no | moderate |
+| .NET code change | focused `make test-dotnet-*` target for the touched component | `make test-dotnet`, then `make validate` before PR | yes when host `dotnet` is unavailable | no | moderate |
 | Docker/Kubernetes change | relevant local smoke test once scripts exist | full local runtime validation | yes | no | moderate |
 | Azure deployment change | static manifest/terraform validation only | manual cloud validation after approval | maybe | yes | paid/approval |
 

--- a/docs/standards/tooling.md
+++ b/docs/standards/tooling.md
@@ -9,10 +9,18 @@ Ubuntu/Debian are the first-class installation target for bootstrap scripts.
 
 Use:
 
+- `make agent-preflight` to print local agent startup context and validation
+  options.
 - `make check-tools` to verify host tools.
 - `make install-tools` to install or print installation guidance for host tools.
+- `make install-optional-tools` to install optional runtime and cloud CLIs
+  after explicit local confirmation.
+- `make print-install-optional-tools` to inspect optional install commands
+  without running them.
 - `make test-dotnet` to build and smoke-test the .NET solution.
+- `make test-dotnet-*` for focused .NET smoke tests during inner-loop work.
 - `make validate` for cheap repository validation.
+- `make validate-docs` and `make validate-automation` for focused validation.
 - `make docs-fix` to apply safe docs formatting fixes before committing.
 - `make github-projects-script-test` to test legacy GitHub tracker helper
   wrappers without network access.
@@ -24,8 +32,10 @@ Use:
 - `npm run docs:check` for docs placeholder checks.
 - `npm run docs:fix` for safe docs formatting fixes.
 - `npm run dotnet:test` for .NET solution validation through npm.
+- `npm run dotnet:test:<target>` for focused .NET smoke tests.
 - `npm run github-project:script-test` for legacy tracker helper wrapper tests.
 - `npm run tools:check` for host tool checks through npm.
+- `npm run tools:print-install:optional` for optional install command review.
 
 ## Tooling Strategy
 
@@ -64,7 +74,10 @@ Notes:
 - .NET SDK: prefer SDK containers for build/test targets; host install is
   optional. `make test-dotnet` uses host `dotnet` when present and otherwise
   runs the .NET SDK container image from `DOTNET_SDK_IMAGE`, defaulting to
-  `mcr.microsoft.com/dotnet/sdk:10.0`.
+  `mcr.microsoft.com/dotnet/sdk:10.0`. Docker-backed .NET validation stores
+  NuGet packages and CLI home data under `.cache/dotnet` by default so repeated
+  agent runs reuse restore artifacts without committing generated files. Override
+  the cache location with `DOTNET_REPO_CACHE_DIR` when needed.
 - Azure CLI: prefer the official Azure CLI container or manual host install; login
   remains manual either way.
 - kubectl/Helm/Dapr: host installs are convenient, but deployment-oriented

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -62,6 +62,9 @@
   lightweight status only.
 - Command routing now uses semantic command topics and light, medium, or heavy
   execution classes instead of media-specific agent projects.
+- Agent execution tooling now includes focused .NET smoke-test targets, focused
+  validation targets, an agent preflight command, and a repo-local ignored
+  Docker .NET cache for faster repeated validation.
 
 ## Ready For Review
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -75,6 +75,11 @@ messages or paste command output unless it explains a decision.
   useful, and simple Project status only.
 - Replaced the media-specific agent skeleton direction with generic command
   routing contracts and light, medium, or heavy execution classes.
+- Added focused .NET smoke-test targets, focused validation targets, an agent
+  preflight command, and a repo-local ignored Docker .NET cache to reduce
+  repeated agent validation time.
+- Added a dedicated optional host-tool installer for .NET SDK, kubectl, Helm,
+  Dapr CLI, and Azure CLI with confirmation and post-install verification.
 
 ## Update Rule
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "scripts": {
     "docs:check": "node scripts/dev/check-docs.mjs",
     "docs:fix": "node scripts/dev/check-docs.mjs --fix",
+    "dotnet:test:contracts": "sh scripts/dev/test-dotnet.sh contracts",
+    "dotnet:test:foundation": "sh scripts/dev/test-dotnet.sh foundation",
+    "dotnet:test:observability": "sh scripts/dev/test-dotnet.sh observability",
+    "dotnet:test:outbox": "sh scripts/dev/test-dotnet.sh outbox",
+    "dotnet:test:persistence": "sh scripts/dev/test-dotnet.sh persistence",
+    "dotnet:test:watcher": "sh scripts/dev/test-dotnet.sh watcher",
+    "dotnet:test:workflow": "sh scripts/dev/test-dotnet.sh workflow",
     "dotnet:test": "sh scripts/dev/test-dotnet.sh",
     "github-project:active": "sh scripts/dev/github-projects.sh active",
     "github-project:audit-fields": "sh scripts/dev/github-projects.sh audit-fields",
@@ -14,6 +21,8 @@
     "github-project:issue-body-lint": "sh scripts/dev/github-projects.sh lint-issue-bodies",
     "github-project:script-test": "sh scripts/dev/test-github-projects.sh",
     "github-project:summary": "sh scripts/dev/github-projects.sh summary",
+    "tools:install:optional": "sh scripts/dev/install-optional-tools.sh",
+    "tools:print-install:optional": "sh scripts/dev/install-optional-tools.sh --print-only",
     "tools:check": "sh scripts/dev/check-tools.sh"
   },
   "devDependencies": {}

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -u
+
+printf '%s\n' "Repository:"
+git status --short --branch
+
+printf '\n%s\n' "Worktrees:"
+git worktree list
+
+printf '\n%s\n' "Required tools:"
+sh scripts/dev/check-tools.sh
+
+printf '\n%s\n' "Canonical validation:"
+printf '%s\n' "- make docs-check"
+printf '%s\n' "- make scripts-check"
+printf '%s\n' "- make test-dotnet"
+printf '%s\n' "- make validate"
+
+printf '\n%s\n' "Focused .NET validation:"
+printf '%s\n' "- make test-dotnet-foundation"
+printf '%s\n' "- make test-dotnet-contracts"
+printf '%s\n' "- make test-dotnet-watcher"
+printf '%s\n' "- make test-dotnet-persistence"
+printf '%s\n' "- make test-dotnet-outbox"
+printf '%s\n' "- make test-dotnet-workflow"
+printf '%s\n' "- make test-dotnet-observability"

--- a/scripts/dev/install-optional-tools.sh
+++ b/scripts/dev/install-optional-tools.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -eu
+
+if [ "$(uname -s)" != "Linux" ]; then
+  printf '%s\n' "This optional tool installer supports Linux only."
+  exit 1
+fi
+
+if [ -r /etc/os-release ]; then
+  . /etc/os-release
+else
+  printf '%s\n' "Cannot detect Linux distribution because /etc/os-release is missing."
+  exit 1
+fi
+
+case "${ID:-}" in
+  ubuntu|debian)
+    ;;
+  *)
+    printf 'Unsupported distribution: %s\n' "${PRETTY_NAME:-unknown}"
+    printf '%s\n' "Install optional tools manually from their official documentation."
+    exit 1
+    ;;
+esac
+
+mode="install"
+if [ "${1:-}" = "--print-only" ]; then
+  mode="print"
+fi
+
+kubernetes_minor="${KUBERNETES_MINOR:-v1.35}"
+
+print_commands() {
+  cat <<EOF
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg lsb-release apt-transport-https gpg
+
+# .NET SDK 10.0.
+sudo apt-get install -y dotnet-sdk-10.0
+
+# Azure CLI apt repository.
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg >/dev/null
+sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+AZ_DIST=\$(lsb_release -cs)
+cat <<AZURE_EOF | sudo tee /etc/apt/sources.list.d/azure-cli.sources >/dev/null
+Types: deb
+URIs: https://packages.microsoft.com/repos/azure-cli/
+Suites: \${AZ_DIST}
+Components: main
+Architectures: \$(dpkg --print-architecture)
+Signed-by: /etc/apt/keyrings/microsoft.gpg
+AZURE_EOF
+
+# kubectl apt repository. Override with KUBERNETES_MINOR=v1.xx when needed.
+curl -fsSL https://pkgs.k8s.io/core:/stable:/${kubernetes_minor}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 0644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${kubernetes_minor}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
+sudo chmod 0644 /etc/apt/sources.list.d/kubernetes.list
+
+# Helm apt repository.
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list >/dev/null
+
+sudo apt-get update
+sudo apt-get install -y azure-cli kubectl helm
+
+# Dapr CLI.
+curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | /bin/bash
+EOF
+}
+
+verify_tool() {
+  tool="$1"
+  if command -v "$tool" >/dev/null 2>&1; then
+    path=$(command -v "$tool")
+    version=$("$tool" --version 2>/dev/null | head -n 1 || true)
+    if [ -n "$version" ]; then
+      printf 'ok       %-8s %s (%s)\n' "$tool" "$path" "$version"
+    else
+      printf 'ok       %-8s %s\n' "$tool" "$path"
+    fi
+  else
+    printf 'missing  %-8s\n' "$tool"
+    return 1
+  fi
+}
+
+if [ "$mode" = "print" ]; then
+  print_commands
+  exit 0
+fi
+
+printf '%s\n' "This script installs optional local tools for this repository:"
+printf '%s\n' "- dotnet SDK 10.0"
+printf '%s\n' "- kubectl from Kubernetes ${kubernetes_minor} apt repo"
+printf '%s\n' "- Helm from the Helm/Buildkite apt repo"
+printf '%s\n' "- Dapr CLI from the official Dapr install script"
+printf '%s\n' "- Azure CLI from the Microsoft Azure CLI apt repo"
+printf '%s\n' ""
+printf '%s\n' "It may use sudo, configure apt repositories, and download packages."
+printf '%s\n' "It will not run az login, dapr init, create cloud resources, or write secrets."
+printf '%s' "Continue? [y/N] "
+read -r answer
+
+case "$answer" in
+  y|Y|yes|YES)
+    ;;
+  *)
+    printf '%s\n' "Installation cancelled."
+    exit 0
+    ;;
+esac
+
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg lsb-release apt-transport-https gpg
+
+sudo apt-get install -y dotnet-sdk-10.0
+
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
+  gpg --dearmor |
+  sudo tee /etc/apt/keyrings/microsoft.gpg >/dev/null
+sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+
+az_dist=$(lsb_release -cs)
+cat <<AZURE_EOF | sudo tee /etc/apt/sources.list.d/azure-cli.sources >/dev/null
+Types: deb
+URIs: https://packages.microsoft.com/repos/azure-cli/
+Suites: ${az_dist}
+Components: main
+Architectures: $(dpkg --print-architecture)
+Signed-by: /etc/apt/keyrings/microsoft.gpg
+AZURE_EOF
+
+curl -fsSL "https://pkgs.k8s.io/core:/stable:/${kubernetes_minor}/deb/Release.key" |
+  sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 0644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+printf 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/%s/deb/ /\n' "$kubernetes_minor" |
+  sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
+sudo chmod 0644 /etc/apt/sources.list.d/kubernetes.list
+
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey |
+  gpg --dearmor |
+  sudo tee /usr/share/keyrings/helm.gpg >/dev/null
+printf '%s\n' "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" |
+  sudo tee /etc/apt/sources.list.d/helm-stable-debian.list >/dev/null
+
+sudo apt-get update
+sudo apt-get install -y azure-cli kubectl helm
+
+if ! command -v dapr >/dev/null 2>&1; then
+  curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | /bin/bash
+fi
+
+printf '\n%s\n' "Verification:"
+missing=0
+for tool in dotnet kubectl helm dapr az; do
+  if ! verify_tool "$tool"; then
+    missing=1
+  fi
+done
+
+if [ "$missing" -ne 0 ]; then
+  printf '\n%s\n' "One or more optional tools are still missing from PATH."
+  exit 1
+fi
+
+cat <<'EOF'
+
+Optional tools are installed.
+
+Manual follow-up when needed:
+- Run `az login` only when Azure access is required.
+- Run `dapr init` only when the local Dapr runtime is required.
+- Run `make check-tools` to verify repository tool status.
+EOF

--- a/scripts/dev/test-dotnet.sh
+++ b/scripts/dev/test-dotnet.sh
@@ -2,16 +2,79 @@
 set -eu
 
 solution="MediaIngest.sln"
-test_projects="tests/MediaIngest.Foundation.Tests/MediaIngest.Foundation.Tests.csproj tests/MediaIngest.Contracts.Tests/MediaIngest.Contracts.Tests.csproj tests/MediaIngest.Worker.Watcher.Tests/MediaIngest.Worker.Watcher.Tests.csproj tests/MediaIngest.Persistence.Tests/MediaIngest.Persistence.Tests.csproj tests/MediaIngest.Worker.Outbox.Tests/MediaIngest.Worker.Outbox.Tests.csproj tests/MediaIngest.Workflow.Tests/MediaIngest.Workflow.Tests.csproj tests/MediaIngest.Observability.Tests/MediaIngest.Observability.Tests.csproj"
 sdk_image="${DOTNET_SDK_IMAGE:-mcr.microsoft.com/dotnet/sdk:10.0}"
+repo_cache_dir="${DOTNET_REPO_CACHE_DIR:-.cache/dotnet}"
+
+foundation_tests="tests/MediaIngest.Foundation.Tests/MediaIngest.Foundation.Tests.csproj"
+contracts_tests="tests/MediaIngest.Contracts.Tests/MediaIngest.Contracts.Tests.csproj"
+watcher_tests="tests/MediaIngest.Worker.Watcher.Tests/MediaIngest.Worker.Watcher.Tests.csproj"
+persistence_tests="tests/MediaIngest.Persistence.Tests/MediaIngest.Persistence.Tests.csproj"
+outbox_tests="tests/MediaIngest.Worker.Outbox.Tests/MediaIngest.Worker.Outbox.Tests.csproj"
+workflow_tests="tests/MediaIngest.Workflow.Tests/MediaIngest.Workflow.Tests.csproj"
+observability_tests="tests/MediaIngest.Observability.Tests/MediaIngest.Observability.Tests.csproj"
+
+all_test_projects="$foundation_tests $contracts_tests $watcher_tests $persistence_tests $outbox_tests $workflow_tests $observability_tests"
+test_projects=""
+scope="selected"
+
+append_project() {
+  if [ -z "$test_projects" ]; then
+    test_projects="$1"
+  else
+    test_projects="$test_projects $1"
+  fi
+}
+
+if [ "$#" -eq 0 ] || [ "${1:-}" = "all" ]; then
+  test_projects="$all_test_projects"
+  scope="all"
+else
+  for target in "$@"; do
+    case "$target" in
+      foundation)
+        append_project "$foundation_tests"
+        ;;
+      contracts)
+        append_project "$contracts_tests"
+        ;;
+      watcher)
+        append_project "$watcher_tests"
+        ;;
+      persistence)
+        append_project "$persistence_tests"
+        ;;
+      outbox)
+        append_project "$outbox_tests"
+        ;;
+      workflow)
+        append_project "$workflow_tests"
+        ;;
+      observability)
+        append_project "$observability_tests"
+        ;;
+      *)
+        printf 'Unknown .NET test target: %s\n' "$target"
+        printf '%s\n' "Supported targets: all foundation contracts watcher persistence outbox workflow observability"
+        exit 2
+        ;;
+    esac
+  done
+fi
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=true
 export DOTNET_NOLOGO=1
 
 if command -v dotnet >/dev/null 2>&1; then
-  dotnet restore "$solution"
-  dotnet build "$solution" --no-restore
+  if [ "$scope" = "all" ]; then
+    dotnet restore "$solution"
+    dotnet build "$solution" --no-restore
+  else
+    for test_project in $test_projects; do
+      dotnet restore "$test_project"
+      dotnet build "$test_project" --no-restore
+    done
+  fi
   for test_project in $test_projects; do
     dotnet run --project "$test_project" --no-restore
   done
@@ -28,14 +91,23 @@ if ! docker info >/dev/null 2>&1; then
   exit 1
 fi
 
+mkdir -p "$repo_cache_dir/cli-home" "$repo_cache_dir/nuget-packages"
+
+if [ "$scope" = "all" ]; then
+  dotnet_command="dotnet restore '$solution' && dotnet build '$solution' --no-restore && for test_project in $test_projects; do dotnet run --project \"\$test_project\" --no-restore; done"
+else
+  dotnet_command="for test_project in $test_projects; do dotnet restore \"\$test_project\" && dotnet build \"\$test_project\" --no-restore && dotnet run --project \"\$test_project\" --no-restore; done"
+fi
+
 docker run --rm \
   -u "$(id -u):$(id -g)" \
-  -e DOTNET_CLI_HOME=/tmp \
+  -e DOTNET_CLI_HOME=/workspace/"$repo_cache_dir"/cli-home \
   -e DOTNET_CLI_TELEMETRY_OPTOUT=1 \
   -e DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=true \
   -e DOTNET_NOLOGO=1 \
-  -e HOME=/tmp \
+  -e HOME=/workspace/"$repo_cache_dir"/cli-home \
+  -e NUGET_PACKAGES=/workspace/"$repo_cache_dir"/nuget-packages \
   -v "$(pwd):/workspace" \
   -w /workspace \
   "$sdk_image" \
-  sh -c "dotnet restore '$solution' && dotnet build '$solution' --no-restore && for test_project in $test_projects; do dotnet run --project \"\$test_project\" --no-restore; done"
+  sh -c "$dotnet_command"


### PR DESCRIPTION
## Summary
- Adds focused validation and focused .NET smoke-test targets for faster agent inner loops.
- Adds cached Docker-backed .NET validation and an agent preflight command.
- Adds a confirmed optional host-tool installer for dotnet, kubectl, Helm, Dapr CLI, and Azure CLI.

Refs #26

## Validation
- `make validate-automation` passed.
- `make docs-check` passed.
- `make validate` passed after optional host tools were installed.
- `git diff --check` passed.
- `make check-tools` reports required and optional tools available.

## Risk
- Low. Changes are local tooling and documentation only.
- Optional installer uses sudo and network downloads only after explicit local confirmation.

## Follow-up
- Run `az login` or `dapr init` manually only when those workflows are needed.