### PR TITLE
USER-STORY-16: Document terminal script Codex launch

### DIFF
--- a/docs/automation/terminal-scripts.md
+++ b/docs/automation/terminal-scripts.md
@@ -9,6 +9,15 @@ task scope, worktree branch name, target files, forbidden files, validation
 command, and stop conditions so a local operator can start independent tracks
 consistently.
 
+Track launch scripts should create or enter the assigned worktree, then pass the
+track prompt directly to `codex --cd <worktree>`. Printing the prompt without
+starting Codex is useful only for manual debugging, not normal parallel work.
+
+Keep generated helpers POSIX `sh` compatible when practical. Operators may run
+them as `sh .terminals/<track>.sh`, which bypasses the script shebang; avoid
+Bash-only shell options such as `set -o pipefail` unless the launch command
+explicitly invokes Bash.
+
 Durable task state does not live in `.terminals/`. Keep durable coordination in:
 
 - `docs/plans`


### PR DESCRIPTION
## Summary
- Document that generated terminal helpers should launch Codex with the track prompt after entering the assigned worktree.
- Document why generated helpers should stay POSIX `sh` compatible when practical.

## Linked Issues
Refs #26

## Validation
- `make docs-check` passed.
- `make validate-automation` passed.
- `git diff --check` passed.

## Risk
- Low. Documentation-only guidance for local, gitignored helper generation.

## Follow-up
- Regenerate local `.terminals/` scripts from this guidance when the parallel plan changes.