### PR TITLE
USER-STORY-12: Add local ingest start UI

### DIFF
--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -29,6 +29,7 @@ mirror.
 | `.worktrees/TASK-6-1-specialized-agent-skeletons` | `TASK-6-1-specialized-agent-skeletons` | #34 | USER-STORY-7 | Essence | Superseded media-agent skeleton paths; command routing now lives in `src/MediaIngest.Contracts/Commands` and contract tests | Cleaned Up | Local merge to `main` |
 | `.worktrees/TASK-7-1-observability-correlation` | `TASK-7-1-observability-correlation` | #37 | USER-STORY-11 | Beacon | `src/MediaIngest.Observability`, `tests/MediaIngest.Observability.Tests`, `MediaIngest.sln`, `scripts/dev/test-dotnet.sh`, `docs/architecture/004-observability-and-ui.md`, `docs/plans/task-index.md`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md` | Cleaned Up | Local merge to `main` |
 | `.worktrees/TASK-8-1-react-control-plane` | `TASK-8-1-react-control-plane` | #33 | USER-STORY-12 | Canvas | `web/ingest-control-plane`, `docs/plans/task-index.md`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md`, `docs/standards/typescript-react.md` | Cleaned Up | Local merge to `main` |
+| `.worktrees/USER-STORY-12-local-ingest-start-ui` | `USER-STORY-12-local-ingest-start-ui` | #22 | USER-STORY-12 | Canvas | `web/ingest-control-plane`, `docs/plans/active-worktrees.md` | PR Open | https://github.com/ankit-singhal87/media-asset-ingest/pull/43 |
 
 ## Update Rule
 

--- a/web/ingest-control-plane/src/App.test.tsx
+++ b/web/ingest-control-plane/src/App.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { App } from "./App";
 
 describe("workflow graph control plane", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("displays mocked workflow nodes and enough state to inspect progress", () => {
     render(<App />);
 
@@ -34,5 +38,38 @@ describe("workflow graph control plane", () => {
     expect(screen.getByText(/running: 1/i)).toBeInTheDocument();
     expect(screen.getByText(/failed: 1/i)).toBeInTheDocument();
     expect(screen.getByText(/waiting: 1/i)).toBeInTheDocument();
+  });
+
+  it("starts local ingest watching when the operator clicks Start ingest", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 202 }));
+
+    render(<App />);
+
+    expect(screen.getByText(/local watcher: idle/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /start ingest/i }));
+
+    expect(screen.getByText(/local watcher: starting/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/ingest/start", {
+        method: "POST"
+      });
+    });
+    expect(await screen.findByText(/local watcher: watching/i)).toBeInTheDocument();
+  });
+
+  it("shows an error status when local ingest start fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 500 })
+    );
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: /start ingest/i }));
+
+    expect(await screen.findByText(/local watcher: error/i)).toBeInTheDocument();
   });
 });

--- a/web/ingest-control-plane/src/App.tsx
+++ b/web/ingest-control-plane/src/App.tsx
@@ -1,4 +1,8 @@
+import { useState } from "react";
+
 import { mockedWorkflowGraph, summarizeStatuses, type WorkflowNode } from "./workflowGraph";
+
+type LocalWatcherStatus = "idle" | "starting" | "watching" | "error";
 
 const progressedStatuses = new Set<WorkflowNode["status"]>([
   "Running",
@@ -36,10 +40,28 @@ function NodeCard({ node }: { node: WorkflowNode }) {
 
 export function App() {
   const graph = mockedWorkflowGraph;
+  const [localWatcherStatus, setLocalWatcherStatus] =
+    useState<LocalWatcherStatus>("idle");
   const statusSummary = summarizeStatuses(graph.nodes);
   const progressedNodeCount = graph.nodes.filter((node) =>
     progressedStatuses.has(node.status)
   ).length;
+
+  async function startLocalIngest() {
+    setLocalWatcherStatus("starting");
+
+    try {
+      const response = await fetch("/api/ingest/start", { method: "POST" });
+
+      if (!response.ok) {
+        throw new Error(`Ingest start failed with ${response.status}`);
+      }
+
+      setLocalWatcherStatus("watching");
+    } catch {
+      setLocalWatcherStatus("error");
+    }
+  }
 
   return (
     <main className="control-plane-shell">
@@ -59,6 +81,21 @@ export function App() {
           </div>
         </dl>
       </header>
+
+      <section className="local-ingest-panel" aria-label="local ingest watcher">
+        <div>
+          <h2>Local ingest</h2>
+          <p>Local watcher: {localWatcherStatus}</p>
+        </div>
+        <button
+          type="button"
+          className="start-ingest-button"
+          disabled={localWatcherStatus === "starting"}
+          onClick={startLocalIngest}
+        >
+          Start ingest
+        </button>
+      </section>
 
       <section className="summary-band" aria-label="workflow progress summary">
         <strong>

--- a/web/ingest-control-plane/src/styles.css
+++ b/web/ingest-control-plane/src/styles.css
@@ -70,6 +70,7 @@ h2 {
 }
 
 .workflow-metadata div,
+.local-ingest-panel,
 .summary-band,
 .graph-section {
   border: 1px solid #d6dde5;
@@ -91,6 +92,48 @@ h2 {
 .workflow-metadata dd {
   margin: 2px 0 0;
   font-weight: 700;
+}
+
+.local-ingest-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin: 0 auto 24px;
+  max-width: 1180px;
+  padding: 16px;
+}
+
+.local-ingest-panel p {
+  margin: 4px 0 0;
+  color: #516170;
+  font-weight: 700;
+}
+
+.start-ingest-button {
+  min-width: 132px;
+  border: 0;
+  border-radius: 8px;
+  background: #116149;
+  color: #ffffff;
+  cursor: pointer;
+  padding: 10px 14px;
+  font: inherit;
+  font-weight: 800;
+}
+
+.start-ingest-button:hover:not(:disabled) {
+  background: #0b4d39;
+}
+
+.start-ingest-button:focus-visible {
+  outline: 3px solid #93c5fd;
+  outline-offset: 2px;
+}
+
+.start-ingest-button:disabled {
+  cursor: wait;
+  opacity: 0.65;
 }
 
 .summary-band {
@@ -229,6 +272,11 @@ h2 {
 @media (max-width: 560px) {
   .control-plane-shell {
     padding: 18px;
+  }
+
+  .local-ingest-panel {
+    align-items: stretch;
+    flex-direction: column;
   }
 
   .workflow-metadata,

--- a/web/ingest-control-plane/src/viteConfig.test.ts
+++ b/web/ingest-control-plane/src/viteConfig.test.ts
@@ -10,7 +10,7 @@ describe("Vite development server", () => {
       server: {
         proxy: {
           "/api": {
-            target: "http://127.0.0.1:5080",
+            target: "http://127.0.0.1:5000",
             changeOrigin: true,
             secure: false
           }

--- a/web/ingest-control-plane/src/viteConfig.test.ts
+++ b/web/ingest-control-plane/src/viteConfig.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import config from "../vite.config";
+
+describe("Vite development server", () => {
+  it("proxies API requests to the local .NET API host", () => {
+    expect(config).toMatchObject({
+      server: {
+        proxy: {
+          "/api": {
+            target: "http://127.0.0.1:5080",
+            changeOrigin: true,
+            secure: false
+          }
+        }
+      }
+    });
+  });
+});

--- a/web/ingest-control-plane/vite.config.ts
+++ b/web/ingest-control-plane/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "http://127.0.0.1:5080",
+        target: "http://127.0.0.1:5000",
         changeOrigin: true,
         secure: false
       }

--- a/web/ingest-control-plane/vite.config.ts
+++ b/web/ingest-control-plane/vite.config.ts
@@ -3,6 +3,15 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://127.0.0.1:5080",
+        changeOrigin: true,
+        secure: false
+      }
+    }
+  },
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## Summary

- Adds a local ingest control panel to the React control plane.
- Adds a Start ingest button that calls `POST /api/ingest/start`.
- Adds a Vite dev proxy for `/api` requests to the local .NET API host at `http://127.0.0.1:5000`.
- Shows local watcher status as `idle`, `starting`, `watching`, or `error` while preserving the existing mocked workflow graph.
- Extends App and Vite config tests for render, POST call, success status, failure status, and dev proxy configuration.

## Validation

- `npm test` from `web/ingest-control-plane`: 2 test files passed, 4 tests passed.
- `npm run build` from `web/ingest-control-plane`: TypeScript and Vite production build passed.
- `git diff --check`: passed.
- `npm run docs:check`: passed after updating active worktree coordination.

## Backend Assumption

Assumes `POST /api/ingest/start` accepts an empty request body and treats any 2xx response as a successful watcher start. During Vite development, `/api` requests proxy to `http://127.0.0.1:5000`.

Refs #22