### PR TITLE
USER-STORY-16: Document local ingest demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .worktrees/
 .cache/
+.terminals/
 /input/
 /output/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .worktrees/
 .cache/
+/input/
+/output/
 
 # .NET build output
 **/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 .worktrees/
 .cache/
-/input/
-/output/
 
 # .NET build output
 **/bin/

--- a/README.md
+++ b/README.md
@@ -58,26 +58,30 @@ introduced.
 
 ## Local Manifest Ingest Demo
 
-This slice is an in-process local demo. It exercises the manifest start path
-through local folders and does not yet use real Dapr Workflow runtime,
+This draft workflow is an in-process local demo. It exercises the manifest start
+path through local folders and does not yet use real Dapr Workflow runtime,
 PostgreSQL, Azure Service Bus, or command runner services.
 
-Start the local ingest host:
+Start the local ingest API on a fixed development port:
 
 ```bash
-dotnet run --project src/MediaIngest.Api
+dotnet run --project src/MediaIngest.Api --urls http://127.0.0.1:5000
 ```
 
-Start the UI in another terminal:
+Start the UI in another terminal. The UI sends `POST /api/ingest/start` as a
+same-origin request, so the Vite development server must proxy `/api` requests
+to `http://127.0.0.1:5000`.
 
 ```bash
 cd web/ingest-control-plane
 npm run dev
 ```
 
-Create a package under the local runtime input folder. The manifest contents are
-opaque to this slice; the presence of `manifest.json` and
-`manifest.json.checksum` is the start signal.
+Open the Vite URL printed by the UI and press **Start ingest**. That starts the
+local watcher against the repo-root `input/` folder. After the watcher is
+running, create a package under the local runtime input folder. The manifest
+contents are opaque to this slice; the presence of `manifest.json` and
+`manifest.json.checksum` is the package start signal.
 
 ```bash
 mkdir -p input/asset-001
@@ -85,16 +89,15 @@ printf '%s\n' '{"asset":"asset-001"}' > input/asset-001/manifest.json
 printf '%s\n' 'local-demo-checksum' > input/asset-001/manifest.json.checksum
 ```
 
-Open the Vite URL printed by the UI and press **Start ingest**. The expected
-local output is:
+The expected local output is:
 
 ```text
 output/asset-001/manifest.json
 output/asset-001/manifest.json.checksum
 ```
 
-The `input/` and `output/` directories are local runtime folders and are ignored
-by Git.
+The `input/` and `output/` directories are local runtime folders. Backend runtime
+setup owns the Git ignore rules for those folders.
 
 ## Agent Tooling
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,46 @@ At this stage validation checks documentation and shell script syntax. Runtime
 build/test targets will be added as the .NET solution and containers are
 introduced.
 
+## Local Manifest Ingest Demo
+
+This slice is an in-process local demo. It exercises the manifest start path
+through local folders and does not yet use real Dapr Workflow runtime,
+PostgreSQL, Azure Service Bus, or command runner services.
+
+Start the local ingest host:
+
+```bash
+dotnet run --project src/MediaIngest.Api
+```
+
+Start the UI in another terminal:
+
+```bash
+cd web/ingest-control-plane
+npm run dev
+```
+
+Create a package under the local runtime input folder. The manifest contents are
+opaque to this slice; the presence of `manifest.json` and
+`manifest.json.checksum` is the start signal.
+
+```bash
+mkdir -p input/asset-001
+printf '%s\n' '{"asset":"asset-001"}' > input/asset-001/manifest.json
+printf '%s\n' 'local-demo-checksum' > input/asset-001/manifest.json.checksum
+```
+
+Open the Vite URL printed by the UI and press **Start ingest**. The expected
+local output is:
+
+```text
+output/asset-001/manifest.json
+output/asset-001/manifest.json.checksum
+```
+
+The `input/` and `output/` directories are local runtime folders and are ignored
+by Git.
+
 ## Agent Tooling
 
 This repository is operated with

--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -29,7 +29,7 @@ mirror.
 | `.worktrees/TASK-6-1-specialized-agent-skeletons` | `TASK-6-1-specialized-agent-skeletons` | #34 | USER-STORY-7 | Essence | Superseded media-agent skeleton paths; command routing now lives in `src/MediaIngest.Contracts/Commands` and contract tests | Cleaned Up | Local merge to `main` |
 | `.worktrees/TASK-7-1-observability-correlation` | `TASK-7-1-observability-correlation` | #37 | USER-STORY-11 | Beacon | `src/MediaIngest.Observability`, `tests/MediaIngest.Observability.Tests`, `MediaIngest.sln`, `scripts/dev/test-dotnet.sh`, `docs/architecture/004-observability-and-ui.md`, `docs/plans/task-index.md`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md` | Cleaned Up | Local merge to `main` |
 | `.worktrees/TASK-8-1-react-control-plane` | `TASK-8-1-react-control-plane` | #33 | USER-STORY-12 | Canvas | `web/ingest-control-plane`, `docs/plans/task-index.md`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md`, `docs/standards/typescript-react.md` | Cleaned Up | Local merge to `main` |
-| `.worktrees/USER-STORY-16-local-ingest-docs` | `USER-STORY-16-local-ingest-docs` | #26 | USER-STORY-16 | Forge | `.gitignore`, `README.md`, `docs/product/backlog.md`, `docs/status/current-status.md`, `docs/status/work-log.md`, `docs/plans/active-worktrees.md` | PR Open | https://github.com/ankit-singhal87/media-asset-ingest/pull/44 |
+| `.worktrees/USER-STORY-16-local-ingest-docs` | `USER-STORY-16-local-ingest-docs` | #26 | USER-STORY-16 | Forge | `README.md`, `docs/product/backlog.md`, `docs/status/current-status.md`, `docs/status/work-log.md`, `docs/plans/active-worktrees.md` | PR Open | https://github.com/ankit-singhal87/media-asset-ingest/pull/44 |
 
 ## Update Rule
 

--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -29,6 +29,7 @@ mirror.
 | `.worktrees/TASK-6-1-specialized-agent-skeletons` | `TASK-6-1-specialized-agent-skeletons` | #34 | USER-STORY-7 | Essence | Superseded media-agent skeleton paths; command routing now lives in `src/MediaIngest.Contracts/Commands` and contract tests | Cleaned Up | Local merge to `main` |
 | `.worktrees/TASK-7-1-observability-correlation` | `TASK-7-1-observability-correlation` | #37 | USER-STORY-11 | Beacon | `src/MediaIngest.Observability`, `tests/MediaIngest.Observability.Tests`, `MediaIngest.sln`, `scripts/dev/test-dotnet.sh`, `docs/architecture/004-observability-and-ui.md`, `docs/plans/task-index.md`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md` | Cleaned Up | Local merge to `main` |
 | `.worktrees/TASK-8-1-react-control-plane` | `TASK-8-1-react-control-plane` | #33 | USER-STORY-12 | Canvas | `web/ingest-control-plane`, `docs/plans/task-index.md`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md`, `docs/standards/typescript-react.md` | Cleaned Up | Local merge to `main` |
+| `.worktrees/USER-STORY-16-local-ingest-docs` | `USER-STORY-16-local-ingest-docs` | #26 | USER-STORY-16 | Forge | `.gitignore`, `README.md`, `docs/product/backlog.md`, `docs/status/current-status.md`, `docs/status/work-log.md`, `docs/plans/active-worktrees.md` | PR Open | https://github.com/ankit-singhal87/media-asset-ingest/pull/44 |
 
 ## Update Rule
 

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -7,8 +7,8 @@ epic/story granularity; detailed implementation tasks belong in plans.
 
 - MILESTONE-2 / USER-STORY-16: scaffold .NET solution, shared contracts, and
   canonical .NET validation.
-- MILESTONE-2 / USER-STORY-16: document the local manifest ingest demo workflow
-  and its in-process runtime boundary.
+- MILESTONE-2 / USER-STORY-16: keep the draft local manifest ingest demo docs
+  aligned with the backend and UI draft PRs.
 - MILESTONE-3 / USER-STORY-1: add ingest watcher scanner foundation.
 - MILESTONE-4 / USER-STORY-8: add persistence and transactional outbox
   foundation.
@@ -23,8 +23,9 @@ epic/story granularity; detailed implementation tasks belong in plans.
 
 - MILESTONE-2 / USER-STORY-17: define local container runtime and Kubernetes
   readiness boundary.
-- MILESTONE-2 / USER-STORY-16: integrate the backend/UI slice branches that
-  provide the documented local manifest ingest demo.
+- MILESTONE-2 / USER-STORY-16: merge the local ingest docs after the backend and
+  UI draft PRs provide the documented API host, UI start action, and runtime
+  ignore setup.
 - MILESTONE-3 / USER-STORY-2 / USER-STORY-3 / USER-STORY-4: implement manifest
   gating, physical file enumeration, and done-marker reconciliation.
 - MILESTONE-3 / USER-STORY-5: implement essence classification.

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -7,6 +7,8 @@ epic/story granularity; detailed implementation tasks belong in plans.
 
 - MILESTONE-2 / USER-STORY-16: scaffold .NET solution, shared contracts, and
   canonical .NET validation.
+- MILESTONE-2 / USER-STORY-16: document the local manifest ingest demo workflow
+  and its in-process runtime boundary.
 - MILESTONE-3 / USER-STORY-1: add ingest watcher scanner foundation.
 - MILESTONE-4 / USER-STORY-8: add persistence and transactional outbox
   foundation.
@@ -21,6 +23,8 @@ epic/story granularity; detailed implementation tasks belong in plans.
 
 - MILESTONE-2 / USER-STORY-17: define local container runtime and Kubernetes
   readiness boundary.
+- MILESTONE-2 / USER-STORY-16: integrate the backend/UI slice branches that
+  provide the documented local manifest ingest demo.
 - MILESTONE-3 / USER-STORY-2 / USER-STORY-3 / USER-STORY-4: implement manifest
   gating, physical file enumeration, and done-marker reconciliation.
 - MILESTONE-3 / USER-STORY-5: implement essence classification.

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -6,7 +6,9 @@
 - Current branch: `main`.
 - Current focus: local `main` contains the first implementation foundations
   across watcher, persistence/outbox, workflow, command routing, observability,
-  and the React control plane.
+  and the React control plane. The local manifest ingest demo docs now describe
+  the in-process API/UI workflow prepared by the backend and UI slice branches
+  over ignored `input/` and `output/` runtime folders.
 
 ## Completed
 
@@ -65,6 +67,10 @@
 - Agent execution tooling now includes focused .NET smoke-test targets, focused
   validation targets, an agent preflight command, and a repo-local ignored
   Docker .NET cache for faster repeated validation.
+- README quickstart now documents the local manifest ingest demo flow:
+  run the local API host and UI, add `manifest.json` plus
+  `manifest.json.checksum` under `input/<asset>/`, press **Start ingest**, and
+  expect both manifest files under `output/<asset>/`.
 
 ## Ready For Review
 
@@ -72,8 +78,8 @@
 
 ## Next
 
-- Plan the next increment from the updated local implementation foundation and
-  reconciled GitHub tracker state.
+- Integrate the backend and UI slice branches that provide the documented local
+  ingest API host and **Start ingest** UI.
 
 ## Update Rule
 

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -6,9 +6,8 @@
 - Current branch: `main`.
 - Current focus: local `main` contains the first implementation foundations
   across watcher, persistence/outbox, workflow, command routing, observability,
-  and the React control plane. The local manifest ingest demo docs now describe
-  the in-process API/UI workflow prepared by the backend and UI slice branches
-  over ignored `input/` and `output/` runtime folders.
+  and the React control plane. Draft local ingest docs are tracking the sibling
+  backend and UI PRs until those branches merge.
 
 ## Completed
 
@@ -67,9 +66,10 @@
 - Agent execution tooling now includes focused .NET smoke-test targets, focused
   validation targets, an agent preflight command, and a repo-local ignored
   Docker .NET cache for faster repeated validation.
-- README quickstart now documents the local manifest ingest demo flow:
-  run the local API host and UI, add `manifest.json` plus
-  `manifest.json.checksum` under `input/<asset>/`, press **Start ingest**, and
+- Draft README quickstart text documents the intended local manifest ingest
+  flow: run the API host on the fixed development port, run the UI with `/api`
+  proxied to that API, press **Start ingest** to begin watching, then add
+  `manifest.json` plus `manifest.json.checksum` under `input/<asset>/` and
   expect both manifest files under `output/<asset>/`.
 
 ## Ready For Review
@@ -78,8 +78,9 @@
 
 ## Next
 
-- Integrate the backend and UI slice branches that provide the documented local
-  ingest API host and **Start ingest** UI.
+- Keep the local ingest docs PR in draft until the backend and UI slice PRs
+  merge the API host, UI **Start ingest** action, Vite `/api` proxy, and runtime
+  folder ignore setup.
 
 ## Update Rule
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -80,11 +80,11 @@ messages or paste command output unless it explains a decision.
   repeated agent validation time.
 - Added a dedicated optional host-tool installer for .NET SDK, kubectl, Helm,
   Dapr CLI, and Azure CLI with confirmation and post-install verification.
-- Documented the local manifest ingest demo workflow in the README, including
-  local host and UI startup, `input/<asset>/manifest.json` plus checksum setup,
-  expected `output/<asset>/` manifest files, ignored runtime folders, and the
-  in-process scope boundary before real Dapr, PostgreSQL, and Azure Service Bus
-  integration.
+- Drafted the local manifest ingest demo workflow in the README, including the
+  fixed local API port, UI `/api` proxy expectation, **Start ingest** watcher
+  sequence, `input/<asset>/manifest.json` plus checksum setup, expected
+  `output/<asset>/` manifest files, and the in-process scope boundary before
+  real Dapr, PostgreSQL, and Azure Service Bus integration.
 
 ## Update Rule
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -80,6 +80,11 @@ messages or paste command output unless it explains a decision.
   repeated agent validation time.
 - Added a dedicated optional host-tool installer for .NET SDK, kubectl, Helm,
   Dapr CLI, and Azure CLI with confirmation and post-install verification.
+- Documented the local manifest ingest demo workflow in the README, including
+  local host and UI startup, `input/<asset>/manifest.json` plus checksum setup,
+  expected `output/<asset>/` manifest files, ignored runtime folders, and the
+  in-process scope boundary before real Dapr, PostgreSQL, and Azure Service Bus
+  integration.
 
 ## Update Rule
 


### PR DESCRIPTION
## Summary

- Documents the draft in-process local manifest ingest demo in the README.
- Records the status, work-log, backlog, and active-worktree updates for the documentation slice while backend/UI work remains in draft.
- Clarifies that backend runtime setup owns the repo-local `input/` and `output/` ignore rules.

## Scope

This is documentation and PR tracking only. It does not add or change backend, UI, Makefile, package, script, or `.gitignore` behavior.

Refs #26

## Validation

- `make docs-check`
- `git diff --check`