### PR TITLE
USER-STORY-3: Add mount package file discovery

### DIFF
--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -33,7 +33,7 @@ mirror.
 | `.worktrees/USER-STORY-16-local-ingest-docs` | `USER-STORY-16-local-ingest-docs` | #26 | USER-STORY-16 | Forge | `README.md`, `docs/product/backlog.md`, `docs/status/current-status.md`, `docs/status/work-log.md`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/44 |
 | `.worktrees/USER-STORY-12-local-ingest-start-ui` | `USER-STORY-12-local-ingest-start-ui` | #22 | USER-STORY-12 | Canvas | `web/ingest-control-plane`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/43 |
 | `.worktrees/parallel-system-components-terminal-scripts` | `USER-STORY-16-parallel-system-components-terminal-scripts` | none | USER-STORY-16 | Forge | `docs/automation/README.md`, `docs/automation/terminal-scripts.md`, `docs/plans/parallel-system-components.md`, `docs/plans/active-worktrees.md`, `.terminals` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/46 |
-| `.worktrees/parallel-04-mount-file-discovery` | `USER-STORY-3-mount-file-discovery` | #13 | USER-STORY-3 | Mount | `src/MediaIngest.Worker.Watcher`, `tests/MediaIngest.Worker.Watcher.Tests`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md` | Ready For PR | none |
+| `.worktrees/parallel-04-mount-file-discovery` | `USER-STORY-3-mount-file-discovery` | #13 | USER-STORY-3 | Mount | `src/MediaIngest.Worker.Watcher`, `tests/MediaIngest.Worker.Watcher.Tests`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md` | PR Open | https://github.com/ankit-singhal87/media-asset-ingest/pull/51 |
 
 ## Update Rule
 

--- a/docs/plans/active-worktrees.md
+++ b/docs/plans/active-worktrees.md
@@ -33,6 +33,7 @@ mirror.
 | `.worktrees/USER-STORY-16-local-ingest-docs` | `USER-STORY-16-local-ingest-docs` | #26 | USER-STORY-16 | Forge | `README.md`, `docs/product/backlog.md`, `docs/status/current-status.md`, `docs/status/work-log.md`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/44 |
 | `.worktrees/USER-STORY-12-local-ingest-start-ui` | `USER-STORY-12-local-ingest-start-ui` | #22 | USER-STORY-12 | Canvas | `web/ingest-control-plane`, `docs/plans/active-worktrees.md` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/43 |
 | `.worktrees/parallel-system-components-terminal-scripts` | `USER-STORY-16-parallel-system-components-terminal-scripts` | none | USER-STORY-16 | Forge | `docs/automation/README.md`, `docs/automation/terminal-scripts.md`, `docs/plans/parallel-system-components.md`, `docs/plans/active-worktrees.md`, `.terminals` | Cleaned Up | https://github.com/ankit-singhal87/media-asset-ingest/pull/46 |
+| `.worktrees/parallel-04-mount-file-discovery` | `USER-STORY-3-mount-file-discovery` | #13 | USER-STORY-3 | Mount | `src/MediaIngest.Worker.Watcher`, `tests/MediaIngest.Worker.Watcher.Tests`, `docs/plans/active-worktrees.md`, `docs/status/work-log.md` | Ready For PR | none |
 
 ## Update Rule
 

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -10,6 +10,8 @@ epic/story granularity; detailed implementation tasks belong in plans.
 - MILESTONE-2 / USER-STORY-16: keep the draft local manifest ingest demo docs
   aligned with the backend and UI draft PRs.
 - MILESTONE-3 / USER-STORY-1: add ingest watcher scanner foundation.
+- MILESTONE-3 / USER-STORY-3: enumerate every physical file under a ready
+  package directory without wiring discovery into copy behavior.
 - MILESTONE-4 / USER-STORY-8: add persistence and transactional outbox
   foundation.
 - MILESTONE-5 / USER-STORY-9: add Dapr workflow skeleton.
@@ -26,8 +28,8 @@ epic/story granularity; detailed implementation tasks belong in plans.
 - MILESTONE-2 / USER-STORY-16: merge the local ingest docs after the backend and
   UI draft PRs provide the documented API host, UI start action, and runtime
   ignore setup.
-- MILESTONE-3 / USER-STORY-2 / USER-STORY-3 / USER-STORY-4: implement manifest
-  gating, physical file enumeration, and done-marker reconciliation.
+- MILESTONE-3 / USER-STORY-2 / USER-STORY-3 / USER-STORY-4: wire manifest
+  gating, discovered files, and done-marker reconciliation into package work.
 - MILESTONE-3 / USER-STORY-5: implement essence classification.
 - MILESTONE-4 / USER-STORY-6: define Azure Service Bus topic/subscription
   adapters and local development strategy.

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -9,7 +9,7 @@ ownership lanes. Keep detailed implementation tasks in `docs/plans/tasks`.
 | --- | --- | --- | --- | --- | --- |
 | USER-STORY-1 | Watch ingest mount | MILESTONE-3 | Ingest package | Mount | In Progress |
 | USER-STORY-2 | Start only when manifest is ready | MILESTONE-3 | Manifest | Mount | Planned |
-| USER-STORY-3 | Ingest all discovered files | MILESTONE-3 | Ingest package | Mount | Planned |
+| USER-STORY-3 | Ingest all discovered files | MILESTONE-3 | Ingest package | Mount | In Progress |
 | USER-STORY-4 | Reconcile on done marker | MILESTONE-3 | Done marker | Mount | Planned |
 | USER-STORY-5 | Classify media essences | MILESTONE-3 | Essence classification | Essence | Planned |
 | USER-STORY-6 | Route work through ASB command topics | MILESTONE-4 | Messaging | Courier | Planned |

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -71,6 +71,8 @@
   proxied to that API, press **Start ingest** to begin watching, then add
   `manifest.json` plus `manifest.json.checksum` under `input/<asset>/` and
   expect both manifest files under `output/<asset>/`.
+- USER-STORY-3 physical file enumeration now scans ready package directories
+  recursively in the watcher without wiring discovery into copy behavior.
 
 ## Ready For Review
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -89,6 +89,12 @@ messages or paste command output unless it explains a decision.
   all immediate child directories, readiness requires both manifest files, and
   start ingest launches a background watcher loop.
 
+## 2026-05-04
+
+- Added Mount file discovery for USER-STORY-3 so the watcher enumerates every
+  physical file under a ready package directory with stable package-relative
+  paths, without wiring discovery into copy, persistence, or workflow behavior.
+
 ## Update Rule
 
 Agents should add a dated bullet when completing a meaningful task, fixing a

--- a/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
@@ -11,4 +11,19 @@ public sealed class IngestMountScanner
             .Select(packagePath => new IngestPackageCandidate(Path.GetFullPath(packagePath)))
             .ToArray();
     }
+
+    public IReadOnlyList<IngestPackageFile> FindPackageFiles(IngestPackageCandidate candidate)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        var packagePath = Path.GetFullPath(candidate.PackagePath);
+
+        return Directory.EnumerateFiles(packagePath, "*", SearchOption.AllDirectories)
+            .Select(filePath => new IngestPackageFile(
+                packagePath,
+                Path.GetFullPath(filePath),
+                Path.GetRelativePath(packagePath, filePath)))
+            .OrderBy(file => file.PackageRelativePath, StringComparer.Ordinal)
+            .ToArray();
+    }
 }

--- a/src/MediaIngest.Worker.Watcher/IngestPackageFile.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestPackageFile.cs
@@ -1,0 +1,6 @@
+namespace MediaIngest.Worker.Watcher;
+
+public sealed record IngestPackageFile(
+    string PackagePath,
+    string FilePath,
+    string PackageRelativePath);

--- a/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
@@ -8,9 +8,13 @@ try
     var firstPackagePath = Directory.CreateDirectory(Path.Combine(mountPath, "package-a")).FullName;
     var secondPackagePath = Directory.CreateDirectory(Path.Combine(mountPath, "package-b")).FullName;
     var readyPackagePath = Directory.CreateDirectory(Path.Combine(mountPath, "package-ready")).FullName;
+    var readyPackageMediaPath = Directory.CreateDirectory(Path.Combine(readyPackagePath, "media")).FullName;
+    var readyPackageSidecarPath = Directory.CreateDirectory(Path.Combine(readyPackagePath, "sidecars", "captions")).FullName;
     File.WriteAllText(Path.Combine(firstPackagePath, "manifest.json"), "{not-json");
     File.WriteAllText(Path.Combine(readyPackagePath, "manifest.json"), "{not-json");
     File.WriteAllText(Path.Combine(readyPackagePath, "manifest.json.checksum"), "not-a-real-checksum");
+    File.WriteAllText(Path.Combine(readyPackageMediaPath, "clip.mov"), "not-real-media");
+    File.WriteAllText(Path.Combine(readyPackageSidecarPath, "clip.en.srt"), "not-real-captions");
     File.WriteAllText(Path.Combine(mountPath, "loose-file.txt"), "not a package");
 
     var scanner = new IngestMountScanner();
@@ -27,6 +31,23 @@ try
     AssertFalse(readinessGate.IsReady(new IngestPackageCandidate(firstPackagePath)), "manifest-only package readiness");
     AssertFalse(readinessGate.IsReady(new IngestPackageCandidate(secondPackagePath)), "empty package readiness");
     AssertTrue(readinessGate.IsReady(new IngestPackageCandidate(readyPackagePath)), "manifest and checksum package readiness");
+
+    var discoveredFiles = scanner.FindPackageFiles(new IngestPackageCandidate(readyPackagePath));
+
+    AssertSequenceEqual(
+        [
+            "manifest.json",
+            "manifest.json.checksum",
+            Path.Combine("media", "clip.mov"),
+            Path.Combine("sidecars", "captions", "clip.en.srt"),
+        ],
+        discoveredFiles.Select(file => file.PackageRelativePath).ToArray(),
+        "ready package discovered relative paths");
+
+    AssertSequenceEqual(
+        discoveredFiles.Select(file => Path.Combine(readyPackagePath, file.PackageRelativePath)).ToArray(),
+        discoveredFiles.Select(file => file.FilePath).ToArray(),
+        "ready package discovered full paths");
 }
 finally
 {


### PR DESCRIPTION
## Summary

- Adds watcher-owned package file discovery for ready package directories.
- Enumerates every physical file recursively and returns full paths plus package-relative paths in deterministic order.
- Updates the watcher smoke test and project status docs for USER-STORY-3.

## Linked Work

Refs #13

## Validation

- `make test-dotnet-watcher` passed.
- `make validate` passed.
- `git diff --check` passed.

## Risk

Low. The change stays in the Mount watcher project and smoke tests. It does not wire discovery into copy behavior, persistence, workflow, outbox, UI, dependency, cloud, or secret handling.

## Follow-Up

- Wire discovered files into package work in a later scoped task.
- Add classification and reconciliation behavior in their own lanes/tasks.