### PR TITLE
parallel-05: Add essence checksum validator

### DIFF
--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -33,6 +33,7 @@ mirror.
 | `.worktrees/USER-STORY-16-local-ingest-docs` | `USER-STORY-16-local-ingest-docs` | #26 | USER-STORY-16 | Forge | `README.md`, `docs/product/backlog.md`, `docs/status/current-status.md`, `docs/status/work-log.md`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/44 |
 | `.worktrees/USER-STORY-12-local-ingest-start-ui` | `USER-STORY-12-local-ingest-start-ui` | #22 | USER-STORY-12 | Canvas | `web/ingest-control-plane`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/43 |
 | `.worktrees/parallel-system-components-terminal-scripts` | `USER-STORY-16-parallel-system-components-terminal-scripts` | none | USER-STORY-16 | Forge | `docs/automation/README.md`, `docs/automation/terminal-scripts.md`, `docs/plans/parallel-system-components.md`, `docs/plans/active-worktrees.md`, `.terminals` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/46 |
+| `.worktrees/parallel-05-essence-checksum-validator` | `parallel-05-essence-checksum-validator` | none | USER-STORY-7 | Essence | `src/MediaIngest.Essence`, `tests/MediaIngest.Essence.Tests`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md` | Ready For PR | none |
 
 ## Update Rule
 

--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -33,7 +33,7 @@ mirror.
 | `.worktrees/USER-STORY-16-local-ingest-docs` | `USER-STORY-16-local-ingest-docs` | #26 | USER-STORY-16 | Forge | `README.md`, `docs/product/backlog.md`, `docs/status/current-status.md`, `docs/status/work-log.md`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/44 |
 | `.worktrees/USER-STORY-12-local-ingest-start-ui` | `USER-STORY-12-local-ingest-start-ui` | #22 | USER-STORY-12 | Canvas | `web/ingest-control-plane`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/43 |
 | `.worktrees/parallel-system-components-terminal-scripts` | `USER-STORY-16-parallel-system-components-terminal-scripts` | none | USER-STORY-16 | Forge | `docs/automation/README.md`, `docs/automation/terminal-scripts.md`, `docs/plans/parallel-system-components.md`, `docs/plans/active-worktrees.md`, `.terminals` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/46 |
-| `.worktrees/parallel-05-essence-checksum-validator` | `parallel-05-essence-checksum-validator` | none | USER-STORY-7 | Essence | `src/MediaIngest.Essence`, `tests/MediaIngest.Essence.Tests`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md` | Ready For PR | none |
+| `.worktrees/parallel-05-essence-checksum-validator` | `parallel-05-essence-checksum-validator` | none | USER-STORY-7 | Essence | `src/MediaIngest.Essence`, `tests/MediaIngest.Essence.Tests`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md` | PR Open | https://github.com/ankit-singhal87/media-asset-ingest/pull/49 |
 
 ## Update Rule
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -3,6 +3,11 @@
 Use this log for concise human-readable progress notes. Do not duplicate commit
 messages or paste command output unless it explains a decision.
 
+## 2026-05-04
+
+- Added the parallel Essence checksum validator component with focused tests for
+  valid, missing, malformed, and mismatched raw SHA-256 manifest checksums.
+
 ## 2026-05-03
 
 - Added Markdown link validation and Git naming conventions for branch, commit,

--- a/src/MediaIngest.Essence/Checksums/ManifestChecksumFailureReason.cs
+++ b/src/MediaIngest.Essence/Checksums/ManifestChecksumFailureReason.cs
@@ -1,0 +1,10 @@
+namespace MediaIngest.Essence.Checksums;
+
+public enum ManifestChecksumFailureReason
+{
+    None = 0,
+    ManifestFileMissing,
+    ChecksumFileMissing,
+    MalformedChecksum,
+    ChecksumMismatch
+}

--- a/src/MediaIngest.Essence/Checksums/ManifestChecksumValidationResult.cs
+++ b/src/MediaIngest.Essence/Checksums/ManifestChecksumValidationResult.cs
@@ -1,0 +1,25 @@
+namespace MediaIngest.Essence.Checksums;
+
+public sealed record ManifestChecksumValidationResult(
+    bool IsValid,
+    ManifestChecksumFailureReason FailureReason,
+    string? ExpectedChecksumHex,
+    string? ActualChecksumHex)
+{
+    public static ManifestChecksumValidationResult Valid(string checksumHex) =>
+        new(
+            IsValid: true,
+            FailureReason: ManifestChecksumFailureReason.None,
+            ExpectedChecksumHex: checksumHex,
+            ActualChecksumHex: checksumHex);
+
+    public static ManifestChecksumValidationResult Failed(
+        ManifestChecksumFailureReason failureReason,
+        string? expectedChecksumHex = null,
+        string? actualChecksumHex = null) =>
+        new(
+            IsValid: false,
+            FailureReason: failureReason,
+            ExpectedChecksumHex: expectedChecksumHex,
+            ActualChecksumHex: actualChecksumHex);
+}

--- a/src/MediaIngest.Essence/Checksums/ManifestChecksumValidator.cs
+++ b/src/MediaIngest.Essence/Checksums/ManifestChecksumValidator.cs
@@ -1,0 +1,58 @@
+using System.Security.Cryptography;
+
+namespace MediaIngest.Essence.Checksums;
+
+public static class ManifestChecksumValidator
+{
+    private const int Sha256HexLength = 64;
+
+    public static ManifestChecksumValidationResult Validate(string manifestPath, string checksumPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(manifestPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(checksumPath);
+
+        if (!File.Exists(manifestPath))
+        {
+            return ManifestChecksumValidationResult.Failed(ManifestChecksumFailureReason.ManifestFileMissing);
+        }
+
+        if (!File.Exists(checksumPath))
+        {
+            return ManifestChecksumValidationResult.Failed(ManifestChecksumFailureReason.ChecksumFileMissing);
+        }
+
+        var expectedChecksumHex = File.ReadAllText(checksumPath).Trim();
+        if (!IsSha256Hex(expectedChecksumHex))
+        {
+            return ManifestChecksumValidationResult.Failed(ManifestChecksumFailureReason.MalformedChecksum);
+        }
+
+        expectedChecksumHex = expectedChecksumHex.ToLowerInvariant();
+        var actualChecksumHex = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(manifestPath))).ToLowerInvariant();
+
+        return string.Equals(expectedChecksumHex, actualChecksumHex, StringComparison.Ordinal)
+            ? ManifestChecksumValidationResult.Valid(actualChecksumHex)
+            : ManifestChecksumValidationResult.Failed(
+                ManifestChecksumFailureReason.ChecksumMismatch,
+                expectedChecksumHex,
+                actualChecksumHex);
+    }
+
+    private static bool IsSha256Hex(string value)
+    {
+        if (value.Length != Sha256HexLength)
+        {
+            return false;
+        }
+
+        foreach (var character in value)
+        {
+            if (!Uri.IsHexDigit(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/MediaIngest.Essence/MediaIngest.Essence.csproj
+++ b/src/MediaIngest.Essence/MediaIngest.Essence.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>MediaIngest.Essence</RootNamespace>
+    <AssemblyName>MediaIngest.Essence</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/tests/MediaIngest.Essence.Tests/MediaIngest.Essence.Tests.csproj
+++ b/tests/MediaIngest.Essence.Tests/MediaIngest.Essence.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MediaIngest.Essence.Tests</RootNamespace>
+    <AssemblyName>MediaIngest.Essence.Tests</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/MediaIngest.Essence/MediaIngest.Essence.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/MediaIngest.Essence.Tests/Program.cs
+++ b/tests/MediaIngest.Essence.Tests/Program.cs
@@ -1,0 +1,77 @@
+using System.Security.Cryptography;
+using System.Text;
+using MediaIngest.Essence.Checksums;
+
+var workspace = Path.Combine(Path.GetTempPath(), "media-ingest-essence-tests", Guid.NewGuid().ToString("N"));
+Directory.CreateDirectory(workspace);
+
+try
+{
+    var manifestPath = Path.Combine(workspace, "manifest.json");
+    var checksumPath = Path.Combine(workspace, "manifest.json.checksum");
+    File.WriteAllText(manifestPath, """{"packageId":"asset-001"}""");
+
+    var expectedChecksum = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(manifestPath))).ToLowerInvariant();
+    File.WriteAllText(checksumPath, expectedChecksum);
+
+    var validResult = ManifestChecksumValidator.Validate(manifestPath, checksumPath);
+    AssertTrue(validResult.IsValid, "valid checksum succeeds");
+    AssertEqual(ManifestChecksumFailureReason.None, validResult.FailureReason, "valid checksum reason");
+    AssertEqual(expectedChecksum, validResult.ExpectedChecksumHex, "expected checksum is normalized");
+    AssertEqual(expectedChecksum, validResult.ActualChecksumHex, "actual checksum is computed");
+
+    var uppercaseChecksumPath = Path.Combine(workspace, "manifest-uppercase.json.checksum");
+    File.WriteAllText(uppercaseChecksumPath, $"  {expectedChecksum.ToUpperInvariant()}{Environment.NewLine}");
+
+    var uppercaseResult = ManifestChecksumValidator.Validate(manifestPath, uppercaseChecksumPath);
+    AssertTrue(uppercaseResult.IsValid, "uppercase checksum succeeds");
+    AssertEqual(expectedChecksum, uppercaseResult.ExpectedChecksumHex, "uppercase checksum is normalized");
+
+    var missingResult = ManifestChecksumValidator.Validate(
+        manifestPath,
+        Path.Combine(workspace, "missing-manifest.json.checksum"));
+    AssertFalse(missingResult.IsValid, "missing checksum fails");
+    AssertEqual(ManifestChecksumFailureReason.ChecksumFileMissing, missingResult.FailureReason, "missing checksum reason");
+
+    File.WriteAllText(checksumPath, "not-a-sha256");
+    var malformedResult = ManifestChecksumValidator.Validate(manifestPath, checksumPath);
+    AssertFalse(malformedResult.IsValid, "malformed checksum fails");
+    AssertEqual(ManifestChecksumFailureReason.MalformedChecksum, malformedResult.FailureReason, "malformed checksum reason");
+
+    File.WriteAllText(checksumPath, new string('0', 64));
+    var mismatchedResult = ManifestChecksumValidator.Validate(manifestPath, checksumPath);
+    AssertFalse(mismatchedResult.IsValid, "mismatched checksum fails");
+    AssertEqual(ManifestChecksumFailureReason.ChecksumMismatch, mismatchedResult.FailureReason, "mismatched checksum reason");
+    AssertEqual(new string('0', 64), mismatchedResult.ExpectedChecksumHex, "mismatched expected checksum");
+    AssertEqual(expectedChecksum, mismatchedResult.ActualChecksumHex, "mismatched actual checksum");
+
+    Console.WriteLine("MediaIngest essence checksum tests passed.");
+}
+finally
+{
+    Directory.Delete(workspace, recursive: true);
+}
+
+static void AssertTrue(bool condition, string name)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException($"{name}: expected true.");
+    }
+}
+
+static void AssertFalse(bool condition, string name)
+{
+    if (condition)
+    {
+        throw new InvalidOperationException($"{name}: expected false.");
+    }
+}
+
+static void AssertEqual<T>(T expected, T actual, string name)
+{
+    if (!EqualityComparer<T>.Default.Equals(expected, actual))
+    {
+        throw new InvalidOperationException($"{name}: expected '{expected}', got '{actual}'.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a standalone `MediaIngest.Essence` checksum component for raw SHA-256 hex validation of `manifest.json.checksum`.
- Covers valid, uppercase/whitespace-normalized, missing, malformed, and mismatched checksum cases with focused executable tests.
- Updates the local active worktree mirror and work log for this parallel track.

Refs #17

## Validation

- `dotnet run --project tests/MediaIngest.Essence.Tests/MediaIngest.Essence.Tests.csproj` passed with `MediaIngest essence checksum tests passed.`
- `git diff --check` passed.