### PR TITLE
USER-STORY-5: Classify media essences

### DIFF
--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -11,7 +11,7 @@ ownership lanes. Keep detailed implementation tasks in `docs/plans/tasks`.
 | USER-STORY-2 | Start only when manifest is ready | MILESTONE-3 | Manifest | Mount | Planned |
 | USER-STORY-3 | Ingest all discovered files | MILESTONE-3 | Ingest package | Mount | In Progress |
 | USER-STORY-4 | Reconcile on done marker | MILESTONE-3 | Done marker | Mount | Planned |
-| USER-STORY-5 | Classify media essences | MILESTONE-3 | Essence classification | Essence | Planned |
+| USER-STORY-5 | Classify media essences | MILESTONE-3 | Essence classification | Essence | Completed |
 | USER-STORY-6 | Route work through ASB command topics | MILESTONE-4 | Messaging | Courier | Planned |
 | USER-STORY-7 | Execute generic media commands | MILESTONE-6 | Command execution | Essence | In Progress |
 | USER-STORY-8 | Use transactional outbox | MILESTONE-4 | Outbox | Courier | In Progress |

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -75,6 +75,9 @@
   expect both manifest files under `output/<asset>/`.
 - USER-STORY-3 physical file enumeration now scans ready package directories
   recursively in the watcher without wiring discovery into copy behavior.
+- USER-STORY-5 essence classification now maps discovered media extensions to
+  video/source, text, audio, or other categories, and watcher discovery exposes
+  file-size metadata for routing policy inputs.
 - USER-STORY-12 now has a Mermaid-backed control-plane graph path: the API
   exposes workflow graph DTOs by workflow instance, workflow lifecycle state
   projects to graph node statuses, and the React UI renders Mermaid diagrams

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -112,6 +112,8 @@ messages or paste command output unless it explains a decision.
 - Added Mount file discovery for USER-STORY-3 so the watcher enumerates every
   physical file under a ready package directory with stable package-relative
   paths, without wiring discovery into copy, persistence, or workflow behavior.
+- Added USER-STORY-5 Essence classification for video/source, text, audio, and
+  other files, plus watcher file-size metadata on discovered package files.
 - Added the USER-STORY-12 Mermaid workflow graph slice: workflow lifecycle
   state now projects to graph DTO statuses, `/api/workflows/{id}/graph` serves
   those DTOs, and the React control plane renders Mermaid diagrams from live

--- a/src/MediaIngest.Essence/Classification/EssenceClassifier.cs
+++ b/src/MediaIngest.Essence/Classification/EssenceClassifier.cs
@@ -1,0 +1,48 @@
+namespace MediaIngest.Essence.Classification;
+
+public static class EssenceClassifier
+{
+    private static readonly HashSet<string> VideoSourceExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".mov",
+        ".mxf",
+        ".mp4",
+    };
+
+    private static readonly HashSet<string> TextExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".srt",
+        ".txt",
+        ".vtt",
+    };
+
+    private static readonly HashSet<string> AudioExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".mp3",
+        ".wav",
+    };
+
+    public static EssenceType Classify(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var extension = Path.GetExtension(filePath);
+
+        if (VideoSourceExtensions.Contains(extension))
+        {
+            return EssenceType.VideoSource;
+        }
+
+        if (TextExtensions.Contains(extension))
+        {
+            return EssenceType.Text;
+        }
+
+        if (AudioExtensions.Contains(extension))
+        {
+            return EssenceType.Audio;
+        }
+
+        return EssenceType.Other;
+    }
+}

--- a/src/MediaIngest.Essence/Classification/EssenceType.cs
+++ b/src/MediaIngest.Essence/Classification/EssenceType.cs
@@ -1,0 +1,9 @@
+namespace MediaIngest.Essence.Classification;
+
+public enum EssenceType
+{
+    VideoSource,
+    Text,
+    Audio,
+    Other,
+}

--- a/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
@@ -22,7 +22,8 @@ public sealed class IngestMountScanner
             .Select(filePath => new IngestPackageFile(
                 packagePath,
                 Path.GetFullPath(filePath),
-                Path.GetRelativePath(packagePath, filePath)))
+                Path.GetRelativePath(packagePath, filePath),
+                new FileInfo(filePath).Length))
             .OrderBy(file => file.PackageRelativePath, StringComparer.Ordinal)
             .ToArray();
     }

--- a/src/MediaIngest.Worker.Watcher/IngestPackageFile.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestPackageFile.cs
@@ -3,4 +3,5 @@ namespace MediaIngest.Worker.Watcher;
 public sealed record IngestPackageFile(
     string PackagePath,
     string FilePath,
-    string PackageRelativePath);
+    string PackageRelativePath,
+    long FileSizeBytes);

--- a/tests/MediaIngest.Essence.Tests/Program.cs
+++ b/tests/MediaIngest.Essence.Tests/Program.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using MediaIngest.Essence.Classification;
 using MediaIngest.Essence.Checksums;
 
 var workspace = Path.Combine(Path.GetTempPath(), "media-ingest-essence-tests", Guid.NewGuid().ToString("N"));
@@ -45,7 +46,17 @@ try
     AssertEqual(new string('0', 64), mismatchedResult.ExpectedChecksumHex, "mismatched expected checksum");
     AssertEqual(expectedChecksum, mismatchedResult.ActualChecksumHex, "mismatched actual checksum");
 
-    Console.WriteLine("MediaIngest essence checksum tests passed.");
+    AssertEqual(EssenceType.VideoSource, EssenceClassifier.Classify("media/clip.mov"), "mov classifies as video source");
+    AssertEqual(EssenceType.VideoSource, EssenceClassifier.Classify("media/clip.mxf"), "mxf classifies as video source");
+    AssertEqual(EssenceType.VideoSource, EssenceClassifier.Classify("media/clip.MP4"), "mp4 classifies as video source");
+    AssertEqual(EssenceType.Text, EssenceClassifier.Classify("sidecars/captions.srt"), "srt classifies as text");
+    AssertEqual(EssenceType.Text, EssenceClassifier.Classify("sidecars/notes.txt"), "txt classifies as text");
+    AssertEqual(EssenceType.Text, EssenceClassifier.Classify("sidecars/captions.vtt"), "vtt classifies as text");
+    AssertEqual(EssenceType.Audio, EssenceClassifier.Classify("audio/dialogue.mp3"), "mp3 classifies as audio");
+    AssertEqual(EssenceType.Audio, EssenceClassifier.Classify("audio/dialogue.wav"), "wav classifies as audio");
+    AssertEqual(EssenceType.Other, EssenceClassifier.Classify("metadata/manifest.json"), "unknown extension classifies as other");
+
+    Console.WriteLine("MediaIngest essence tests passed.");
 }
 finally
 {

--- a/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
@@ -48,6 +48,16 @@ try
         discoveredFiles.Select(file => Path.Combine(readyPackagePath, file.PackageRelativePath)).ToArray(),
         discoveredFiles.Select(file => file.FilePath).ToArray(),
         "ready package discovered full paths");
+
+    var discoveredFileByRelativePath = discoveredFiles.ToDictionary(file => file.PackageRelativePath, StringComparer.Ordinal);
+    AssertEqual(
+        new FileInfo(Path.Combine(readyPackageMediaPath, "clip.mov")).Length,
+        discoveredFileByRelativePath[Path.Combine("media", "clip.mov")].FileSizeBytes,
+        "ready package discovered media file size");
+    AssertEqual(
+        new FileInfo(Path.Combine(readyPackageSidecarPath, "clip.en.srt")).Length,
+        discoveredFileByRelativePath[Path.Combine("sidecars", "captions", "clip.en.srt")].FileSizeBytes,
+        "ready package discovered sidecar file size");
 }
 finally
 {


### PR DESCRIPTION
## Summary

- Adds an Essence classifier that maps `.mov`, `.mxf`, and `.mp4` to video/source; `.srt`, `.txt`, and `.vtt` to text; `.mp3` and `.wav` to audio; and unknown extensions to other.
- Adds file-size metadata to watcher-discovered package files.
- Updates story/status/work-log docs for USER-STORY-5 completion.

Closes #15

## Validation

- RED: `dotnet run --project tests/MediaIngest.Essence.Tests/MediaIngest.Essence.Tests.csproj` failed because `MediaIngest.Essence.Classification` did not exist.
- RED: `dotnet run --project tests/MediaIngest.Worker.Watcher.Tests/MediaIngest.Worker.Watcher.Tests.csproj` failed because `IngestPackageFile.FileSizeBytes` did not exist.
- GREEN: `dotnet run --project tests/MediaIngest.Essence.Tests/MediaIngest.Essence.Tests.csproj` passed.
- GREEN: `dotnet run --project tests/MediaIngest.Worker.Watcher.Tests/MediaIngest.Worker.Watcher.Tests.csproj` passed.
- `make test-dotnet-watcher` passed.
- `make test-dotnet` passed.
- `make validate` passed.
- `git diff --check` passed.

## Risk

Low. The classifier is local to the Essence assembly and watcher discovery only adds size metadata to the existing record shape. Persistence, workflow, outbox, UI, and deployment paths are untouched.

## Follow-up Notes

- This slice intentionally does not wire classification into persistence, workflow command routing, or command-runner dispatch.
- `make test-dotnet` currently does not include the Essence smoke project, so the focused Essence command is listed separately above.