### PR TITLE
USER-STORY-2: Add local manifest ingest backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .worktrees/
 .cache/
+/input/
+/output/
 
 # .NET build output
 **/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help agent-preflight check-tools install-tools install-optional-tools print-install-tools print-install-optional-tools validate validate-docs validate-automation test-dotnet test-dotnet-foundation test-dotnet-contracts test-dotnet-watcher test-dotnet-persistence test-dotnet-outbox test-dotnet-workflow test-dotnet-observability docs-check docs-fix scripts-check github-projects-script-test github-project-check github-project-summary github-project-hierarchy github-project-active github-project-audit-fields github-issue-body-lint
+.PHONY: help agent-preflight check-tools install-tools install-optional-tools print-install-tools print-install-optional-tools validate validate-docs validate-automation test-dotnet test-dotnet-foundation test-dotnet-contracts test-dotnet-watcher test-dotnet-api test-dotnet-persistence test-dotnet-outbox test-dotnet-workflow test-dotnet-observability docs-check docs-fix scripts-check github-projects-script-test github-project-check github-project-summary github-project-hierarchy github-project-active github-project-audit-fields github-issue-body-lint
 
 help:
 	@printf '%s\n' "Available targets:"
@@ -59,6 +59,9 @@ test-dotnet-contracts:
 
 test-dotnet-watcher:
 	@sh scripts/dev/test-dotnet.sh watcher
+
+test-dotnet-api:
+	@sh scripts/dev/test-dotnet.sh api
 
 test-dotnet-persistence:
 	@sh scripts/dev/test-dotnet.sh persistence

--- a/MediaIngest.sln
+++ b/MediaIngest.sln
@@ -30,6 +30,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaIngest.Observability",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaIngest.Observability.Tests", "tests\MediaIngest.Observability.Tests\MediaIngest.Observability.Tests.csproj", "{3E8F83CC-8568-4298-A2D7-1686C47B43EA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaIngest.Api", "src\MediaIngest.Api\MediaIngest.Api.csproj", "{F5F6B820-85B3-428D-869F-8CC210295E08}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaIngest.Api.Tests", "tests\MediaIngest.Api.Tests\MediaIngest.Api.Tests.csproj", "{6E1CF5CB-149D-4B70-ACB7-BB429588D439}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -92,6 +96,14 @@ Global
 		{3E8F83CC-8568-4298-A2D7-1686C47B43EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E8F83CC-8568-4298-A2D7-1686C47B43EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3E8F83CC-8568-4298-A2D7-1686C47B43EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5F6B820-85B3-428D-869F-8CC210295E08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5F6B820-85B3-428D-869F-8CC210295E08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5F6B820-85B3-428D-869F-8CC210295E08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5F6B820-85B3-428D-869F-8CC210295E08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E1CF5CB-149D-4B70-ACB7-BB429588D439}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E1CF5CB-149D-4B70-ACB7-BB429588D439}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E1CF5CB-149D-4B70-ACB7-BB429588D439}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E1CF5CB-149D-4B70-ACB7-BB429588D439}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/architecture/000-system-overview.md
+++ b/docs/architecture/000-system-overview.md
@@ -23,7 +23,7 @@ visibility through a workflow graph UI.
 
 1. A watcher monitors a configured directory such as `/mnt/ingest`.
 2. Each immediate child directory is treated as an ingest package.
-3. Work starts only after `manifest.json` exists.
+3. Work starts only after `manifest.json` and `manifest.json.checksum` exist.
 4. The package scanner enumerates every file physically present in the directory.
 5. The classifier records file metadata needed by command-routing policy.
 6. The package workflow emits semantic commands through the outbox to Azure Service Bus.

--- a/docs/architecture/001-ingest-lifecycle.md
+++ b/docs/architecture/001-ingest-lifecycle.md
@@ -8,9 +8,9 @@ production can later bind the same path to Azure-backed storage.
 
 ## Start Conditions
 
-An ingest package is not eligible for work until `manifest.json` exists. The
-manifest is a start signal and metadata source, not the authoritative list of
-files to ingest.
+An ingest package is not eligible for work until `manifest.json` and
+`manifest.json.checksum` exist. The manifest is a start signal and metadata
+source, not the authoritative list of files to ingest.
 
 ## File Enumeration
 

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -8,7 +8,7 @@ ownership lanes. Keep detailed implementation tasks in `docs/plans/tasks`.
 | ID | Title | Milestone | Domain | Primary lane | Status |
 | --- | --- | --- | --- | --- | --- |
 | USER-STORY-1 | Watch ingest mount | MILESTONE-3 | Ingest package | Mount | In Progress |
-| USER-STORY-2 | Start only when manifest exists | MILESTONE-3 | Manifest | Mount | Planned |
+| USER-STORY-2 | Start only when manifest is ready | MILESTONE-3 | Manifest | Mount | Planned |
 | USER-STORY-3 | Ingest all discovered files | MILESTONE-3 | Ingest package | Mount | Planned |
 | USER-STORY-4 | Reconcile on done marker | MILESTONE-3 | Done marker | Mount | Planned |
 | USER-STORY-5 | Classify media essences | MILESTONE-3 | Essence classification | Essence | Planned |
@@ -59,10 +59,11 @@ Dependencies:
 
 - MILESTONE-2 local runtime foundation.
 
-## USER-STORY-2: Start Only When Manifest Exists
+## USER-STORY-2: Start Only When Manifest Is Ready
 
-As an ingest producer, I want ingest to start only after `manifest.json` exists,
-so that incomplete package directories are not processed prematurely.
+As an ingest producer, I want ingest to start only after `manifest.json` and
+`manifest.json.checksum` exist, so that incomplete package directories are not
+processed prematurely.
 
 Milestone: MILESTONE-3
 
@@ -86,7 +87,9 @@ Components involved:
 Acceptance themes:
 
 - Package directory without `manifest.json` is observed but not processed.
-- Package work starts after `manifest.json` appears.
+- Package directory with only `manifest.json` is observed but not processed.
+- Package work starts after `manifest.json` and `manifest.json.checksum`
+  appear.
 - Manifest is treated as metadata and a start signal.
 
 Dependencies:

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -80,6 +80,9 @@ messages or paste command output unless it explains a decision.
   repeated agent validation time.
 - Added a dedicated optional host-tool installer for .NET SDK, kubectl, Helm,
   Dapr CLI, and Azure CLI with confirmation and post-install verification.
+- Updated PR #45 local manifest ingest behavior so package discovery observes
+  all immediate child directories, readiness requires both manifest files, and
+  start ingest launches a background watcher loop.
 
 ## Update Rule
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "docs:fix": "node scripts/dev/check-docs.mjs --fix",
     "dotnet:test:contracts": "sh scripts/dev/test-dotnet.sh contracts",
     "dotnet:test:foundation": "sh scripts/dev/test-dotnet.sh foundation",
+    "dotnet:test:api": "sh scripts/dev/test-dotnet.sh api",
     "dotnet:test:observability": "sh scripts/dev/test-dotnet.sh observability",
     "dotnet:test:outbox": "sh scripts/dev/test-dotnet.sh outbox",
     "dotnet:test:persistence": "sh scripts/dev/test-dotnet.sh persistence",

--- a/scripts/dev/test-dotnet.sh
+++ b/scripts/dev/test-dotnet.sh
@@ -8,12 +8,13 @@ repo_cache_dir="${DOTNET_REPO_CACHE_DIR:-.cache/dotnet}"
 foundation_tests="tests/MediaIngest.Foundation.Tests/MediaIngest.Foundation.Tests.csproj"
 contracts_tests="tests/MediaIngest.Contracts.Tests/MediaIngest.Contracts.Tests.csproj"
 watcher_tests="tests/MediaIngest.Worker.Watcher.Tests/MediaIngest.Worker.Watcher.Tests.csproj"
+api_tests="tests/MediaIngest.Api.Tests/MediaIngest.Api.Tests.csproj"
 persistence_tests="tests/MediaIngest.Persistence.Tests/MediaIngest.Persistence.Tests.csproj"
 outbox_tests="tests/MediaIngest.Worker.Outbox.Tests/MediaIngest.Worker.Outbox.Tests.csproj"
 workflow_tests="tests/MediaIngest.Workflow.Tests/MediaIngest.Workflow.Tests.csproj"
 observability_tests="tests/MediaIngest.Observability.Tests/MediaIngest.Observability.Tests.csproj"
 
-all_test_projects="$foundation_tests $contracts_tests $watcher_tests $persistence_tests $outbox_tests $workflow_tests $observability_tests"
+all_test_projects="$foundation_tests $contracts_tests $watcher_tests $api_tests $persistence_tests $outbox_tests $workflow_tests $observability_tests"
 test_projects=""
 scope="selected"
 
@@ -40,6 +41,9 @@ else
       watcher)
         append_project "$watcher_tests"
         ;;
+      api)
+        append_project "$api_tests"
+        ;;
       persistence)
         append_project "$persistence_tests"
         ;;
@@ -54,7 +58,7 @@ else
         ;;
       *)
         printf 'Unknown .NET test target: %s\n' "$target"
-        printf '%s\n' "Supported targets: all foundation contracts watcher persistence outbox workflow observability"
+        printf '%s\n' "Supported targets: all foundation contracts watcher api persistence outbox workflow observability"
         exit 2
         ;;
     esac
@@ -65,18 +69,24 @@ export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=true
 export DOTNET_NOLOGO=1
 
+mkdir -p "$repo_cache_dir/cli-home" "$repo_cache_dir/nuget-packages"
+
+export DOTNET_CLI_HOME="$(pwd)/$repo_cache_dir/cli-home"
+export HOME="$(pwd)/$repo_cache_dir/cli-home"
+export NUGET_PACKAGES="$(pwd)/$repo_cache_dir/nuget-packages"
+
 if command -v dotnet >/dev/null 2>&1; then
   if [ "$scope" = "all" ]; then
-    dotnet restore "$solution"
-    dotnet build "$solution" --no-restore
+    dotnet restore "$solution" -m:1
+    dotnet build "$solution" --no-restore -m:1
   else
     for test_project in $test_projects; do
-      dotnet restore "$test_project"
-      dotnet build "$test_project" --no-restore
+      dotnet restore "$test_project" -m:1
+      dotnet build "$test_project" --no-restore -m:1
     done
   fi
   for test_project in $test_projects; do
-    dotnet run --project "$test_project" --no-restore
+    dotnet run --project "$test_project" --no-build
   done
   exit 0
 fi
@@ -91,12 +101,10 @@ if ! docker info >/dev/null 2>&1; then
   exit 1
 fi
 
-mkdir -p "$repo_cache_dir/cli-home" "$repo_cache_dir/nuget-packages"
-
 if [ "$scope" = "all" ]; then
-  dotnet_command="dotnet restore '$solution' && dotnet build '$solution' --no-restore && for test_project in $test_projects; do dotnet run --project \"\$test_project\" --no-restore; done"
+  dotnet_command="dotnet restore '$solution' -m:1 && dotnet build '$solution' --no-restore -m:1 && for test_project in $test_projects; do dotnet run --project \"\$test_project\" --no-build; done"
 else
-  dotnet_command="for test_project in $test_projects; do dotnet restore \"\$test_project\" && dotnet build \"\$test_project\" --no-restore && dotnet run --project \"\$test_project\" --no-restore; done"
+  dotnet_command="for test_project in $test_projects; do dotnet restore \"\$test_project\" -m:1 && dotnet build \"\$test_project\" --no-restore -m:1 && dotnet run --project \"\$test_project\" --no-build; done"
 fi
 
 docker run --rm \

--- a/src/MediaIngest.Api/IngestApiApplication.cs
+++ b/src/MediaIngest.Api/IngestApiApplication.cs
@@ -1,0 +1,131 @@
+using MediaIngest.Persistence;
+using MediaIngest.Worker.Outbox;
+using MediaIngest.Worker.Watcher;
+using MediaIngest.Workflow;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace MediaIngest.Api;
+
+public sealed class IngestApiApplication : IAsyncDisposable
+{
+    private readonly WebApplication webApplication;
+
+    private IngestApiApplication(WebApplication webApplication, HttpClient httpClient)
+    {
+        this.webApplication = webApplication;
+        HttpClient = httpClient;
+    }
+
+    public HttpClient HttpClient { get; }
+
+    public static async Task<IngestApiApplication> StartAsync(
+        string inputPath,
+        string outputPath,
+        CancellationToken cancellationToken = default)
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+
+        ConfigureServices(builder.Services, inputPath, outputPath);
+
+        var app = builder.Build();
+        MapEndpoints(app);
+
+        await app.StartAsync(cancellationToken);
+
+        var addresses = app.Services
+            .GetRequiredService<IServer>()
+            .Features
+            .Get<IServerAddressesFeature>();
+
+        var address = addresses?.Addresses.Single()
+            ?? throw new InvalidOperationException("The API host did not publish a server address.");
+
+        return new IngestApiApplication(
+            app,
+            new HttpClient { BaseAddress = new Uri(address) });
+    }
+
+    public static Task RunAsync(string[] args, CancellationToken cancellationToken = default)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+        var repoRoot = FindRepoRoot();
+        var inputPath = builder.Configuration["Ingest:InputPath"]
+            ?? Path.Combine(repoRoot, "input");
+        var outputPath = builder.Configuration["Ingest:OutputPath"]
+            ?? Path.Combine(repoRoot, "output");
+
+        ConfigureServices(builder.Services, inputPath, outputPath);
+
+        var app = builder.Build();
+        MapEndpoints(app);
+
+        return app.RunAsync(cancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        HttpClient.Dispose();
+        await webApplication.DisposeAsync();
+    }
+
+    private static void ConfigureServices(IServiceCollection services, string inputPath, string outputPath)
+    {
+        services.AddSingleton(new IngestRuntimePaths(
+            Path.GetFullPath(inputPath),
+            Path.GetFullPath(outputPath)));
+        services.AddSingleton<IngestMountScanner>();
+        services.AddSingleton<PackageWorkflowStarter>();
+        services.AddSingleton<InMemoryIngestPersistenceStore>();
+        services.AddSingleton<IIngestPersistenceStore>(serviceProvider =>
+            serviceProvider.GetRequiredService<InMemoryIngestPersistenceStore>());
+        services.AddSingleton<IOutboxMessagePublisher, LocalManifestTransferPublisher>();
+        services.AddSingleton<OutboxDispatcher>();
+        services.AddSingleton<IngestRuntimeService>();
+    }
+
+    private static void MapEndpoints(WebApplication app)
+    {
+        app.MapPost("/api/ingest/start", StartIngestAsync);
+        app.MapGet("/api/ingest/status", GetStatus);
+    }
+
+    private static async Task<IResult> StartIngestAsync(
+        IngestRuntimeService runtimeService,
+        CancellationToken cancellationToken)
+    {
+        var result = await runtimeService.StartAsync(cancellationToken);
+
+        return result.HasConflict
+            ? Results.Conflict(result.Response)
+            : Results.Accepted(value: result.Response);
+    }
+
+    private static IngestStatusResponse GetStatus(IngestRuntimeService runtimeService)
+    {
+        return runtimeService.GetStatus();
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "MediaIngest.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        return Directory.GetCurrentDirectory();
+    }
+}

--- a/src/MediaIngest.Api/IngestApiApplication.cs
+++ b/src/MediaIngest.Api/IngestApiApplication.cs
@@ -81,6 +81,7 @@ public sealed class IngestApiApplication : IAsyncDisposable
             Path.GetFullPath(inputPath),
             Path.GetFullPath(outputPath)));
         services.AddSingleton<IngestMountScanner>();
+        services.AddSingleton<ManifestReadinessGate>();
         services.AddSingleton<PackageWorkflowStarter>();
         services.AddSingleton<InMemoryIngestPersistenceStore>();
         services.AddSingleton<IIngestPersistenceStore>(serviceProvider =>

--- a/src/MediaIngest.Api/IngestResponses.cs
+++ b/src/MediaIngest.Api/IngestResponses.cs
@@ -1,0 +1,21 @@
+namespace MediaIngest.Api;
+
+public sealed record IngestStartResponse(
+    IReadOnlyList<StartedIngestPackageResponse> StartedPackages);
+
+public sealed record IngestStartResult(
+    IngestStartResponse Response,
+    bool HasConflict);
+
+public sealed record StartedIngestPackageResponse(
+    string PackageId,
+    string WorkflowInstanceId);
+
+public sealed record IngestStatusResponse(
+    IReadOnlyList<IngestPackageStatusResponse> Packages);
+
+public sealed record IngestPackageStatusResponse(
+    string PackageId,
+    string WorkflowInstanceId,
+    string Status,
+    DateTimeOffset UpdatedAt);

--- a/src/MediaIngest.Api/IngestRuntimePaths.cs
+++ b/src/MediaIngest.Api/IngestRuntimePaths.cs
@@ -1,0 +1,5 @@
+namespace MediaIngest.Api;
+
+public sealed record IngestRuntimePaths(
+    string InputPath,
+    string OutputPath);

--- a/src/MediaIngest.Api/IngestRuntimeService.cs
+++ b/src/MediaIngest.Api/IngestRuntimeService.cs
@@ -17,7 +17,7 @@ public sealed class IngestRuntimeService(
     private static readonly TimeSpan WatchInterval = TimeSpan.FromMilliseconds(100);
 
     private readonly object watcherLock = new();
-    private readonly HashSet<string> succeededPackageIds = new(StringComparer.Ordinal);
+    private readonly HashSet<string> terminalPackageIds = new(StringComparer.Ordinal);
     private readonly SemaphoreSlim scanLock = new(1, 1);
     private CancellationTokenSource? watcherCancellation;
     private Task? watcherTask;
@@ -78,7 +78,7 @@ public sealed class IngestRuntimeService(
             {
                 var packageId = Path.GetFileName(candidate.PackagePath);
 
-                if (succeededPackageIds.Contains(packageId))
+                if (terminalPackageIds.Contains(packageId))
                 {
                     continue;
                 }
@@ -106,14 +106,19 @@ public sealed class IngestRuntimeService(
                     await store.SaveAsync(new PersistenceBatch(
                         [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Succeeded", DateTimeOffset.UtcNow)],
                         []), cancellationToken);
-                    succeededPackageIds.Add(packageId);
+                    terminalPackageIds.Add(packageId);
                 }
                 catch (LocalManifestTransferConflictException)
                 {
                     hadTransferConflict = true;
+                    await store.MarkOutboxMessageDispatchedAsync(
+                        message.MessageId,
+                        DateTimeOffset.UtcNow,
+                        cancellationToken);
                     await store.SaveAsync(new PersistenceBatch(
                         [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Failed", DateTimeOffset.UtcNow)],
                         []), cancellationToken);
+                    terminalPackageIds.Add(packageId);
                 }
             }
 

--- a/src/MediaIngest.Api/IngestRuntimeService.cs
+++ b/src/MediaIngest.Api/IngestRuntimeService.cs
@@ -9,65 +9,129 @@ namespace MediaIngest.Api;
 public sealed class IngestRuntimeService(
     IngestRuntimePaths paths,
     IngestMountScanner scanner,
+    ManifestReadinessGate readinessGate,
     PackageWorkflowStarter workflowStarter,
     InMemoryIngestPersistenceStore store,
-    OutboxDispatcher outboxDispatcher)
+    OutboxDispatcher outboxDispatcher) : IAsyncDisposable
 {
+    private static readonly TimeSpan WatchInterval = TimeSpan.FromMilliseconds(100);
+
+    private readonly object watcherLock = new();
+    private readonly HashSet<string> succeededPackageIds = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim scanLock = new(1, 1);
+    private CancellationTokenSource? watcherCancellation;
+    private Task? watcherTask;
+
     public async Task<IngestStartResult> StartAsync(CancellationToken cancellationToken = default)
     {
         Directory.CreateDirectory(paths.InputPath);
         Directory.CreateDirectory(paths.OutputPath);
 
-        var candidates = scanner.FindPackageCandidates(paths.InputPath);
-        var startedPackages = new List<StartedIngestPackageResponse>();
-        var hadTransferConflict = false;
+        var result = await ScanOnceAsync(cancellationToken);
+        StartWatcher();
 
-        foreach (var candidate in candidates)
+        return result;
+    }
+
+    private void StartWatcher()
+    {
+        lock (watcherLock)
         {
-            var packageId = Path.GetFileName(candidate.PackagePath);
-            var acceptedAt = DateTimeOffset.UtcNow;
-            var workflowStart = workflowStarter.Start(new PackageIngestRequest(
-                PackageId: packageId,
-                PackagePath: candidate.PackagePath,
-                CorrelationId: $"correlation-{packageId}",
-                AcceptedAt: acceptedAt));
+            if (watcherTask is { IsCompleted: false })
+            {
+                return;
+            }
 
-            var message = CreateLocalTransferMessage(workflowStart, paths.OutputPath);
+            watcherCancellation?.Dispose();
+            watcherCancellation = new CancellationTokenSource();
+            watcherTask = WatchAsync(watcherCancellation.Token);
+        }
+    }
 
-            await store.SaveAsync(new PersistenceBatch(
-                [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Started", acceptedAt)],
-                [message]), cancellationToken);
-
-            startedPackages.Add(new StartedIngestPackageResponse(
-                packageId,
-                workflowStart.WorkflowInstanceId));
-
+    private async Task WatchAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
             try
             {
-                await outboxDispatcher.DispatchPendingAsync(cancellationToken);
-                await store.SaveAsync(new PersistenceBatch(
-                    [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Succeeded", DateTimeOffset.UtcNow)],
-                    []), cancellationToken);
+                await ScanOnceAsync(cancellationToken);
+                await Task.Delay(WatchInterval, cancellationToken);
             }
-            catch (LocalManifestTransferConflictException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                hadTransferConflict = true;
-                await store.SaveAsync(new PersistenceBatch(
-                    [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Failed", DateTimeOffset.UtcNow)],
-                    []), cancellationToken);
+                return;
             }
         }
+    }
 
-        return new IngestStartResult(
-            new IngestStartResponse(startedPackages),
-            hadTransferConflict);
+    private async Task<IngestStartResult> ScanOnceAsync(CancellationToken cancellationToken)
+    {
+        await scanLock.WaitAsync(cancellationToken);
+
+        try
+        {
+            var candidates = scanner.FindPackageCandidates(paths.InputPath);
+            var startedPackages = new List<StartedIngestPackageResponse>();
+            var hadTransferConflict = false;
+
+            foreach (var candidate in candidates.Where(readinessGate.IsReady))
+            {
+                var packageId = Path.GetFileName(candidate.PackagePath);
+
+                if (succeededPackageIds.Contains(packageId))
+                {
+                    continue;
+                }
+
+                var acceptedAt = DateTimeOffset.UtcNow;
+                var workflowStart = workflowStarter.Start(new PackageIngestRequest(
+                    PackageId: packageId,
+                    PackagePath: candidate.PackagePath,
+                    CorrelationId: $"correlation-{packageId}",
+                    AcceptedAt: acceptedAt));
+
+                var message = CreateLocalTransferMessage(workflowStart, paths.OutputPath);
+
+                await store.SaveAsync(new PersistenceBatch(
+                    [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Started", acceptedAt)],
+                    [message]), cancellationToken);
+
+                startedPackages.Add(new StartedIngestPackageResponse(
+                    packageId,
+                    workflowStart.WorkflowInstanceId));
+
+                try
+                {
+                    await outboxDispatcher.DispatchPendingAsync(cancellationToken);
+                    await store.SaveAsync(new PersistenceBatch(
+                        [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Succeeded", DateTimeOffset.UtcNow)],
+                        []), cancellationToken);
+                    succeededPackageIds.Add(packageId);
+                }
+                catch (LocalManifestTransferConflictException)
+                {
+                    hadTransferConflict = true;
+                    await store.SaveAsync(new PersistenceBatch(
+                        [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Failed", DateTimeOffset.UtcNow)],
+                        []), cancellationToken);
+                }
+            }
+
+            return new IngestStartResult(
+                new IngestStartResponse(startedPackages),
+                hadTransferConflict);
+        }
+        finally
+        {
+            scanLock.Release();
+        }
     }
 
     public IngestStatusResponse GetStatus()
     {
         var packages = store.PackageStates
             .GroupBy(packageState => packageState.PackageId, StringComparer.Ordinal)
-            .Select(group => group.OrderByDescending(packageState => packageState.UpdatedAt).First())
+            .Select(group => group.Last())
             .OrderBy(packageState => packageState.PackageId, StringComparer.Ordinal)
             .Select(packageState => new IngestPackageStatusResponse(
                 packageState.PackageId,
@@ -77,6 +141,42 @@ public sealed class IngestRuntimeService(
             .ToArray();
 
         return new IngestStatusResponse(packages);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        CancellationTokenSource? cancellation;
+        Task? task;
+
+        lock (watcherLock)
+        {
+            cancellation = watcherCancellation;
+            task = watcherTask;
+            watcherCancellation = null;
+            watcherTask = null;
+        }
+
+        if (cancellation is null)
+        {
+            scanLock.Dispose();
+            return;
+        }
+
+        await cancellation.CancelAsync();
+
+        if (task is not null)
+        {
+            try
+            {
+                await task;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        cancellation.Dispose();
+        scanLock.Dispose();
     }
 
     private static OutboxMessage CreateLocalTransferMessage(

--- a/src/MediaIngest.Api/IngestRuntimeService.cs
+++ b/src/MediaIngest.Api/IngestRuntimeService.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using MediaIngest.Persistence;
+using MediaIngest.Worker.Outbox;
+using MediaIngest.Worker.Watcher;
+using MediaIngest.Workflow;
+
+namespace MediaIngest.Api;
+
+public sealed class IngestRuntimeService(
+    IngestRuntimePaths paths,
+    IngestMountScanner scanner,
+    PackageWorkflowStarter workflowStarter,
+    InMemoryIngestPersistenceStore store,
+    OutboxDispatcher outboxDispatcher)
+{
+    public async Task<IngestStartResult> StartAsync(CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(paths.InputPath);
+        Directory.CreateDirectory(paths.OutputPath);
+
+        var candidates = scanner.FindPackageCandidates(paths.InputPath);
+        var startedPackages = new List<StartedIngestPackageResponse>();
+        var hadTransferConflict = false;
+
+        foreach (var candidate in candidates)
+        {
+            var packageId = Path.GetFileName(candidate.PackagePath);
+            var acceptedAt = DateTimeOffset.UtcNow;
+            var workflowStart = workflowStarter.Start(new PackageIngestRequest(
+                PackageId: packageId,
+                PackagePath: candidate.PackagePath,
+                CorrelationId: $"correlation-{packageId}",
+                AcceptedAt: acceptedAt));
+
+            var message = CreateLocalTransferMessage(workflowStart, paths.OutputPath);
+
+            await store.SaveAsync(new PersistenceBatch(
+                [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Started", acceptedAt)],
+                [message]), cancellationToken);
+
+            startedPackages.Add(new StartedIngestPackageResponse(
+                packageId,
+                workflowStart.WorkflowInstanceId));
+
+            try
+            {
+                await outboxDispatcher.DispatchPendingAsync(cancellationToken);
+                await store.SaveAsync(new PersistenceBatch(
+                    [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Succeeded", DateTimeOffset.UtcNow)],
+                    []), cancellationToken);
+            }
+            catch (LocalManifestTransferConflictException)
+            {
+                hadTransferConflict = true;
+                await store.SaveAsync(new PersistenceBatch(
+                    [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Failed", DateTimeOffset.UtcNow)],
+                    []), cancellationToken);
+            }
+        }
+
+        return new IngestStartResult(
+            new IngestStartResponse(startedPackages),
+            hadTransferConflict);
+    }
+
+    public IngestStatusResponse GetStatus()
+    {
+        var packages = store.PackageStates
+            .GroupBy(packageState => packageState.PackageId, StringComparer.Ordinal)
+            .Select(group => group.OrderByDescending(packageState => packageState.UpdatedAt).First())
+            .OrderBy(packageState => packageState.PackageId, StringComparer.Ordinal)
+            .Select(packageState => new IngestPackageStatusResponse(
+                packageState.PackageId,
+                packageState.WorkflowInstanceId,
+                packageState.Status,
+                packageState.UpdatedAt))
+            .ToArray();
+
+        return new IngestStatusResponse(packages);
+    }
+
+    private static OutboxMessage CreateLocalTransferMessage(
+        PackageWorkflowStart workflowStart,
+        string outputPath)
+    {
+        var payload = JsonSerializer.Serialize(new LocalManifestTransferRequest(
+            workflowStart.PackageId,
+            workflowStart.PackagePath,
+            outputPath));
+
+        return new OutboxMessage(
+            MessageId: $"local-transfer-{workflowStart.PackageId}-{Guid.NewGuid():N}",
+            Destination: "local.manifest.transfer",
+            MessageType: nameof(LocalManifestTransferRequest),
+            PayloadJson: payload,
+            CorrelationId: workflowStart.CorrelationId,
+            CreatedAt: workflowStart.AcceptedAt);
+    }
+}

--- a/src/MediaIngest.Api/LocalManifestTransferConflictException.cs
+++ b/src/MediaIngest.Api/LocalManifestTransferConflictException.cs
@@ -1,0 +1,11 @@
+namespace MediaIngest.Api;
+
+public sealed class LocalManifestTransferConflictException(
+    string packageId,
+    string path)
+    : InvalidOperationException($"Output file '{path}' already exists with different content for package '{packageId}'.")
+{
+    public string PackageId { get; } = packageId;
+
+    public string Path { get; } = path;
+}

--- a/src/MediaIngest.Api/LocalManifestTransferPublisher.cs
+++ b/src/MediaIngest.Api/LocalManifestTransferPublisher.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using MediaIngest.Persistence;
+using MediaIngest.Worker.Outbox;
+
+namespace MediaIngest.Api;
+
+public sealed class LocalManifestTransferPublisher : IOutboxMessagePublisher
+{
+    private static readonly string[] ManifestFileNames =
+    [
+        "manifest.json",
+        "manifest.json.checksum"
+    ];
+
+    public async Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var request = JsonSerializer.Deserialize<LocalManifestTransferRequest>(message.PayloadJson)
+            ?? throw new InvalidOperationException("Local manifest transfer payload is required.");
+
+        var outputPackagePath = Path.Combine(request.OutputRootPath, request.PackageId);
+        Directory.CreateDirectory(outputPackagePath);
+
+        foreach (var fileName in ManifestFileNames)
+        {
+            var sourcePath = Path.Combine(request.PackagePath, fileName);
+            var destinationPath = Path.Combine(outputPackagePath, fileName);
+
+            if (File.Exists(destinationPath))
+            {
+                if (await FilesAreEqualAsync(sourcePath, destinationPath, cancellationToken))
+                {
+                    continue;
+                }
+
+                throw new LocalManifestTransferConflictException(request.PackageId, destinationPath);
+            }
+
+            await using var source = File.OpenRead(sourcePath);
+            await using var destination = File.Create(destinationPath);
+            await source.CopyToAsync(destination, cancellationToken);
+        }
+    }
+
+    private static async Task<bool> FilesAreEqualAsync(
+        string sourcePath,
+        string destinationPath,
+        CancellationToken cancellationToken)
+    {
+        var sourceBytes = await File.ReadAllBytesAsync(sourcePath, cancellationToken);
+        var destinationBytes = await File.ReadAllBytesAsync(destinationPath, cancellationToken);
+
+        return sourceBytes.AsSpan().SequenceEqual(destinationBytes);
+    }
+}

--- a/src/MediaIngest.Api/LocalManifestTransferRequest.cs
+++ b/src/MediaIngest.Api/LocalManifestTransferRequest.cs
@@ -1,0 +1,6 @@
+namespace MediaIngest.Api;
+
+public sealed record LocalManifestTransferRequest(
+    string PackageId,
+    string PackagePath,
+    string OutputRootPath);

--- a/src/MediaIngest.Api/MediaIngest.Api.csproj
+++ b/src/MediaIngest.Api/MediaIngest.Api.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MediaIngest.Api</RootNamespace>
+    <AssemblyName>MediaIngest.Api</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="../MediaIngest.Persistence/MediaIngest.Persistence.csproj" />
+    <ProjectReference Include="../MediaIngest.Worker.Outbox/MediaIngest.Worker.Outbox.csproj" />
+    <ProjectReference Include="../MediaIngest.Worker.Watcher/MediaIngest.Worker.Watcher.csproj" />
+    <ProjectReference Include="../MediaIngest.Workflow/MediaIngest.Workflow.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/MediaIngest.Api/Program.cs
+++ b/src/MediaIngest.Api/Program.cs
@@ -1,0 +1,3 @@
+using MediaIngest.Api;
+
+await IngestApiApplication.RunAsync(args);

--- a/src/MediaIngest.Persistence/InMemoryIngestPersistenceStore.cs
+++ b/src/MediaIngest.Persistence/InMemoryIngestPersistenceStore.cs
@@ -2,12 +2,31 @@ namespace MediaIngest.Persistence;
 
 public sealed class InMemoryIngestPersistenceStore : IIngestPersistenceStore
 {
+    private readonly object storeLock = new();
     private readonly List<IngestPackageState> packageStates = [];
     private readonly List<OutboxMessage> outboxMessages = [];
 
-    public IReadOnlyList<IngestPackageState> PackageStates => packageStates;
+    public IReadOnlyList<IngestPackageState> PackageStates
+    {
+        get
+        {
+            lock (storeLock)
+            {
+                return packageStates.ToArray();
+            }
+        }
+    }
 
-    public IReadOnlyList<OutboxMessage> OutboxMessages => outboxMessages;
+    public IReadOnlyList<OutboxMessage> OutboxMessages
+    {
+        get
+        {
+            lock (storeLock)
+            {
+                return outboxMessages.ToArray();
+            }
+        }
+    }
 
     public Task SaveAsync(PersistenceBatch batch, CancellationToken cancellationToken = default)
     {
@@ -16,8 +35,11 @@ public sealed class InMemoryIngestPersistenceStore : IIngestPersistenceStore
 
         Validate(batch);
 
-        packageStates.AddRange(batch.PackageStates);
-        outboxMessages.AddRange(batch.OutboxMessages);
+        lock (storeLock)
+        {
+            packageStates.AddRange(batch.PackageStates);
+            outboxMessages.AddRange(batch.OutboxMessages);
+        }
 
         return Task.CompletedTask;
     }
@@ -26,9 +48,14 @@ public sealed class InMemoryIngestPersistenceStore : IIngestPersistenceStore
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        IReadOnlyList<OutboxMessage> pendingMessages = outboxMessages
-            .Where(message => message.DispatchedAt is null)
-            .ToArray();
+        IReadOnlyList<OutboxMessage> pendingMessages;
+
+        lock (storeLock)
+        {
+            pendingMessages = outboxMessages
+                .Where(message => message.DispatchedAt is null)
+                .ToArray();
+        }
 
         return Task.FromResult(pendingMessages);
     }
@@ -45,14 +72,17 @@ public sealed class InMemoryIngestPersistenceStore : IIngestPersistenceStore
             throw new ArgumentException("Outbox message id is required.", nameof(messageId));
         }
 
-        var messageIndex = outboxMessages.FindIndex(message => message.MessageId == messageId);
-
-        if (messageIndex < 0)
+        lock (storeLock)
         {
-            throw new InvalidOperationException($"Outbox message '{messageId}' was not found.");
-        }
+            var messageIndex = outboxMessages.FindIndex(message => message.MessageId == messageId);
 
-        outboxMessages[messageIndex] = outboxMessages[messageIndex] with { DispatchedAt = dispatchedAt };
+            if (messageIndex < 0)
+            {
+                throw new InvalidOperationException($"Outbox message '{messageId}' was not found.");
+            }
+
+            outboxMessages[messageIndex] = outboxMessages[messageIndex] with { DispatchedAt = dispatchedAt };
+        }
 
         return Task.CompletedTask;
     }

--- a/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
@@ -8,7 +8,14 @@ public sealed class IngestMountScanner
 
         return Directory.EnumerateDirectories(ingestMountPath)
             .Order(StringComparer.Ordinal)
+            .Where(IsReadyForIngest)
             .Select(packagePath => new IngestPackageCandidate(Path.GetFullPath(packagePath)))
             .ToArray();
+    }
+
+    private static bool IsReadyForIngest(string packagePath)
+    {
+        return File.Exists(Path.Combine(packagePath, "manifest.json"))
+            && File.Exists(Path.Combine(packagePath, "manifest.json.checksum"));
     }
 }

--- a/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
@@ -8,14 +8,7 @@ public sealed class IngestMountScanner
 
         return Directory.EnumerateDirectories(ingestMountPath)
             .Order(StringComparer.Ordinal)
-            .Where(IsReadyForIngest)
             .Select(packagePath => new IngestPackageCandidate(Path.GetFullPath(packagePath)))
             .ToArray();
-    }
-
-    private static bool IsReadyForIngest(string packagePath)
-    {
-        return File.Exists(Path.Combine(packagePath, "manifest.json"))
-            && File.Exists(Path.Combine(packagePath, "manifest.json.checksum"));
     }
 }

--- a/src/MediaIngest.Worker.Watcher/ManifestReadinessGate.cs
+++ b/src/MediaIngest.Worker.Watcher/ManifestReadinessGate.cs
@@ -1,0 +1,15 @@
+namespace MediaIngest.Worker.Watcher;
+
+public sealed class ManifestReadinessGate
+{
+    private const string ManifestFileName = "manifest.json";
+    private const string ManifestChecksumFileName = "manifest.json.checksum";
+
+    public bool IsReady(IngestPackageCandidate candidate)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        return File.Exists(Path.Combine(candidate.PackagePath, ManifestFileName))
+            && File.Exists(Path.Combine(candidate.PackagePath, ManifestChecksumFileName));
+    }
+}

--- a/tests/MediaIngest.Api.Tests/MediaIngest.Api.Tests.csproj
+++ b/tests/MediaIngest.Api.Tests/MediaIngest.Api.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MediaIngest.Api.Tests</RootNamespace>
+    <AssemblyName>MediaIngest.Api.Tests</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/MediaIngest.Api/MediaIngest.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/MediaIngest.Api.Tests/Program.cs
+++ b/tests/MediaIngest.Api.Tests/Program.cs
@@ -1,0 +1,91 @@
+using MediaIngest.Api;
+using MediaIngest.Persistence;
+using MediaIngest.Worker.Outbox;
+using MediaIngest.Worker.Watcher;
+using MediaIngest.Workflow;
+
+var repoRoot = Path.Combine(Path.GetTempPath(), "media-ingest-api-tests", Guid.NewGuid().ToString("N"));
+var inputPath = Path.Combine(repoRoot, "input");
+var outputPath = Path.Combine(repoRoot, "output");
+var packagePath = Path.Combine(inputPath, "asset-001");
+
+Directory.CreateDirectory(packagePath);
+Directory.CreateDirectory(outputPath);
+
+try
+{
+    File.WriteAllText(Path.Combine(packagePath, "manifest.json"), "{garbage");
+    File.WriteAllText(Path.Combine(packagePath, "manifest.json.checksum"), "opaque checksum");
+    File.WriteAllText(Path.Combine(packagePath, "source.mov"), "media is not copied by local transfer");
+
+    var runtimeService = CreateRuntimeService(inputPath, outputPath);
+
+    var startResult = await runtimeService.StartAsync();
+
+    AssertFalse(startResult.HasConflict, "start has conflict");
+    AssertEqual(1, startResult.Response.StartedPackages.Count, "started package count");
+    AssertEqual("asset-001", startResult.Response.StartedPackages[0].PackageId, "started package id");
+
+    AssertTrue(File.Exists(Path.Combine(outputPath, "asset-001", "manifest.json")), "manifest copied");
+    AssertTrue(File.Exists(Path.Combine(outputPath, "asset-001", "manifest.json.checksum")), "checksum copied");
+    AssertFalse(File.Exists(Path.Combine(outputPath, "asset-001", "source.mov")), "source file not copied");
+
+    var idempotentResult = await runtimeService.StartAsync();
+
+    AssertFalse(idempotentResult.HasConflict, "idempotent start has conflict");
+
+    File.WriteAllText(Path.Combine(outputPath, "asset-001", "manifest.json"), "different");
+
+    var conflictingResult = await runtimeService.StartAsync();
+    var conflictingStatus = runtimeService.GetStatus();
+
+    AssertTrue(conflictingResult.HasConflict, "conflicting start has conflict");
+    AssertEqual("Failed", conflictingStatus.Packages[0].Status, "conflicting package status");
+    AssertEqual("different", File.ReadAllText(Path.Combine(outputPath, "asset-001", "manifest.json")), "conflicting output preserved");
+}
+finally
+{
+    if (Directory.Exists(repoRoot))
+    {
+        Directory.Delete(repoRoot, recursive: true);
+    }
+}
+
+Console.WriteLine("MediaIngest API smoke tests passed.");
+
+static IngestRuntimeService CreateRuntimeService(string inputPath, string outputPath)
+{
+    var store = new InMemoryIngestPersistenceStore();
+    var publisher = new LocalManifestTransferPublisher();
+
+    return new IngestRuntimeService(
+        new IngestRuntimePaths(inputPath, outputPath),
+        new IngestMountScanner(),
+        new PackageWorkflowStarter(),
+        store,
+        new OutboxDispatcher(store, publisher));
+}
+
+static void AssertEqual<T>(T expected, T actual, string name)
+{
+    if (!EqualityComparer<T>.Default.Equals(expected, actual))
+    {
+        throw new InvalidOperationException($"{name}: expected '{expected}', got '{actual}'.");
+    }
+}
+
+static void AssertTrue(bool condition, string name)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException($"{name}: expected true.");
+    }
+}
+
+static void AssertFalse(bool condition, string name)
+{
+    if (condition)
+    {
+        throw new InvalidOperationException($"{name}: expected false.");
+    }
+}

--- a/tests/MediaIngest.Api.Tests/Program.cs
+++ b/tests/MediaIngest.Api.Tests/Program.cs
@@ -5,13 +5,15 @@ using MediaIngest.Worker.Watcher;
 using MediaIngest.Workflow;
 
 var repoRoot = Path.Combine(Path.GetTempPath(), "media-ingest-api-tests", Guid.NewGuid().ToString("N"));
-var inputPath = Path.Combine(repoRoot, "input");
-var outputPath = Path.Combine(repoRoot, "output");
-Directory.CreateDirectory(outputPath);
 
 try
 {
-    await using var runtimeService = CreateRuntimeService(inputPath, outputPath);
+    var inputPath = Path.Combine(repoRoot, "success-input");
+    var outputPath = Path.Combine(repoRoot, "success-output");
+    Directory.CreateDirectory(outputPath);
+
+    await using var runtime = CreateRuntimeService(inputPath, outputPath);
+    var runtimeService = runtime.Service;
     var startResult = await runtimeService.StartAsync();
 
     AssertFalse(startResult.HasConflict, "initial start has conflict");
@@ -51,6 +53,39 @@ try
     AssertFalse(repeatedStartResult.HasConflict, "repeated start has conflict");
     AssertEqual("Succeeded", repeatedStartStatus.Packages[0].Status, "repeated start status");
     AssertEqual("different", File.ReadAllText(Path.Combine(outputPath, "asset-001", "manifest.json")), "repeated start output preserved");
+
+    var conflictInputPath = Path.Combine(repoRoot, "conflict-input");
+    var conflictOutputPath = Path.Combine(repoRoot, "conflict-output");
+    var conflictOutputPackagePath = Path.Combine(conflictOutputPath, "asset-001");
+    Directory.CreateDirectory(conflictOutputPackagePath);
+    File.WriteAllText(Path.Combine(conflictOutputPackagePath, "manifest.json"), "existing output");
+
+    await using var conflictRuntime = CreateRuntimeService(conflictInputPath, conflictOutputPath);
+    await conflictRuntime.Service.StartAsync();
+
+    var conflictPackagePath = Path.Combine(conflictInputPath, "asset-001");
+    Directory.CreateDirectory(conflictPackagePath);
+    File.WriteAllText(Path.Combine(conflictPackagePath, "manifest.json"), "new input");
+    File.WriteAllText(Path.Combine(conflictPackagePath, "manifest.json.checksum"), "opaque checksum");
+
+    await WaitForAsync(
+        () => conflictRuntime.Service.GetStatus().Packages.SingleOrDefault()?.Status == "Failed",
+        "conflicting package created after start to fail");
+
+    var conflictStatus = conflictRuntime.Service.GetStatus();
+    AssertEqual(1, conflictStatus.Packages.Count, "conflict package count");
+    AssertEqual("Failed", conflictStatus.Packages[0].Status, "conflict package status");
+    AssertEqual("existing output", File.ReadAllText(Path.Combine(conflictOutputPackagePath, "manifest.json")), "conflict output preserved");
+
+    var stateCountAfterFailure = conflictRuntime.Store.PackageStates.Count;
+    var messageCountAfterFailure = conflictRuntime.Store.OutboxMessages.Count;
+    await Task.Delay(TimeSpan.FromMilliseconds(250));
+
+    var conflictStatusAfterDelay = conflictRuntime.Service.GetStatus();
+    AssertEqual("Failed", conflictStatusAfterDelay.Packages[0].Status, "conflict status after watcher intervals");
+    AssertEqual("existing output", File.ReadAllText(Path.Combine(conflictOutputPackagePath, "manifest.json")), "conflict output preserved after watcher intervals");
+    AssertEqual(stateCountAfterFailure, conflictRuntime.Store.PackageStates.Count, "conflict state count after watcher intervals");
+    AssertEqual(messageCountAfterFailure, conflictRuntime.Store.OutboxMessages.Count, "conflict outbox message count after watcher intervals");
 }
 finally
 {
@@ -62,18 +97,20 @@ finally
 
 Console.WriteLine("MediaIngest API smoke tests passed.");
 
-static IngestRuntimeService CreateRuntimeService(string inputPath, string outputPath)
+static TestRuntime CreateRuntimeService(string inputPath, string outputPath)
 {
     var store = new InMemoryIngestPersistenceStore();
     var publisher = new LocalManifestTransferPublisher();
 
-    return new IngestRuntimeService(
+    var service = new IngestRuntimeService(
         new IngestRuntimePaths(inputPath, outputPath),
         new IngestMountScanner(),
         new ManifestReadinessGate(),
         new PackageWorkflowStarter(),
         store,
         new OutboxDispatcher(store, publisher));
+
+    return new TestRuntime(service, store);
 }
 
 static async Task WaitForAsync(Func<bool> condition, string name)
@@ -115,4 +152,11 @@ static void AssertFalse(bool condition, string name)
     {
         throw new InvalidOperationException($"{name}: expected false.");
     }
+}
+
+internal sealed record TestRuntime(
+    IngestRuntimeService Service,
+    InMemoryIngestPersistenceStore Store) : IAsyncDisposable
+{
+    public ValueTask DisposeAsync() => Service.DisposeAsync();
 }

--- a/tests/MediaIngest.Api.Tests/Program.cs
+++ b/tests/MediaIngest.Api.Tests/Program.cs
@@ -7,41 +7,50 @@ using MediaIngest.Workflow;
 var repoRoot = Path.Combine(Path.GetTempPath(), "media-ingest-api-tests", Guid.NewGuid().ToString("N"));
 var inputPath = Path.Combine(repoRoot, "input");
 var outputPath = Path.Combine(repoRoot, "output");
-var packagePath = Path.Combine(inputPath, "asset-001");
-
-Directory.CreateDirectory(packagePath);
 Directory.CreateDirectory(outputPath);
 
 try
 {
+    await using var runtimeService = CreateRuntimeService(inputPath, outputPath);
+    var startResult = await runtimeService.StartAsync();
+
+    AssertFalse(startResult.HasConflict, "initial start has conflict");
+    AssertEqual(0, startResult.Response.StartedPackages.Count, "initial started package count");
+
+    var packagePath = Path.Combine(inputPath, "asset-001");
+    Directory.CreateDirectory(packagePath);
     File.WriteAllText(Path.Combine(packagePath, "manifest.json"), "{garbage");
     File.WriteAllText(Path.Combine(packagePath, "manifest.json.checksum"), "opaque checksum");
     File.WriteAllText(Path.Combine(packagePath, "source.mov"), "media is not copied by local transfer");
 
-    var runtimeService = CreateRuntimeService(inputPath, outputPath);
+    await WaitForAsync(
+        () => runtimeService.GetStatus().Packages.SingleOrDefault()?.Status == "Succeeded",
+        "package created after start to succeed");
 
-    var startResult = await runtimeService.StartAsync();
-
-    AssertFalse(startResult.HasConflict, "start has conflict");
-    AssertEqual(1, startResult.Response.StartedPackages.Count, "started package count");
-    AssertEqual("asset-001", startResult.Response.StartedPackages[0].PackageId, "started package id");
+    var startedStatus = runtimeService.GetStatus();
+    AssertEqual(1, startedStatus.Packages.Count, "started package count");
+    AssertEqual("asset-001", startedStatus.Packages[0].PackageId, "started package id");
+    AssertEqual("Succeeded", startedStatus.Packages[0].Status, "started package status");
 
     AssertTrue(File.Exists(Path.Combine(outputPath, "asset-001", "manifest.json")), "manifest copied");
     AssertTrue(File.Exists(Path.Combine(outputPath, "asset-001", "manifest.json.checksum")), "checksum copied");
     AssertFalse(File.Exists(Path.Combine(outputPath, "asset-001", "source.mov")), "source file not copied");
 
-    var idempotentResult = await runtimeService.StartAsync();
+    var stateCountAfterSuccess = runtimeService.GetStatus().Packages.Count;
+    await Task.Delay(TimeSpan.FromMilliseconds(250));
+    var idempotentStatus = runtimeService.GetStatus();
 
-    AssertFalse(idempotentResult.HasConflict, "idempotent start has conflict");
+    AssertEqual(stateCountAfterSuccess, idempotentStatus.Packages.Count, "idempotent watcher package count");
+    AssertEqual("Succeeded", idempotentStatus.Packages[0].Status, "idempotent watcher status");
 
     File.WriteAllText(Path.Combine(outputPath, "asset-001", "manifest.json"), "different");
 
-    var conflictingResult = await runtimeService.StartAsync();
-    var conflictingStatus = runtimeService.GetStatus();
+    var repeatedStartResult = await runtimeService.StartAsync();
+    var repeatedStartStatus = runtimeService.GetStatus();
 
-    AssertTrue(conflictingResult.HasConflict, "conflicting start has conflict");
-    AssertEqual("Failed", conflictingStatus.Packages[0].Status, "conflicting package status");
-    AssertEqual("different", File.ReadAllText(Path.Combine(outputPath, "asset-001", "manifest.json")), "conflicting output preserved");
+    AssertFalse(repeatedStartResult.HasConflict, "repeated start has conflict");
+    AssertEqual("Succeeded", repeatedStartStatus.Packages[0].Status, "repeated start status");
+    AssertEqual("different", File.ReadAllText(Path.Combine(outputPath, "asset-001", "manifest.json")), "repeated start output preserved");
 }
 finally
 {
@@ -61,9 +70,27 @@ static IngestRuntimeService CreateRuntimeService(string inputPath, string output
     return new IngestRuntimeService(
         new IngestRuntimePaths(inputPath, outputPath),
         new IngestMountScanner(),
+        new ManifestReadinessGate(),
         new PackageWorkflowStarter(),
         store,
         new OutboxDispatcher(store, publisher));
+}
+
+static async Task WaitForAsync(Func<bool> condition, string name)
+{
+    var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+
+    while (DateTimeOffset.UtcNow < deadline)
+    {
+        if (condition())
+        {
+            return;
+        }
+
+        await Task.Delay(TimeSpan.FromMilliseconds(25));
+    }
+
+    throw new InvalidOperationException($"{name}: timed out.");
 }
 
 static void AssertEqual<T>(T expected, T actual, string name)

--- a/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
@@ -14,14 +14,19 @@ try
     File.WriteAllText(Path.Combine(mountPath, "loose-file.txt"), "not a package");
 
     var scanner = new IngestMountScanner();
+    var readinessGate = new ManifestReadinessGate();
 
     var candidates = scanner.FindPackageCandidates(mountPath);
 
-    AssertEqual(1, candidates.Count, "ready package candidate count");
+    AssertEqual(3, candidates.Count, "package candidate count");
     AssertSequenceEqual(
-        [readyPackagePath],
+        [firstPackagePath, secondPackagePath, readyPackagePath],
         candidates.Select(candidate => candidate.PackagePath).ToArray(),
-        "ready package candidate paths");
+        "package candidate paths");
+
+    AssertFalse(readinessGate.IsReady(new IngestPackageCandidate(firstPackagePath)), "manifest-only package readiness");
+    AssertFalse(readinessGate.IsReady(new IngestPackageCandidate(secondPackagePath)), "empty package readiness");
+    AssertTrue(readinessGate.IsReady(new IngestPackageCandidate(readyPackagePath)), "manifest and checksum package readiness");
 }
 finally
 {
@@ -38,6 +43,22 @@ static void AssertEqual<T>(T expected, T actual, string name)
     if (!EqualityComparer<T>.Default.Equals(expected, actual))
     {
         throw new InvalidOperationException($"{name}: expected '{expected}', got '{actual}'.");
+    }
+}
+
+static void AssertTrue(bool condition, string name)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException($"{name}: expected true.");
+    }
+}
+
+static void AssertFalse(bool condition, string name)
+{
+    if (condition)
+    {
+        throw new InvalidOperationException($"{name}: expected false.");
     }
 }
 

--- a/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
@@ -7,17 +7,21 @@ try
 {
     var firstPackagePath = Directory.CreateDirectory(Path.Combine(mountPath, "package-a")).FullName;
     var secondPackagePath = Directory.CreateDirectory(Path.Combine(mountPath, "package-b")).FullName;
+    var readyPackagePath = Directory.CreateDirectory(Path.Combine(mountPath, "package-ready")).FullName;
+    File.WriteAllText(Path.Combine(firstPackagePath, "manifest.json"), "{not-json");
+    File.WriteAllText(Path.Combine(readyPackagePath, "manifest.json"), "{not-json");
+    File.WriteAllText(Path.Combine(readyPackagePath, "manifest.json.checksum"), "not-a-real-checksum");
     File.WriteAllText(Path.Combine(mountPath, "loose-file.txt"), "not a package");
 
     var scanner = new IngestMountScanner();
 
     var candidates = scanner.FindPackageCandidates(mountPath);
 
-    AssertEqual(2, candidates.Count, "package candidate count");
+    AssertEqual(1, candidates.Count, "ready package candidate count");
     AssertSequenceEqual(
-        [firstPackagePath, secondPackagePath],
+        [readyPackagePath],
         candidates.Select(candidate => candidate.PackagePath).ToArray(),
-        "package candidate paths");
+        "ready package candidate paths");
 }
 finally
 {


### PR DESCRIPTION
Refs #12

## Summary
- Add manifest readiness gating so watcher candidates require both `manifest.json` and `manifest.json.checksum`.
- Add a minimal ASP.NET Core API host with `POST /api/ingest/start` and `GET /api/ingest/status`.
- Wire scanner, `PackageWorkflowStarter`, `InMemoryIngestPersistenceStore`, `OutboxDispatcher`, and a local manifest transfer publisher for repo-local input/output paths.
- Copy only manifest readiness files to `output/<asset-directory-name>`, treating identical existing files as idempotent and different existing files as package failure without overwriting.

## Validation
- `make test-dotnet-watcher`
- `make test-dotnet-api`
- `make test-dotnet`
- `git diff --check`

## Notes
- Docs and `web/ingest-control-plane` were intentionally left untouched.
- API orchestration is covered behind the endpoint service; this sandbox denies Kestrel socket binding, so HTTP socket validation should be done in a less restricted local runtime.