### PR TITLE
TASK-8-1: Refresh control plane with Mermaid graph

### DIFF
--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -20,6 +20,8 @@ epic/story granularity; detailed implementation tasks belong in plans.
 - MILESTONE-7 / USER-STORY-11: add observability correlation field foundation.
 - MILESTONE-8 / USER-STORY-12: scaffold React workflow control plane with
   mocked workflow graph data.
+- MILESTONE-8 / USER-STORY-12: add the first workflow graph API and Mermaid
+  control-plane rendering slice.
 
 ## Ready For Planning
 
@@ -41,7 +43,8 @@ epic/story granularity; detailed implementation tasks belong in plans.
 
 - MILESTONE-6 / USER-STORY-7: implement light, medium, and heavy command
   runner services.
-- MILESTONE-8 / USER-STORY-12 / USER-STORY-13: implement workflow graph API.
+- MILESTONE-8 / USER-STORY-12 / USER-STORY-13: expand workflow graph data with
+  node detail, timeline, and log-backed status sources.
 - MILESTONE-9 / USER-STORY-17: add Kubernetes and Dapr deployment assets.
 - MILESTONE-9 / USER-STORY-17: add Azure deployment documentation.
 

--- a/docs/standards/typescript-react.md
+++ b/docs/standards/typescript-react.md
@@ -23,5 +23,8 @@ ingest packages and workflow state.
   Testing Library.
 - Run `npm test` and `npm run build` from `web/ingest-control-plane` when
   changing React behavior.
+- The control-plane build uses the TypeScript 7 native preview through
+  `@typescript/native-preview` and `tsgo`; do not reintroduce the JavaScript
+  `typescript` compiler unless a compatibility task explicitly requires it.
 - Keep package-local generated output such as `node_modules`, `dist`, coverage,
   and TypeScript build metadata out of Git.

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -75,6 +75,10 @@
   expect both manifest files under `output/<asset>/`.
 - USER-STORY-3 physical file enumeration now scans ready package directories
   recursively in the watcher without wiring discovery into copy behavior.
+- USER-STORY-12 now has a Mermaid-backed control-plane graph path: the API
+  exposes workflow graph DTOs by workflow instance, workflow lifecycle state
+  projects to graph node statuses, and the React UI renders Mermaid diagrams
+  while keeping package status and local start controls intact.
 
 ## Ready For Review
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -112,6 +112,10 @@ messages or paste command output unless it explains a decision.
 - Added Mount file discovery for USER-STORY-3 so the watcher enumerates every
   physical file under a ready package directory with stable package-relative
   paths, without wiring discovery into copy, persistence, or workflow behavior.
+- Added the USER-STORY-12 Mermaid workflow graph slice: workflow lifecycle
+  state now projects to graph DTO statuses, `/api/workflows/{id}/graph` serves
+  those DTOs, and the React control plane renders Mermaid diagrams from live
+  graph data with focused API, workflow, and UI tests.
 
 ## Update Rule
 

--- a/src/MediaIngest.Api/IngestApiApplication.cs
+++ b/src/MediaIngest.Api/IngestApiApplication.cs
@@ -95,6 +95,7 @@ public sealed class IngestApiApplication : IAsyncDisposable
     {
         app.MapPost("/api/ingest/start", StartIngestAsync);
         app.MapGet("/api/ingest/status", GetStatus);
+        app.MapGet("/api/workflows/{workflowInstanceId}/graph", GetWorkflowGraph);
     }
 
     private static async Task<IResult> StartIngestAsync(
@@ -111,6 +112,17 @@ public sealed class IngestApiApplication : IAsyncDisposable
     private static IngestStatusResponse GetStatus(IngestRuntimeService runtimeService)
     {
         return runtimeService.GetStatus();
+    }
+
+    private static IResult GetWorkflowGraph(
+        string workflowInstanceId,
+        IngestRuntimeService runtimeService)
+    {
+        var graph = runtimeService.GetWorkflowGraph(workflowInstanceId);
+
+        return graph is null
+            ? Results.NotFound()
+            : Results.Ok(graph);
     }
 
     private static string FindRepoRoot()

--- a/src/MediaIngest.Api/IngestRuntimeService.cs
+++ b/src/MediaIngest.Api/IngestRuntimeService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using MediaIngest.Contracts.Workflow;
 using MediaIngest.Persistence;
 using MediaIngest.Worker.Outbox;
 using MediaIngest.Worker.Watcher;
@@ -146,6 +147,27 @@ public sealed class IngestRuntimeService(
             .ToArray();
 
         return new IngestStatusResponse(packages);
+    }
+
+    public WorkflowGraphDto? GetWorkflowGraph(string workflowInstanceId)
+    {
+        if (string.IsNullOrWhiteSpace(workflowInstanceId))
+        {
+            return null;
+        }
+
+        var packageState = store.PackageStates
+            .GroupBy(packageState => packageState.PackageId, StringComparer.Ordinal)
+            .Select(group => group.Last())
+            .SingleOrDefault(packageState =>
+                string.Equals(packageState.WorkflowInstanceId, workflowInstanceId, StringComparison.Ordinal));
+
+        return packageState is null
+            ? null
+            : PackageWorkflowGraphProjection.FromPackageStatus(
+                packageState.PackageId,
+                packageState.WorkflowInstanceId,
+                packageState.Status);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs
@@ -1,0 +1,163 @@
+using MediaIngest.Contracts.Workflow;
+
+namespace MediaIngest.Workflow;
+
+public static class PackageWorkflowGraphProjection
+{
+    private static readonly PreparedChildWork[] PackageStartPlan =
+    [
+        new("scan-package", "Package scan"),
+        new("classify-files", "Classify discovered files"),
+        new("dispatch-processing", "Dispatch processing work")
+    ];
+
+    public static WorkflowGraphDto FromLifecycle(PackageWorkflowLifecycle lifecycle)
+    {
+        ArgumentNullException.ThrowIfNull(lifecycle);
+
+        return FromLifecycle(lifecycle.Current);
+    }
+
+    public static WorkflowGraphDto FromLifecycle(PackageWorkflowLifecycleSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var workflowInstanceId = string.IsNullOrWhiteSpace(snapshot.WorkflowInstanceId)
+            ? $"pending-{snapshot.PackageId}"
+            : snapshot.WorkflowInstanceId;
+
+        return CreateGraph(
+            snapshot.PackageId,
+            workflowInstanceId,
+            MapLifecycleState(snapshot.State));
+    }
+
+    public static WorkflowGraphDto FromPackageStatus(
+        string packageId,
+        string workflowInstanceId,
+        string status)
+    {
+        if (string.IsNullOrWhiteSpace(packageId))
+        {
+            throw new ArgumentException("Package id is required.", nameof(packageId));
+        }
+
+        if (string.IsNullOrWhiteSpace(workflowInstanceId))
+        {
+            throw new ArgumentException("Workflow instance id is required.", nameof(workflowInstanceId));
+        }
+
+        if (string.IsNullOrWhiteSpace(status))
+        {
+            throw new ArgumentException("Package status is required.", nameof(status));
+        }
+
+        return CreateGraph(packageId, workflowInstanceId, MapPackageStatus(status));
+    }
+
+    private static WorkflowGraphDto CreateGraph(
+        string packageId,
+        string workflowInstanceId,
+        WorkflowNodeStatus packageStatus)
+    {
+        var childStatuses = MapChildStatuses(packageStatus);
+        var nodes = new List<WorkflowNodeDto>
+        {
+            new(
+                NodeId: "package-start",
+                DisplayName: "Package ingest",
+                Kind: WorkflowNodeKind.WorkflowStep,
+                Status: packageStatus,
+                WorkflowInstanceId: workflowInstanceId,
+                PackageId: packageId,
+                WorkItemId: null,
+                ChildWorkflowInstanceId: null)
+        };
+
+        nodes.AddRange(PackageStartPlan.Select((work, index) => new WorkflowNodeDto(
+            NodeId: work.NodeId,
+            DisplayName: work.DisplayName,
+            Kind: WorkflowNodeKind.Activity,
+            Status: childStatuses[index],
+            WorkflowInstanceId: workflowInstanceId,
+            PackageId: packageId,
+            WorkItemId: work.NodeId,
+            ChildWorkflowInstanceId: null)));
+
+        var edges = new[]
+        {
+            new WorkflowEdgeDto("package-start-scan-package", "package-start", "scan-package"),
+            new WorkflowEdgeDto("scan-package-classify-files", "scan-package", "classify-files"),
+            new WorkflowEdgeDto("classify-files-dispatch-processing", "classify-files", "dispatch-processing")
+        };
+
+        return new WorkflowGraphDto(
+            WorkflowInstanceId: workflowInstanceId,
+            WorkflowName: WorkflowContractNames.PackageIngestWorkflow,
+            PackageId: packageId,
+            ParentWorkflowInstanceId: null,
+            Nodes: nodes,
+            Edges: edges);
+    }
+
+    private static WorkflowNodeStatus MapLifecycleState(PackageWorkflowLifecycleState state)
+    {
+        return state switch
+        {
+            PackageWorkflowLifecycleState.Observed => WorkflowNodeStatus.Pending,
+            PackageWorkflowLifecycleState.Ready => WorkflowNodeStatus.Queued,
+            PackageWorkflowLifecycleState.Started => WorkflowNodeStatus.Running,
+            PackageWorkflowLifecycleState.Succeeded => WorkflowNodeStatus.Succeeded,
+            PackageWorkflowLifecycleState.Failed => WorkflowNodeStatus.Failed,
+            _ => WorkflowNodeStatus.Pending
+        };
+    }
+
+    private static WorkflowNodeStatus MapPackageStatus(string status)
+    {
+        return status switch
+        {
+            "Started" => WorkflowNodeStatus.Running,
+            "Succeeded" => WorkflowNodeStatus.Succeeded,
+            "Failed" => WorkflowNodeStatus.Failed,
+            _ => WorkflowNodeStatus.Pending
+        };
+    }
+
+    private static WorkflowNodeStatus[] MapChildStatuses(WorkflowNodeStatus packageStatus)
+    {
+        return packageStatus switch
+        {
+            WorkflowNodeStatus.Succeeded =>
+            [
+                WorkflowNodeStatus.Succeeded,
+                WorkflowNodeStatus.Succeeded,
+                WorkflowNodeStatus.Succeeded
+            ],
+            WorkflowNodeStatus.Failed =>
+            [
+                WorkflowNodeStatus.Failed,
+                WorkflowNodeStatus.Failed,
+                WorkflowNodeStatus.Failed
+            ],
+            WorkflowNodeStatus.Running =>
+            [
+                WorkflowNodeStatus.Running,
+                WorkflowNodeStatus.Pending,
+                WorkflowNodeStatus.Pending
+            ],
+            WorkflowNodeStatus.Queued =>
+            [
+                WorkflowNodeStatus.Pending,
+                WorkflowNodeStatus.Pending,
+                WorkflowNodeStatus.Pending
+            ],
+            _ =>
+            [
+                WorkflowNodeStatus.Pending,
+                WorkflowNodeStatus.Pending,
+                WorkflowNodeStatus.Pending
+            ]
+        };
+    }
+}

--- a/tests/MediaIngest.Api.Tests/Program.cs
+++ b/tests/MediaIngest.Api.Tests/Program.cs
@@ -34,6 +34,22 @@ try
     AssertEqual("asset-001", startedStatus.Packages[0].PackageId, "started package id");
     AssertEqual("Succeeded", startedStatus.Packages[0].Status, "started package status");
 
+    var graph = runtimeService.GetWorkflowGraph("package-asset-001")
+        ?? throw new InvalidOperationException("workflow graph endpoint source returned null.");
+    AssertEqual("package-asset-001", graph.WorkflowInstanceId, "graph workflow instance id");
+    AssertEqual("PackageIngestWorkflow", graph.WorkflowName, "graph workflow name");
+    AssertEqual("asset-001", graph.PackageId, "graph package id");
+    AssertEqual(4, graph.Nodes.Count, "graph node count");
+    AssertEqual(3, graph.Edges.Count, "graph edge count");
+    AssertEqual("package-start", graph.Nodes[0].NodeId, "graph first node id");
+    AssertEqual("scan-package", graph.Nodes[1].NodeId, "graph scan node id");
+    AssertEqual("classify-files", graph.Nodes[2].NodeId, "graph classify node id");
+    AssertEqual("dispatch-processing", graph.Nodes[3].NodeId, "graph dispatch node id");
+    AssertEqual("Succeeded", graph.Nodes[0].Status.ToString(), "graph first node status");
+
+    var missingGraph = runtimeService.GetWorkflowGraph("missing-workflow");
+    AssertNull(missingGraph, "missing graph");
+
     AssertTrue(File.Exists(Path.Combine(outputPath, "asset-001", "manifest.json")), "manifest copied");
     AssertTrue(File.Exists(Path.Combine(outputPath, "asset-001", "manifest.json.checksum")), "checksum copied");
     AssertFalse(File.Exists(Path.Combine(outputPath, "asset-001", "source.mov")), "source file not copied");
@@ -76,6 +92,18 @@ try
     AssertEqual(1, conflictStatus.Packages.Count, "conflict package count");
     AssertEqual("Failed", conflictStatus.Packages[0].Status, "conflict package status");
     AssertEqual("existing output", File.ReadAllText(Path.Combine(conflictOutputPackagePath, "manifest.json")), "conflict output preserved");
+
+    await using var apiHost = await IngestApiApplication.StartAsync(inputPath, outputPath);
+    using var apiStartResponse = await apiHost.HttpClient.PostAsync("/api/ingest/start", content: null);
+    AssertEqual(System.Net.HttpStatusCode.Conflict, apiStartResponse.StatusCode, "api host start status");
+    using var graphResponse = await apiHost.HttpClient.GetAsync("/api/workflows/package-asset-001/graph");
+    AssertEqual(System.Net.HttpStatusCode.OK, graphResponse.StatusCode, "graph endpoint status");
+    var graphJson = await graphResponse.Content.ReadAsStringAsync();
+    AssertContains("\"workflowInstanceId\":\"package-asset-001\"", graphJson, "graph endpoint workflow instance id");
+    AssertContains("\"packageId\":\"asset-001\"", graphJson, "graph endpoint package id");
+
+    using var missingGraphResponse = await apiHost.HttpClient.GetAsync("/api/workflows/missing-workflow/graph");
+    AssertEqual(System.Net.HttpStatusCode.NotFound, missingGraphResponse.StatusCode, "missing graph endpoint status");
 
     var stateCountAfterFailure = conflictRuntime.Store.PackageStates.Count;
     var messageCountAfterFailure = conflictRuntime.Store.OutboxMessages.Count;
@@ -151,6 +179,22 @@ static void AssertFalse(bool condition, string name)
     if (condition)
     {
         throw new InvalidOperationException($"{name}: expected false.");
+    }
+}
+
+static void AssertNull<T>(T? actual, string name)
+{
+    if (actual is not null)
+    {
+        throw new InvalidOperationException($"{name}: expected null.");
+    }
+}
+
+static void AssertContains(string expectedSubstring, string actual, string name)
+{
+    if (!actual.Contains(expectedSubstring, StringComparison.Ordinal))
+    {
+        throw new InvalidOperationException($"{name}: expected '{actual}' to contain '{expectedSubstring}'.");
     }
 }
 

--- a/tests/MediaIngest.Workflow.Tests/Program.cs
+++ b/tests/MediaIngest.Workflow.Tests/Program.cs
@@ -1,4 +1,5 @@
 using MediaIngest.Workflow;
+using MediaIngest.Contracts.Workflow;
 
 var request = new PackageIngestRequest(
     PackageId: "package-001",
@@ -38,6 +39,17 @@ AssertEqual(PackageWorkflowLifecycleState.Ready, lifecycle.Events[1].State, "sec
 AssertEqual(PackageWorkflowLifecycleState.Started, lifecycle.Events[2].State, "third lifecycle event");
 AssertEqual(PackageWorkflowLifecycleState.Succeeded, lifecycle.Events[3].State, "fourth lifecycle event");
 
+var succeededGraph = PackageWorkflowGraphProjection.FromLifecycle(lifecycle);
+AssertEqual("package-package-001", succeededGraph.WorkflowInstanceId, "succeeded graph workflow instance id");
+AssertEqual("PackageIngestWorkflow", succeededGraph.WorkflowName, "succeeded graph workflow name");
+AssertEqual("package-001", succeededGraph.PackageId, "succeeded graph package id");
+AssertEqual(4, succeededGraph.Nodes.Count, "succeeded graph node count");
+AssertEqual(3, succeededGraph.Edges.Count, "succeeded graph edge count");
+AssertEqual("package-start", succeededGraph.Nodes[0].NodeId, "succeeded graph start node id");
+AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[0].Status, "succeeded graph start status");
+AssertEqual("scan-package", succeededGraph.Nodes[1].NodeId, "succeeded graph scan node id");
+AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[1].Status, "succeeded graph scan status");
+
 var failingLifecycle = PackageWorkflowLifecycle.Observe(request);
 failingLifecycle.MarkReady(new DateTimeOffset(2026, 5, 3, 12, 4, 0, TimeSpan.Zero));
 failingLifecycle.Start(new DateTimeOffset(2026, 5, 3, 12, 5, 0, TimeSpan.Zero));
@@ -46,6 +58,16 @@ var failed = failingLifecycle.MarkFailed(
     new DateTimeOffset(2026, 5, 3, 12, 6, 0, TimeSpan.Zero));
 AssertEqual(PackageWorkflowLifecycleState.Failed, failed.State, "failed lifecycle state");
 AssertEqual("classification command failed", failed.FailureReason, "failure reason");
+
+var failedGraph = PackageWorkflowGraphProjection.FromLifecycle(failingLifecycle);
+AssertEqual(WorkflowNodeStatus.Failed, failedGraph.Nodes[0].Status, "failed graph start status");
+AssertEqual(WorkflowNodeStatus.Failed, failedGraph.Nodes[1].Status, "failed graph scan status");
+
+var readyGraph = PackageWorkflowGraphProjection.FromLifecycle(PackageWorkflowLifecycle.Observe(request).MarkReady(
+    new DateTimeOffset(2026, 5, 3, 12, 8, 0, TimeSpan.Zero)));
+AssertEqual("pending-package-001", readyGraph.WorkflowInstanceId, "ready graph fallback workflow instance id");
+AssertEqual(WorkflowNodeStatus.Queued, readyGraph.Nodes[0].Status, "ready graph start status");
+AssertEqual(WorkflowNodeStatus.Pending, readyGraph.Nodes[1].Status, "ready graph scan status");
 
 AssertThrows<InvalidOperationException>(
     () => PackageWorkflowLifecycle.Observe(request).Start(new DateTimeOffset(2026, 5, 3, 12, 7, 0, TimeSpan.Zero)),

--- a/web/ingest-control-plane/package-lock.json
+++ b/web/ingest-control-plane/package-lock.json
@@ -16,9 +16,9 @@
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",
+        "@typescript/native-preview": "^7.0.0-dev.20260421.2",
         "@vitejs/plugin-react": "^5.0.4",
         "jsdom": "^27.0.1",
-        "typescript": "^5.9.3",
         "vite": "^7.1.12",
         "vitest": "^3.2.4"
       }
@@ -1604,6 +1604,123 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo.js"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260421.2"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
@@ -2827,20 +2944,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/web/ingest-control-plane/package-lock.json
+++ b/web/ingest-control-plane/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@media-ingest/ingest-control-plane",
       "version": "0.1.0",
       "dependencies": {
+        "mermaid": "^11.14.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -36,6 +37,28 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@antfu/install-pkg/node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "4.1.2",
@@ -383,6 +406,49 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
@@ -984,6 +1050,23 @@
         }
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.1.tgz",
+      "integrity": "sha512-MwzoDtw9rO1x+qfgLTV/IVXsHDBqeYZoMIQC8SfxfYSlaSUG+oWiAcoiB1yajAda6mqblm4/1/w2E8tRu7a7Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.2"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1032,6 +1115,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1570,6 +1662,259 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1582,6 +1927,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -1603,6 +1954,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript/native-preview": {
       "version": "7.0.0-dev.20260421.2",
@@ -1720,6 +2078,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -1855,6 +2223,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -2027,12 +2407,64 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
+      "integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.18.1"
+      },
+      "peerDependencies": {
+        "chevrotain": "^12.0.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -2088,6 +2520,505 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/data-urls": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
@@ -2111,6 +3042,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2147,6 +3084,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2164,6 +3110,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.349",
@@ -2307,6 +3262,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -2348,6 +3309,18 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2356,6 +3329,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2438,6 +3420,66 @@
         "node": ">=6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/langium": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.3.tgz",
+      "integrity": "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.3",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2476,12 +3518,53 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mermaid": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -2491,6 +3574,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
       }
     },
     "node_modules/ms": {
@@ -2526,6 +3621,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -2539,11 +3640,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
@@ -2574,6 +3680,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -2694,6 +3827,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -2738,6 +3877,30 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -2830,6 +3993,12 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
       "license": "MIT"
     },
     "node_modules/symbol-tree": {
@@ -2946,6 +4115,21 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -2975,6 +4159,19 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -3147,6 +4344,55 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/web/ingest-control-plane/package.json
+++ b/web/ingest-control-plane/package.json
@@ -10,6 +10,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "mermaid": "^11.14.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/web/ingest-control-plane/package.json
+++ b/web/ingest-control-plane/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
-    "build": "tsc -b && vite build",
+    "build": "tsgo -b && vite build",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -18,9 +18,9 @@
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
+    "@typescript/native-preview": "^7.0.0-dev.20260421.2",
     "@vitejs/plugin-react": "^5.0.4",
     "jsdom": "^27.0.1",
-    "typescript": "^5.9.3",
     "vite": "^7.1.12",
     "vitest": "^3.2.4"
   }

--- a/web/ingest-control-plane/src/App.test.tsx
+++ b/web/ingest-control-plane/src/App.test.tsx
@@ -3,19 +3,35 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { App } from "./App";
 
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(async (_id: string, diagram: string) => ({
+      svg: `<svg role="img" data-diagram="${encodeURIComponent(diagram)}"></svg>`
+    }))
+  }
+}));
+
 describe("workflow graph control plane", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
-  it("displays mocked workflow nodes and enough state to inspect progress", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ packages: [] }), {
-        headers: { "Content-Type": "application/json" },
-        status: 200
-      })
-    );
+  it("renders the live workflow graph with Mermaid and enough state to inspect progress", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ packages: [] }), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(liveWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      );
 
     render(<App />);
 
@@ -25,28 +41,31 @@ describe("workflow graph control plane", () => {
     expect(screen.getByText(/package PKG-2026-05-03-001/i)).toBeInTheDocument();
     expect(screen.getByText(/5 of 7 nodes progressed/i)).toBeInTheDocument();
 
-    const graph = screen.getByRole("list", { name: /mocked workflow graph/i });
-    const nodes = within(graph).getAllByRole("listitem");
+    const graph = await screen.findByRole("img", { name: /workflow diagram/i });
 
-    expect(nodes).toHaveLength(7);
+    expect(graph).toHaveClass("workflow-diagram__svg");
+    expect(graph.innerHTML).toContain("<svg");
     expect(
-      within(graph).getByRole("listitem", { name: /manifest detected succeeded/i })
+      screen.getByRole("listitem", { name: /manifest detected succeeded/i })
     ).toBeInTheDocument();
     expect(
-      within(graph).getByRole("listitem", { name: /classify package running/i })
+      screen.getByRole("listitem", { name: /classify package running/i })
     ).toBeInTheDocument();
     expect(
-      within(graph).getByRole("listitem", { name: /proxy workflow waiting/i })
+      screen.getByRole("listitem", { name: /proxy workflow waiting/i })
     ).toBeInTheDocument();
     expect(
-      within(graph).getByRole("listitem", { name: /audio essence pending/i })
+      screen.getByRole("listitem", { name: /audio essence pending/i })
     ).toBeInTheDocument();
 
     expect(screen.getByText(/pending: 1/i)).toBeInTheDocument();
     expect(screen.getByText(/running: 1/i)).toBeInTheDocument();
     expect(screen.getByText(/failed: 1/i)).toBeInTheDocument();
     expect(screen.getByText(/waiting: 1/i)).toBeInTheDocument();
-    expect(await screen.findByText(/no packages reported yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/queued: 0/i)).toBeInTheDocument();
+    expect(screen.getByText(/skipped: 0/i)).toBeInTheDocument();
+    expect(screen.getByText(/cancelled: 0/i)).toBeInTheDocument();
+    expect(screen.getByText(/no packages reported yet/i)).toBeInTheDocument();
   });
 
   it("starts local ingest watching when the operator clicks Start ingest", async () => {
@@ -61,6 +80,12 @@ describe("workflow graph control plane", () => {
       .mockResolvedValueOnce(new Response(null, { status: 202 }))
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ packages: [] }), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(liveWorkflowGraphResponse), {
           headers: { "Content-Type": "application/json" },
           status: 200
         })
@@ -86,24 +111,31 @@ describe("workflow graph control plane", () => {
   });
 
   it("shows real package status from the ingest status endpoint separately from the mocked graph", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          packages: [
-            {
-              packageId: "PKG-LOCAL-001",
-              workflowInstanceId: "workflow-local-001",
-              status: "Running",
-              updatedAt: "2026-05-03T18:42:00Z"
-            }
-          ]
-        }),
-        {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            packages: [
+              {
+                packageId: "PKG-LOCAL-001",
+                workflowInstanceId: "workflow-local-001",
+                status: "Running",
+                updatedAt: "2026-05-03T18:42:00Z"
+              }
+            ]
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 200
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(liveWorkflowGraphResponse), {
           headers: { "Content-Type": "application/json" },
           status: 200
-        }
-      )
-    );
+        })
+      );
 
     render(<App />);
 
@@ -116,9 +148,10 @@ describe("workflow graph control plane", () => {
     expect(within(statusPanel).getByText("Running")).toBeInTheDocument();
     expect(within(statusPanel).getByText(/May 3, 2026/)).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith("/api/ingest/status");
-    expect(
-      screen.getByRole("list", { name: /mocked workflow graph/i })
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/graph");
+    });
+    expect(await screen.findByRole("img", { name: /workflow diagram/i })).toBeInTheDocument();
   });
 
   it("refreshes real package status while the operator watches ingest progress", async () => {
@@ -149,6 +182,12 @@ describe("workflow graph control plane", () => {
             status: 200
           }
         )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(liveWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
     );
 
     render(<App />);
@@ -167,7 +206,7 @@ describe("workflow graph control plane", () => {
       name: /real package status/i
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(within(statusPanel).getByText("PKG-LIVE-001")).toBeInTheDocument();
     expect(within(statusPanel).getByText("Succeeded")).toBeInTheDocument();
     expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/ingest/status");
@@ -190,3 +229,90 @@ describe("workflow graph control plane", () => {
     expect(await screen.findByText(/local watcher: error/i)).toBeInTheDocument();
   });
 });
+
+const liveWorkflowGraphResponse = {
+  workflowInstanceId: "workflow-local-001",
+  workflowName: "Package ingest workflow",
+  packageId: "PKG-2026-05-03-001",
+  parentWorkflowInstanceId: null,
+  nodes: [
+    {
+      nodeId: "manifest",
+      displayName: "Manifest detected",
+      kind: "WorkflowStep",
+      status: "Succeeded",
+      workflowInstanceId: "workflow-local-001",
+      packageId: "PKG-2026-05-03-001",
+      workItemId: null,
+      childWorkflowInstanceId: null
+    },
+    {
+      nodeId: "classify",
+      displayName: "Classify package",
+      kind: "Activity",
+      status: "Running",
+      workflowInstanceId: "workflow-local-001",
+      packageId: "PKG-2026-05-03-001",
+      workItemId: null,
+      childWorkflowInstanceId: null
+    },
+    {
+      nodeId: "proxy",
+      displayName: "Proxy workflow",
+      kind: "ChildWorkflow",
+      status: "Waiting",
+      workflowInstanceId: "workflow-local-001",
+      packageId: "PKG-2026-05-03-001",
+      workItemId: null,
+      childWorkflowInstanceId: "workflow-proxy-001"
+    },
+    {
+      nodeId: "audio",
+      displayName: "Audio essence",
+      kind: "WorkItem",
+      status: "Pending",
+      workflowInstanceId: "workflow-local-001",
+      packageId: "PKG-2026-05-03-001",
+      workItemId: "audio-001",
+      childWorkflowInstanceId: null
+    },
+    {
+      nodeId: "subtitle",
+      displayName: "Subtitle sidecar",
+      kind: "WorkItem",
+      status: "Failed",
+      workflowInstanceId: "workflow-local-001",
+      packageId: "PKG-2026-05-03-001",
+      workItemId: "subtitle-001",
+      childWorkflowInstanceId: null
+    },
+    {
+      nodeId: "video",
+      displayName: "Source video work item",
+      kind: "WorkItem",
+      status: "Succeeded",
+      workflowInstanceId: "workflow-local-001",
+      packageId: "PKG-2026-05-03-001",
+      workItemId: "video-001",
+      childWorkflowInstanceId: null
+    },
+    {
+      nodeId: "done",
+      displayName: "Done marker reconciliation",
+      kind: "WorkflowStep",
+      status: "Succeeded",
+      workflowInstanceId: "workflow-local-001",
+      packageId: "PKG-2026-05-03-001",
+      workItemId: null,
+      childWorkflowInstanceId: null
+    }
+  ],
+  edges: [
+    { edgeId: "manifest-classify", sourceNodeId: "manifest", targetNodeId: "classify" },
+    { edgeId: "classify-proxy", sourceNodeId: "classify", targetNodeId: "proxy" },
+    { edgeId: "classify-audio", sourceNodeId: "classify", targetNodeId: "audio" },
+    { edgeId: "classify-subtitle", sourceNodeId: "classify", targetNodeId: "subtitle" },
+    { edgeId: "classify-video", sourceNodeId: "classify", targetNodeId: "video" },
+    { edgeId: "video-done", sourceNodeId: "video", targetNodeId: "done" }
+  ]
+};

--- a/web/ingest-control-plane/src/App.test.tsx
+++ b/web/ingest-control-plane/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { App } from "./App";
@@ -6,6 +6,7 @@ import { App } from "./App";
 describe("workflow graph control plane", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("displays mocked workflow nodes and enough state to inspect progress", async () => {
@@ -57,7 +58,13 @@ describe("workflow graph control plane", () => {
           status: 200
         })
       )
-      .mockResolvedValueOnce(new Response(null, { status: 202 }));
+      .mockResolvedValueOnce(new Response(null, { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ packages: [] }), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      );
 
     render(<App />);
 
@@ -73,6 +80,9 @@ describe("workflow graph control plane", () => {
       });
     });
     expect(await screen.findByText(/local watcher: watching/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenNthCalledWith(3, "/api/ingest/status");
+    });
   });
 
   it("shows real package status from the ingest status endpoint separately from the mocked graph", async () => {
@@ -109,6 +119,58 @@ describe("workflow graph control plane", () => {
     expect(
       screen.getByRole("list", { name: /mocked workflow graph/i })
     ).toBeInTheDocument();
+  });
+
+  it("refreshes real package status while the operator watches ingest progress", async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ packages: [] }), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            packages: [
+              {
+                packageId: "PKG-LIVE-001",
+                workflowInstanceId: "workflow-live-001",
+                status: "Succeeded",
+                updatedAt: "2026-05-03T18:45:00Z"
+              }
+            ]
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 200
+          }
+        )
+    );
+
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText(/no packages reported yet/i)).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    const statusPanel = screen.getByRole("region", {
+      name: /real package status/i
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(within(statusPanel).getByText("PKG-LIVE-001")).toBeInTheDocument();
+    expect(within(statusPanel).getByText("Succeeded")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/ingest/status");
   });
 
   it("shows an error status when local ingest start fails", async () => {

--- a/web/ingest-control-plane/src/App.tsx
+++ b/web/ingest-control-plane/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { mockedWorkflowGraph, summarizeStatuses, type WorkflowNode } from "./workflowGraph";
 
@@ -31,6 +31,19 @@ const statusOrder: WorkflowNode["status"][] = [
   "Waiting",
   "Succeeded"
 ];
+const packageStatusRefreshIntervalMs = 5000;
+
+async function fetchPackageStatuses() {
+  const response = await fetch("/api/ingest/status");
+
+  if (!response.ok) {
+    throw new Error(`Ingest status failed with ${response.status}`);
+  }
+
+  const statusResponse = (await response.json()) as IngestStatusResponse;
+
+  return statusResponse.packages;
+}
 
 function formatStatus(status: WorkflowNode["status"]) {
   return status.toLowerCase();
@@ -70,38 +83,28 @@ export function App() {
     progressedStatuses.has(node.status)
   ).length;
 
-  useEffect(() => {
-    let isCurrent = true;
+  const loadPackageStatuses = useCallback(async () => {
+    try {
+      const packages = await fetchPackageStatuses();
 
-    async function loadPackageStatuses() {
-      try {
-        const response = await fetch("/api/ingest/status");
-
-        if (!response.ok) {
-          throw new Error(`Ingest status failed with ${response.status}`);
-        }
-
-        const statusResponse = (await response.json()) as IngestStatusResponse;
-
-        if (!isCurrent) {
-          return;
-        }
-
-        setPackageStatuses(statusResponse.packages);
-        setPackageStatusLoadState("ready");
-      } catch {
-        if (isCurrent) {
-          setPackageStatusLoadState("error");
-        }
-      }
+      setPackageStatuses(packages);
+      setPackageStatusLoadState("ready");
+    } catch {
+      setPackageStatusLoadState("error");
     }
+  }, []);
 
+  useEffect(() => {
     void loadPackageStatuses();
+    const refreshIntervalId = window.setInterval(
+      () => void loadPackageStatuses(),
+      packageStatusRefreshIntervalMs
+    );
 
     return () => {
-      isCurrent = false;
+      window.clearInterval(refreshIntervalId);
     };
-  }, []);
+  }, [loadPackageStatuses]);
 
   async function startLocalIngest() {
     setLocalWatcherStatus("starting");
@@ -114,6 +117,7 @@ export function App() {
       }
 
       setLocalWatcherStatus("watching");
+      void loadPackageStatuses();
     } catch {
       setLocalWatcherStatus("error");
     }

--- a/web/ingest-control-plane/src/App.tsx
+++ b/web/ingest-control-plane/src/App.tsx
@@ -1,9 +1,17 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import mermaid from "mermaid";
 
-import { mockedWorkflowGraph, summarizeStatuses, type WorkflowNode } from "./workflowGraph";
+import {
+  buildMermaidFlowchart,
+  mockedWorkflowGraph,
+  summarizeStatuses,
+  type WorkflowGraph,
+  type WorkflowNode
+} from "./workflowGraph";
 
 type LocalWatcherStatus = "idle" | "starting" | "watching" | "error";
 type PackageStatusLoadState = "loading" | "ready" | "error";
+type WorkflowGraphLoadState = "ready" | "loading" | "error";
 
 type IngestPackageStatus = {
   packageId: string;
@@ -26,10 +34,13 @@ const progressedStatuses = new Set<WorkflowNode["status"]>([
 
 const statusOrder: WorkflowNode["status"][] = [
   "Pending",
+  "Queued",
   "Running",
   "Failed",
   "Waiting",
-  "Succeeded"
+  "Succeeded",
+  "Skipped",
+  "Cancelled"
 ];
 const packageStatusRefreshIntervalMs = 5000;
 
@@ -43,6 +54,16 @@ async function fetchPackageStatuses() {
   const statusResponse = (await response.json()) as IngestStatusResponse;
 
   return statusResponse.packages;
+}
+
+async function fetchWorkflowGraph(workflowInstanceId: string) {
+  const response = await fetch(`/api/workflows/${encodeURIComponent(workflowInstanceId)}/graph`);
+
+  if (!response.ok) {
+    throw new Error(`Workflow graph failed with ${response.status}`);
+  }
+
+  return (await response.json()) as WorkflowGraph;
 }
 
 function formatStatus(status: WorkflowNode["status"]) {
@@ -71,13 +92,55 @@ function NodeCard({ node }: { node: WorkflowNode }) {
   );
 }
 
+function MermaidWorkflowDiagram({ graph }: { graph: WorkflowGraph }) {
+  const [diagramSvg, setDiagramSvg] = useState("");
+  const diagramSyntax = useMemo(() => buildMermaidFlowchart(graph), [graph]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: "strict",
+      theme: "base"
+    });
+
+    void mermaid
+      .render(`workflow-graph-${graph.workflowInstanceId.replace(/[^A-Za-z0-9_-]/g, "-")}`, diagramSyntax)
+      .then(({ svg }) => {
+        if (!cancelled) {
+          setDiagramSvg(svg);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [diagramSyntax, graph.workflowInstanceId]);
+
+  if (!diagramSvg) {
+    return <p role="status">Rendering workflow diagram...</p>;
+  }
+
+  return (
+    <div
+      role="img"
+      aria-label="workflow diagram"
+      className="workflow-diagram__svg"
+      dangerouslySetInnerHTML={{ __html: diagramSvg }}
+    />
+  );
+}
+
 export function App() {
-  const graph = mockedWorkflowGraph;
   const [localWatcherStatus, setLocalWatcherStatus] =
     useState<LocalWatcherStatus>("idle");
   const [packageStatusLoadState, setPackageStatusLoadState] =
     useState<PackageStatusLoadState>("loading");
+  const [workflowGraphLoadState, setWorkflowGraphLoadState] =
+    useState<WorkflowGraphLoadState>("ready");
   const [packageStatuses, setPackageStatuses] = useState<IngestPackageStatus[]>([]);
+  const [graph, setGraph] = useState<WorkflowGraph>(mockedWorkflowGraph);
   const statusSummary = summarizeStatuses(graph.nodes);
   const progressedNodeCount = graph.nodes.filter((node) =>
     progressedStatuses.has(node.status)
@@ -94,6 +157,19 @@ export function App() {
     }
   }, []);
 
+  const loadWorkflowGraph = useCallback(async (workflowInstanceId: string) => {
+    setWorkflowGraphLoadState("loading");
+
+    try {
+      const workflowGraph = await fetchWorkflowGraph(workflowInstanceId);
+
+      setGraph(workflowGraph);
+      setWorkflowGraphLoadState("ready");
+    } catch {
+      setWorkflowGraphLoadState("error");
+    }
+  }, []);
+
   useEffect(() => {
     void loadPackageStatuses();
     const refreshIntervalId = window.setInterval(
@@ -105,6 +181,14 @@ export function App() {
       window.clearInterval(refreshIntervalId);
     };
   }, [loadPackageStatuses]);
+
+  useEffect(() => {
+    const selectedWorkflowInstanceId = packageStatuses[0]?.workflowInstanceId;
+
+    if (packageStatusLoadState === "ready" && selectedWorkflowInstanceId) {
+      void loadWorkflowGraph(selectedWorkflowInstanceId);
+    }
+  }, [loadWorkflowGraph, packageStatusLoadState, packageStatuses]);
 
   async function startLocalIngest() {
     setLocalWatcherStatus("starting");
@@ -200,9 +284,18 @@ export function App() {
       <section className="graph-section" aria-labelledby="graph-heading">
         <div className="section-heading">
           <h2 id="graph-heading">{graph.workflowName}</h2>
-          <span>Mocked workflow graph data</span>
+          <span>Mermaid workflow graph</span>
         </div>
-        <ol className="workflow-graph" aria-label="mocked workflow graph">
+        {workflowGraphLoadState === "loading" && (
+          <p role="status">Loading workflow graph...</p>
+        )}
+        {workflowGraphLoadState === "error" && (
+          <p role="status">Workflow graph unavailable</p>
+        )}
+        <div className="workflow-diagram">
+          <MermaidWorkflowDiagram graph={graph} />
+        </div>
+        <ol className="workflow-graph" aria-label="workflow graph node status">
           {graph.nodes.map((node) => (
             <NodeCard key={node.nodeId} node={node} />
           ))}

--- a/web/ingest-control-plane/src/styles.css
+++ b/web/ingest-control-plane/src/styles.css
@@ -232,9 +232,27 @@ h2 {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 14px;
-  margin: 0;
+  margin: 18px 0 0;
   padding: 0;
   list-style: none;
+}
+
+.workflow-diagram {
+  overflow: auto;
+  border: 1px solid #d6dde5;
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 14px;
+}
+
+.workflow-diagram__svg {
+  min-width: 720px;
+}
+
+.workflow-diagram__svg svg {
+  display: block;
+  width: 100%;
+  min-height: 260px;
 }
 
 .workflow-node {
@@ -272,9 +290,14 @@ h2 {
   border-left-color: #7b8794;
 }
 
-.workflow-node--pending .workflow-node__status {
+.workflow-node--pending .workflow-node__status,
+.workflow-node--queued .workflow-node__status {
   background: #e5eaf0;
   color: #344054;
+}
+
+.workflow-node--queued {
+  border-left-color: #7b8794;
 }
 
 .workflow-node--running {
@@ -311,6 +334,17 @@ h2 {
 .workflow-node--waiting .workflow-node__status {
   background: #ede9fe;
   color: #5b21b6;
+}
+
+.workflow-node--skipped,
+.workflow-node--cancelled {
+  border-left-color: #8a94a3;
+}
+
+.workflow-node--skipped .workflow-node__status,
+.workflow-node--cancelled .workflow-node__status {
+  background: #eef2f5;
+  color: #4b5563;
 }
 
 @media (max-width: 900px) {

--- a/web/ingest-control-plane/src/vite-env.d.ts
+++ b/web/ingest-control-plane/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/web/ingest-control-plane/src/workflowGraph.test.ts
+++ b/web/ingest-control-plane/src/workflowGraph.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMermaidFlowchart,
+  mockedWorkflowGraph,
+  workflowStatusPalette
+} from "./workflowGraph";
+
+describe("workflow graph mermaid syntax", () => {
+  it("builds flowchart syntax with node classes and target-status link colors", () => {
+    const diagram = buildMermaidFlowchart(mockedWorkflowGraph);
+
+    expect(diagram).toContain("flowchart LR");
+    expect(diagram).toContain('manifest["Manifest detected"]:::succeeded');
+    expect(diagram).toContain('classify["Classify package"]:::running');
+    expect(diagram).toContain('proxy["Proxy workflow"]:::waiting');
+    expect(diagram).toContain("manifest --> scan");
+    expect(diagram).toContain(
+      `linkStyle 1 stroke:${workflowStatusPalette.Running.stroke}`
+    );
+    expect(diagram).toContain(
+      `linkStyle 3 stroke:${workflowStatusPalette.Waiting.stroke}`
+    );
+  });
+
+  it("escapes labels and sanitizes node identifiers for Mermaid", () => {
+    const diagram = buildMermaidFlowchart({
+      workflowInstanceId: "workflow-escape",
+      workflowName: "Escaped workflow",
+      packageId: "package-escape",
+      nodes: [
+        {
+          nodeId: "scan.package/1",
+          displayName: 'Scan "package" [ready]',
+          kind: "Activity",
+          status: "Succeeded",
+          workflowInstanceId: "workflow-escape",
+          packageId: "package-escape"
+        },
+        {
+          nodeId: "classify.package/1",
+          displayName: "Classify package",
+          kind: "Activity",
+          status: "Queued",
+          workflowInstanceId: "workflow-escape",
+          packageId: "package-escape"
+        }
+      ],
+      edges: [
+        {
+          edgeId: "scan-classify",
+          sourceNodeId: "scan.package/1",
+          targetNodeId: "classify.package/1"
+        }
+      ]
+    });
+
+    expect(diagram).toContain('scan_package_1["Scan #quot;package#quot; #91;ready#93;"]:::succeeded');
+    expect(diagram).toContain("scan_package_1 --> classify_package_1");
+    expect(diagram).toContain(
+      `linkStyle 0 stroke:${workflowStatusPalette.Queued.stroke}`
+    );
+  });
+});

--- a/web/ingest-control-plane/src/workflowGraph.ts
+++ b/web/ingest-control-plane/src/workflowGraph.ts
@@ -40,6 +40,23 @@ export type WorkflowGraph = {
   edges: WorkflowEdge[];
 };
 
+type WorkflowStatusStyle = {
+  fill: string;
+  stroke: string;
+  text: string;
+};
+
+export const workflowStatusPalette: Record<WorkflowNodeStatus, WorkflowStatusStyle> = {
+  Pending: { fill: "#e5eaf0", stroke: "#7b8794", text: "#344054" },
+  Queued: { fill: "#e5eaf0", stroke: "#7b8794", text: "#344054" },
+  Running: { fill: "#dbeafe", stroke: "#2563eb", text: "#1e3a8a" },
+  Succeeded: { fill: "#d9f0e4", stroke: "#18865b", text: "#07583d" },
+  Failed: { fill: "#ffedd5", stroke: "#c2410c", text: "#9a3412" },
+  Waiting: { fill: "#ede9fe", stroke: "#8b5cf6", text: "#5b21b6" },
+  Skipped: { fill: "#eef2f5", stroke: "#8a94a3", text: "#4b5563" },
+  Cancelled: { fill: "#eef2f5", stroke: "#8a94a3", text: "#4b5563" }
+};
+
 export const mockedWorkflowGraph: WorkflowGraph = {
   workflowInstanceId: "wf-pkg-2026-05-03-001",
   workflowName: "Package ingest workflow",
@@ -133,4 +150,55 @@ export function summarizeStatuses(nodes: WorkflowNode[]) {
       Cancelled: 0
     }
   );
+}
+
+export function buildMermaidFlowchart(graph: WorkflowGraph) {
+  const nodeIdMap = new Map(
+    graph.nodes.map((node) => [node.nodeId, sanitizeMermaidId(node.nodeId)])
+  );
+  const lines = ["flowchart LR"];
+
+  for (const node of graph.nodes) {
+    const mermaidId = nodeIdMap.get(node.nodeId) ?? sanitizeMermaidId(node.nodeId);
+    lines.push(
+      `  ${mermaidId}["${escapeMermaidLabel(node.displayName)}"]:::${formatStatusClass(node.status)}`
+    );
+  }
+
+  graph.edges.forEach((edge) => {
+    const sourceId = nodeIdMap.get(edge.sourceNodeId) ?? sanitizeMermaidId(edge.sourceNodeId);
+    const targetId = nodeIdMap.get(edge.targetNodeId) ?? sanitizeMermaidId(edge.targetNodeId);
+    lines.push(`  ${sourceId} --> ${targetId}`);
+  });
+
+  for (const [status, style] of Object.entries(workflowStatusPalette)) {
+    lines.push(
+      `  classDef ${formatStatusClass(status as WorkflowNodeStatus)} fill:${style.fill},stroke:${style.stroke},color:${style.text},stroke-width:2px`
+    );
+  }
+
+  graph.edges.forEach((edge, index) => {
+    const target = graph.nodes.find((node) => node.nodeId === edge.targetNodeId);
+    const style = workflowStatusPalette[target?.status ?? "Pending"];
+    lines.push(`  linkStyle ${index} stroke:${style.stroke},stroke-width:2px`);
+  });
+
+  return lines.join("\n");
+}
+
+function sanitizeMermaidId(nodeId: string) {
+  const sanitized = nodeId.replace(/[^A-Za-z0-9_]/g, "_");
+
+  return /^[A-Za-z_]/.test(sanitized) ? sanitized : `node_${sanitized}`;
+}
+
+function escapeMermaidLabel(label: string) {
+  return label
+    .replace(/"/g, "#quot;")
+    .replace(/\[/g, "#91;")
+    .replace(/\]/g, "#93;");
+}
+
+function formatStatusClass(status: WorkflowNodeStatus) {
+  return status.toLowerCase();
 }


### PR DESCRIPTION
## Summary

- Refresh the live package status panel every 5 seconds and immediately after `Start ingest` succeeds.
- Move the control-plane build from the JavaScript `typescript` compiler to the TypeScript 7 native preview `tsgo` compiler.
- Add `GET /api/workflows/{workflowInstanceId}/graph` and project package workflow lifecycle/status into `WorkflowGraphDto` nodes and edges.
- Add Mermaid as the control-plane graph renderer, generate Mermaid flowchart syntax from graph DTOs, and color nodes plus links by workflow status.
- Keep the existing local demo contract unchanged: `input/<package-id>/...` still produces `output/<package-id>/...`.

Refs #33

## Validation

- `npm test` from `web/ingest-control-plane` passed: 3 files, 8 tests.
- `npm run build` from `web/ingest-control-plane` passed using `tsgo -b && vite build`; Vite emitted a Mermaid bundle-size warning.
- `make test-dotnet-api` passed with real loopback validation for the graph endpoint.
- `make test-dotnet-workflow` passed.
- `make validate` passed, including docs checks, GitHub helper tests, .NET build, and smoke tests.
- `git diff --check` passed.

## Risk

- Mermaid increases the UI bundle size; the production build passes but Vite warns that some chunks exceed 500 kB after minification.
- The graph projection is intentionally lightweight and derives current node statuses from in-process package lifecycle/status state. Node detail, timeline, and log-backed status sources remain future work.
- TypeScript 7 is currently consumed through `@typescript/native-preview`, so future package updates may expose native-preview compatibility changes before TS7 is published as the stable `typescript` package.

## Follow-up

- Expand workflow graph data with node detail, timeline, and log-backed status sources.
- Add nested workflow drilldown and node logs in later USER-STORY-13 through USER-STORY-15 slices.