### PR TITLE
USER-STORY-2: Gate ready packages on manifest checksum

### DIFF
--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -8,7 +8,7 @@ ownership lanes. Keep detailed implementation tasks in `docs/plans/tasks`.
 | ID | Title | Milestone | Domain | Primary lane | Status |
 | --- | --- | --- | --- | --- | --- |
 | USER-STORY-1 | Watch ingest mount | MILESTONE-3 | Ingest package | Mount | In Progress |
-| USER-STORY-2 | Start only when manifest is ready | MILESTONE-3 | Manifest | Mount | Planned |
+| USER-STORY-2 | Start only when manifest is ready | MILESTONE-3 | Manifest | Mount | Complete |
 | USER-STORY-3 | Ingest all discovered files | MILESTONE-3 | Ingest package | Mount | In Progress |
 | USER-STORY-4 | Reconcile on done marker | MILESTONE-3 | Done marker | Mount | Planned |
 | USER-STORY-5 | Classify media essences | MILESTONE-3 | Essence classification | Essence | Planned |

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -73,6 +73,9 @@
   proxied to that API, press **Start ingest** to begin watching, then add
   `manifest.json` plus `manifest.json.checksum` under `input/<asset>/` and
   expect both manifest files under `output/<asset>/`.
+- USER-STORY-2 manifest readiness now keeps package observation separate from
+  start readiness and requires both `manifest.json` and
+  `manifest.json.checksum` before package work may begin.
 - USER-STORY-3 physical file enumeration now scans ready package directories
   recursively in the watcher without wiring discovery into copy behavior.
 - USER-STORY-12 now has a Mermaid-backed control-plane graph path: the API

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -5,6 +5,9 @@ messages or paste command output unless it explains a decision.
 
 ## 2026-05-04
 
+- Completed the USER-STORY-2 Mount readiness gate so watcher code can observe
+  package directories while exposing only manifest-plus-checksum packages as
+  ready to start.
 - Replaced the tracked active worktree ledger with ignored local
   `.worktrees/state/<worktree-slug>.md` records and updated planning and
   automation docs to keep worktree state out of commits.

--- a/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
@@ -12,6 +12,17 @@ public sealed class IngestMountScanner
             .ToArray();
     }
 
+    public IReadOnlyList<IngestPackageCandidate> FindReadyPackageCandidates(
+        string ingestMountPath,
+        ManifestReadinessGate readinessGate)
+    {
+        ArgumentNullException.ThrowIfNull(readinessGate);
+
+        return FindPackageCandidates(ingestMountPath)
+            .Where(readinessGate.IsReady)
+            .ToArray();
+    }
+
     public IReadOnlyList<IngestPackageFile> FindPackageFiles(IngestPackageCandidate candidate)
     {
         ArgumentNullException.ThrowIfNull(candidate);

--- a/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
@@ -32,6 +32,22 @@ try
     AssertFalse(readinessGate.IsReady(new IngestPackageCandidate(secondPackagePath)), "empty package readiness");
     AssertTrue(readinessGate.IsReady(new IngestPackageCandidate(readyPackagePath)), "manifest and checksum package readiness");
 
+    var readyCandidates = scanner.FindReadyPackageCandidates(mountPath, readinessGate);
+
+    AssertSequenceEqual(
+        [readyPackagePath],
+        readyCandidates.Select(candidate => candidate.PackagePath).ToArray(),
+        "ready package candidate paths before checksum arrival");
+
+    File.WriteAllText(Path.Combine(firstPackagePath, "manifest.json.checksum"), "not-a-real-checksum");
+
+    var readyCandidatesAfterChecksumArrival = scanner.FindReadyPackageCandidates(mountPath, readinessGate);
+
+    AssertSequenceEqual(
+        [firstPackagePath, readyPackagePath],
+        readyCandidatesAfterChecksumArrival.Select(candidate => candidate.PackagePath).ToArray(),
+        "ready package candidate paths after checksum arrival");
+
     var discoveredFiles = scanner.FindPackageFiles(new IngestPackageCandidate(readyPackagePath));
 
     AssertSequenceEqual(


### PR DESCRIPTION
## Summary
- Add a watcher-level ready-candidate scan that observes package directories separately from packages that may start work.
- Keep manifest readiness gated on both `manifest.json` and `manifest.json.checksum` while preserving physical file discovery as the source of package files.
- Mark USER-STORY-2 complete in product/status docs and record the work-log entry.

Closes #12

## Validation
- RED: `make test-dotnet-watcher` failed before production changes with CS1061 for missing `IngestMountScanner.FindReadyPackageCandidates`.
- GREEN: `make test-dotnet-watcher` passed after implementation.
- `make test-dotnet-watcher` passed after rebase.
- `make validate` passed after rebase.
- `git diff --check` passed after rebase.

## Risk
- Low: change is limited to watcher filtering over existing package candidate discovery and existing `ManifestReadinessGate` behavior.

## Follow-up Notes
- The API runtime already filters candidates through manifest readiness; future watcher loop work can call the new ready-candidate API directly when that integration is revisited.