### PR TITLE
USER-STORY-16: Add local Docker runtime

### DIFF
--- a/deploy/docker/api.Dockerfile
+++ b/deploy/docker/api.Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY . .
+RUN dotnet publish src/MediaIngest.Api/MediaIngest.Api.csproj \
+    --configuration Release \
+    --output /app/publish \
+    --no-self-contained
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+
+COPY --from=build /app/publish .
+
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "MediaIngest.Api.dll"]

--- a/deploy/docker/compose.yaml
+++ b/deploy/docker/compose.yaml
@@ -1,0 +1,44 @@
+services:
+  api:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/api.Dockerfile
+    environment:
+      ASPNETCORE_URLS: http://+:8080
+      Ingest__InputPath: /mnt/ingest/input
+      Ingest__OutputPath: /mnt/ingest/output
+    ports:
+      - "5000:8080"
+    volumes:
+      - ../../input:/mnt/ingest/input
+      - ../../output:/mnt/ingest/output
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  ui:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/ui.Dockerfile
+    ports:
+      - "5173:80"
+    depends_on:
+      - api
+
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: media_ingest
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d media_ingest"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+volumes:
+  postgres-data:

--- a/deploy/docker/ui.Dockerfile
+++ b/deploy/docker/ui.Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+
+COPY web/ingest-control-plane/package.json web/ingest-control-plane/package-lock.json ./
+RUN npm ci
+
+COPY web/ingest-control-plane/ ./
+RUN npm run build
+
+FROM nginx:1.27-alpine AS runtime
+COPY deploy/docker/ui.nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/deploy/docker/ui.nginx.conf
+++ b/deploy/docker/ui.nginx.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://api:8080;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -33,6 +33,7 @@ mirror.
 | `.worktrees/USER-STORY-16-local-ingest-docs` | `USER-STORY-16-local-ingest-docs` | #26 | USER-STORY-16 | Forge | `README.md`, `docs/product/backlog.md`, `docs/status/current-status.md`, `docs/status/work-log.md`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/44 |
 | `.worktrees/USER-STORY-12-local-ingest-start-ui` | `USER-STORY-12-local-ingest-start-ui` | #22 | USER-STORY-12 | Canvas | `web/ingest-control-plane`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/43 |
 | `.worktrees/parallel-system-components-terminal-scripts` | `USER-STORY-16-parallel-system-components-terminal-scripts` | none | USER-STORY-16 | Forge | `docs/automation/README.md`, `docs/automation/terminal-scripts.md`, `docs/plans/parallel-system-components.md`, `docs/plans/active-worktrees.md`, `.terminals` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/46 |
+| `.worktrees/parallel-01-forge-docker-runtime` | `parallel-01-forge-docker-runtime` | none | USER-STORY-16 | Forge | `deploy/docker`, `docs/plans/active-worktrees.md` | Ready For PR | none |
 
 ## Update Rule
 

--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -33,7 +33,7 @@ mirror.
 | `.worktrees/USER-STORY-16-local-ingest-docs` | `USER-STORY-16-local-ingest-docs` | #26 | USER-STORY-16 | Forge | `README.md`, `docs/product/backlog.md`, `docs/status/current-status.md`, `docs/status/work-log.md`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/44 |
 | `.worktrees/USER-STORY-12-local-ingest-start-ui` | `USER-STORY-12-local-ingest-start-ui` | #22 | USER-STORY-12 | Canvas | `web/ingest-control-plane`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/43 |
 | `.worktrees/parallel-system-components-terminal-scripts` | `USER-STORY-16-parallel-system-components-terminal-scripts` | none | USER-STORY-16 | Forge | `docs/automation/README.md`, `docs/automation/terminal-scripts.md`, `docs/plans/parallel-system-components.md`, `docs/plans/active-worktrees.md`, `.terminals` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/46 |
-| `.worktrees/parallel-01-forge-docker-runtime` | `parallel-01-forge-docker-runtime` | none | USER-STORY-16 | Forge | `deploy/docker`, `docs/plans/active-worktrees.md` | Ready For PR | none |
+| `.worktrees/parallel-01-forge-docker-runtime` | `parallel-01-forge-docker-runtime` | none | USER-STORY-16 | Forge | `deploy/docker`, `docs/plans/active-worktrees.md` | PR Open | https://github.com/ankit-singhal87/media-asset-ingest/pull/47 |
 
 ## Update Rule
 


### PR DESCRIPTION
## Summary

- Adds `deploy/docker/compose.yaml` for local API, UI, and PostgreSQL services.
- Adds Dockerfiles for the .NET API and React control-plane UI.
- Serves the built UI through nginx and proxies `/api` to the API service inside the Compose network.
- Bind-mounts repo-root `input/` and `output/` into the API container at `/mnt/ingest/input` and `/mnt/ingest/output`.
- Marks the local parallel worktree row as ready for PR.

Refs #26

## Validation

- `docker compose -f deploy/docker/compose.yaml config` passed.
- `git diff --check` passed.
- `make docs-check` passed.
- `make validate` passed, including documentation checks, GitHub helper tests, build, and component smoke tests.

## Risk

- Low for repository code paths: this adds local runtime configuration only and does not change app code, shared solution files, package scripts, schemas, or contracts.
- Full image build and `docker compose up` runtime smoke validation are left for a follow-up because this track requested `docker compose config` validation only.

## Follow-Up Notes

- A coordinator can decide whether to add a canonical Makefile entry for this Compose runtime in a separate coordinator-owned tooling track.