### PR TITLE
USER-STORY-11: Add diagnostic event names

### DIFF
--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -33,7 +33,7 @@ mirror.
 | `.worktrees/USER-STORY-16-local-ingest-docs` | `USER-STORY-16-local-ingest-docs` | #26 | USER-STORY-16 | Forge | `README.md`, `docs/product/backlog.md`, `docs/status/current-status.md`, `docs/status/work-log.md`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/44 |
 | `.worktrees/USER-STORY-12-local-ingest-start-ui` | `USER-STORY-12-local-ingest-start-ui` | #22 | USER-STORY-12 | Canvas | `web/ingest-control-plane`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/43 |
 | `.worktrees/parallel-system-components-terminal-scripts` | `USER-STORY-16-parallel-system-components-terminal-scripts` | none | USER-STORY-16 | Forge | `docs/automation/README.md`, `docs/automation/terminal-scripts.md`, `docs/plans/parallel-system-components.md`, `docs/plans/active-worktrees.md`, `.terminals` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/46 |
-| `.worktrees/parallel-08-beacon-runtime-diagnostics` | `parallel-08-beacon-runtime-diagnostics` | Track 08 | USER-STORY-11 | Beacon | `src/MediaIngest.Observability`, `tests/MediaIngest.Observability.Tests`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md` | Ready For PR | none |
+| `.worktrees/parallel-08-beacon-runtime-diagnostics` | `parallel-08-beacon-runtime-diagnostics` | Track 08 | USER-STORY-11 | Beacon | `src/MediaIngest.Observability`, `tests/MediaIngest.Observability.Tests`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md` | PR Open | https://github.com/ankit-singhal87/media-asset-ingest/pull/50 |
 
 ## Update Rule
 

--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -33,6 +33,7 @@ mirror.
 | `.worktrees/USER-STORY-16-local-ingest-docs` | `USER-STORY-16-local-ingest-docs` | #26 | USER-STORY-16 | Forge | `README.md`, `docs/product/backlog.md`, `docs/status/current-status.md`, `docs/status/work-log.md`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/44 |
 | `.worktrees/USER-STORY-12-local-ingest-start-ui` | `USER-STORY-12-local-ingest-start-ui` | #22 | USER-STORY-12 | Canvas | `web/ingest-control-plane`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/43 |
 | `.worktrees/parallel-system-components-terminal-scripts` | `USER-STORY-16-parallel-system-components-terminal-scripts` | none | USER-STORY-16 | Forge | `docs/automation/README.md`, `docs/automation/terminal-scripts.md`, `docs/plans/parallel-system-components.md`, `docs/plans/active-worktrees.md`, `.terminals` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/46 |
+| `.worktrees/parallel-08-beacon-runtime-diagnostics` | `parallel-08-beacon-runtime-diagnostics` | Track 08 | USER-STORY-11 | Beacon | `src/MediaIngest.Observability`, `tests/MediaIngest.Observability.Tests`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md` | Ready For PR | none |
 
 ## Update Rule
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -3,6 +3,11 @@
 Use this log for concise human-readable progress notes. Do not duplicate commit
 messages or paste command output unless it explains a decision.
 
+## 2026-05-04
+
+- Added the Track 08 Beacon runtime diagnostic event-name catalog for scan,
+  readiness, copy, outbox dispatch, success, and failure observability records.
+
 ## 2026-05-03
 
 - Added Markdown link validation and Git naming conventions for branch, commit,

--- a/src/MediaIngest.Observability/DiagnosticEventNames.cs
+++ b/src/MediaIngest.Observability/DiagnosticEventNames.cs
@@ -1,0 +1,21 @@
+namespace MediaIngest.Observability;
+
+public static class DiagnosticEventNames
+{
+    public const string Scan = "ingest.scan";
+    public const string Readiness = "ingest.readiness";
+    public const string Copy = "ingest.copy";
+    public const string OutboxDispatch = "outbox.dispatch";
+    public const string Success = "ingest.succeeded";
+    public const string Failure = "ingest.failed";
+
+    public static IReadOnlyList<string> All { get; } =
+    [
+        Scan,
+        Readiness,
+        Copy,
+        OutboxDispatch,
+        Success,
+        Failure
+    ];
+}

--- a/tests/MediaIngest.Observability.Tests/Program.cs
+++ b/tests/MediaIngest.Observability.Tests/Program.cs
@@ -17,6 +17,24 @@ var expectedFields = new[]
 
 AssertSequenceEqual(expectedFields, CorrelationFieldNames.All, "correlation field catalog");
 
+var expectedDiagnosticEvents = new[]
+{
+    "ingest.scan",
+    "ingest.readiness",
+    "ingest.copy",
+    "outbox.dispatch",
+    "ingest.succeeded",
+    "ingest.failed"
+};
+
+AssertSequenceEqual(expectedDiagnosticEvents, DiagnosticEventNames.All, "diagnostic event catalog");
+AssertEqual("ingest.scan", DiagnosticEventNames.Scan, "scan diagnostic event");
+AssertEqual("ingest.readiness", DiagnosticEventNames.Readiness, "readiness diagnostic event");
+AssertEqual("ingest.copy", DiagnosticEventNames.Copy, "copy diagnostic event");
+AssertEqual("outbox.dispatch", DiagnosticEventNames.OutboxDispatch, "outbox dispatch diagnostic event");
+AssertEqual("ingest.succeeded", DiagnosticEventNames.Success, "success diagnostic event");
+AssertEqual("ingest.failed", DiagnosticEventNames.Failure, "failure diagnostic event");
+
 var context = new ObservabilityCorrelationContext(
     WorkflowInstanceId: "workflow-package-001",
     PackageId: "package-001",
@@ -45,7 +63,7 @@ AssertEqual("package-001", fields["packageId"], "package correlation");
 AssertEqual("proxy", fields["agentType"], "agent correlation");
 AssertEqual("work-item-proxy-001", fields["workItemId"], "work item correlation");
 
-Console.WriteLine("MediaIngest observability correlation smoke test passed.");
+Console.WriteLine("MediaIngest observability smoke test passed.");
 
 static void AssertSequenceEqual<T>(IReadOnlyList<T> expected, IReadOnlyList<T> actual, string name)
 {


### PR DESCRIPTION
## Summary

- Adds `DiagnosticEventNames` in `MediaIngest.Observability` for scan, readiness, copy, outbox dispatch, success, and failure diagnostic records.
- Extends the observability smoke test to verify the diagnostic event catalog and constants.
- Updates the local active-worktree mirror and work log for Track 08.

Refs #21

## Validation

- `make test-dotnet-observability` passed: build succeeded with 0 warnings/errors and the observability smoke test passed.
- `make validate-docs` passed: documentation checks passed.
- `make validate` passed: docs checks, GitHub helper tests, .NET solution build, and smoke tests passed.
- `git diff --check` passed.

## Risk

Low. This adds shared observability constants and test coverage only; it does not wire new runtime behavior into workflow, watcher, or outbox components.

## Follow-up

- Runtime lanes can adopt these names when emitting structured diagnostic logs or timeline diagnostic records.