### PR TITLE
USER-STORY-9: Connect workflow lifecycle projection

### DIFF
--- a/src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs
@@ -4,7 +4,16 @@ namespace MediaIngest.Workflow;
 
 public static class PackageWorkflowGraphProjection
 {
-    private static readonly PreparedChildWork[] PackageStartPlan =
+    private static readonly PreparedChildWork[] PackageLifecyclePlan =
+    [
+        new("scan-package", "Package scan"),
+        new("classify-files", "Classify discovered files"),
+        new("dispatch-processing", "Dispatch processing work"),
+        new("reconcile-package", "Reconcile package"),
+        new("finalize-package", "Finalize package")
+    ];
+
+    private static readonly PreparedChildWork[] PackageBusinessStatusPlan =
     [
         new("scan-package", "Package scan"),
         new("classify-files", "Classify discovered files"),
@@ -29,7 +38,8 @@ public static class PackageWorkflowGraphProjection
         return CreateGraph(
             snapshot.PackageId,
             workflowInstanceId,
-            MapLifecycleState(snapshot.State));
+            MapLifecycleState(snapshot.State),
+            PackageLifecyclePlan);
     }
 
     public static WorkflowGraphDto FromPackageStatus(
@@ -52,15 +62,20 @@ public static class PackageWorkflowGraphProjection
             throw new ArgumentException("Package status is required.", nameof(status));
         }
 
-        return CreateGraph(packageId, workflowInstanceId, MapPackageStatus(status));
+        return CreateGraph(
+            packageId,
+            workflowInstanceId,
+            MapPackageStatus(status),
+            PackageBusinessStatusPlan);
     }
 
     private static WorkflowGraphDto CreateGraph(
         string packageId,
         string workflowInstanceId,
-        WorkflowNodeStatus packageStatus)
+        WorkflowNodeStatus packageStatus,
+        IReadOnlyList<PreparedChildWork> workflowPlan)
     {
-        var childStatuses = MapChildStatuses(packageStatus);
+        var childStatuses = MapChildStatuses(packageStatus, workflowPlan.Count);
         var nodes = new List<WorkflowNodeDto>
         {
             new(
@@ -74,7 +89,7 @@ public static class PackageWorkflowGraphProjection
                 ChildWorkflowInstanceId: null)
         };
 
-        nodes.AddRange(PackageStartPlan.Select((work, index) => new WorkflowNodeDto(
+        nodes.AddRange(workflowPlan.Select((work, index) => new WorkflowNodeDto(
             NodeId: work.NodeId,
             DisplayName: work.DisplayName,
             Kind: WorkflowNodeKind.Activity,
@@ -84,12 +99,7 @@ public static class PackageWorkflowGraphProjection
             WorkItemId: work.NodeId,
             ChildWorkflowInstanceId: null)));
 
-        var edges = new[]
-        {
-            new WorkflowEdgeDto("package-start-scan-package", "package-start", "scan-package"),
-            new WorkflowEdgeDto("scan-package-classify-files", "scan-package", "classify-files"),
-            new WorkflowEdgeDto("classify-files-dispatch-processing", "classify-files", "dispatch-processing")
-        };
+        var edges = CreateEdges(workflowPlan);
 
         return new WorkflowGraphDto(
             WorkflowInstanceId: workflowInstanceId,
@@ -124,40 +134,36 @@ public static class PackageWorkflowGraphProjection
         };
     }
 
-    private static WorkflowNodeStatus[] MapChildStatuses(WorkflowNodeStatus packageStatus)
+    private static WorkflowEdgeDto[] CreateEdges(IReadOnlyList<PreparedChildWork> workflowPlan)
     {
-        return packageStatus switch
+        var edges = new List<WorkflowEdgeDto>(workflowPlan.Count);
+        var previousNodeId = "package-start";
+
+        foreach (var work in workflowPlan)
         {
-            WorkflowNodeStatus.Succeeded =>
-            [
-                WorkflowNodeStatus.Succeeded,
-                WorkflowNodeStatus.Succeeded,
-                WorkflowNodeStatus.Succeeded
-            ],
-            WorkflowNodeStatus.Failed =>
-            [
-                WorkflowNodeStatus.Failed,
-                WorkflowNodeStatus.Failed,
-                WorkflowNodeStatus.Failed
-            ],
-            WorkflowNodeStatus.Running =>
-            [
-                WorkflowNodeStatus.Running,
-                WorkflowNodeStatus.Pending,
-                WorkflowNodeStatus.Pending
-            ],
-            WorkflowNodeStatus.Queued =>
-            [
-                WorkflowNodeStatus.Pending,
-                WorkflowNodeStatus.Pending,
-                WorkflowNodeStatus.Pending
-            ],
-            _ =>
-            [
-                WorkflowNodeStatus.Pending,
-                WorkflowNodeStatus.Pending,
-                WorkflowNodeStatus.Pending
-            ]
-        };
+            edges.Add(new WorkflowEdgeDto(
+                EdgeId: $"{previousNodeId}-{work.NodeId}",
+                SourceNodeId: previousNodeId,
+                TargetNodeId: work.NodeId));
+            previousNodeId = work.NodeId;
+        }
+
+        return [.. edges];
+    }
+
+    private static WorkflowNodeStatus[] MapChildStatuses(WorkflowNodeStatus packageStatus, int childCount)
+    {
+        var childStatuses = Enumerable.Repeat(WorkflowNodeStatus.Pending, childCount).ToArray();
+
+        if (packageStatus is WorkflowNodeStatus.Succeeded or WorkflowNodeStatus.Failed)
+        {
+            Array.Fill(childStatuses, packageStatus);
+        }
+        else if (packageStatus == WorkflowNodeStatus.Running && childStatuses.Length > 0)
+        {
+            childStatuses[0] = WorkflowNodeStatus.Running;
+        }
+
+        return childStatuses;
     }
 }

--- a/src/MediaIngest.Workflow/PackageWorkflowStarter.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowStarter.cs
@@ -8,7 +8,9 @@ public sealed class PackageWorkflowStarter
     [
         new("scan-package", "Package scan"),
         new("classify-files", "Classify discovered files"),
-        new("dispatch-processing", "Dispatch processing work")
+        new("dispatch-processing", "Dispatch processing work"),
+        new("reconcile-package", "Reconcile package"),
+        new("finalize-package", "Finalize package")
     ];
 
     public PackageWorkflowStart Start(PackageIngestRequest request)

--- a/tests/MediaIngest.Workflow.Tests/Program.cs
+++ b/tests/MediaIngest.Workflow.Tests/Program.cs
@@ -14,10 +14,12 @@ AssertEqual("package-001", start.PackageId, "package id");
 AssertEqual("PackageIngestWorkflow", start.WorkflowName, "workflow name");
 AssertEqual("package-package-001", start.WorkflowInstanceId, "workflow instance id");
 AssertEqual("correlation-001", start.CorrelationId, "correlation id");
-AssertEqual(3, start.PreparedChildWork.Count, "prepared child work count");
+AssertEqual(5, start.PreparedChildWork.Count, "prepared child work count");
 AssertEqual("scan-package", start.PreparedChildWork[0].NodeId, "scan node id");
 AssertEqual("classify-files", start.PreparedChildWork[1].NodeId, "classify node id");
 AssertEqual("dispatch-processing", start.PreparedChildWork[2].NodeId, "dispatch node id");
+AssertEqual("reconcile-package", start.PreparedChildWork[3].NodeId, "reconcile node id");
+AssertEqual("finalize-package", start.PreparedChildWork[4].NodeId, "finalize node id");
 
 var lifecycle = PackageWorkflowLifecycle.Observe(request);
 AssertEqual(PackageWorkflowLifecycleState.Observed, lifecycle.Current.State, "observed lifecycle state");
@@ -43,12 +45,16 @@ var succeededGraph = PackageWorkflowGraphProjection.FromLifecycle(lifecycle);
 AssertEqual("package-package-001", succeededGraph.WorkflowInstanceId, "succeeded graph workflow instance id");
 AssertEqual("PackageIngestWorkflow", succeededGraph.WorkflowName, "succeeded graph workflow name");
 AssertEqual("package-001", succeededGraph.PackageId, "succeeded graph package id");
-AssertEqual(4, succeededGraph.Nodes.Count, "succeeded graph node count");
-AssertEqual(3, succeededGraph.Edges.Count, "succeeded graph edge count");
+AssertEqual(6, succeededGraph.Nodes.Count, "succeeded graph node count");
+AssertEqual(5, succeededGraph.Edges.Count, "succeeded graph edge count");
 AssertEqual("package-start", succeededGraph.Nodes[0].NodeId, "succeeded graph start node id");
 AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[0].Status, "succeeded graph start status");
 AssertEqual("scan-package", succeededGraph.Nodes[1].NodeId, "succeeded graph scan node id");
 AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[1].Status, "succeeded graph scan status");
+AssertEqual("reconcile-package", succeededGraph.Nodes[4].NodeId, "succeeded graph reconcile node id");
+AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[4].Status, "succeeded graph reconcile status");
+AssertEqual("finalize-package", succeededGraph.Nodes[5].NodeId, "succeeded graph finalization node id");
+AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[5].Status, "succeeded graph finalization status");
 
 var failingLifecycle = PackageWorkflowLifecycle.Observe(request);
 failingLifecycle.MarkReady(new DateTimeOffset(2026, 5, 3, 12, 4, 0, TimeSpan.Zero));
@@ -68,6 +74,13 @@ var readyGraph = PackageWorkflowGraphProjection.FromLifecycle(PackageWorkflowLif
 AssertEqual("pending-package-001", readyGraph.WorkflowInstanceId, "ready graph fallback workflow instance id");
 AssertEqual(WorkflowNodeStatus.Queued, readyGraph.Nodes[0].Status, "ready graph start status");
 AssertEqual(WorkflowNodeStatus.Pending, readyGraph.Nodes[1].Status, "ready graph scan status");
+
+var businessStatusGraph = PackageWorkflowGraphProjection.FromPackageStatus(
+    packageId: "package-001",
+    workflowInstanceId: "package-package-001",
+    status: "Succeeded");
+AssertEqual(4, businessStatusGraph.Nodes.Count, "business status graph node count");
+AssertEqual("dispatch-processing", businessStatusGraph.Nodes[3].NodeId, "business status graph final visible node");
 
 AssertThrows<InvalidOperationException>(
     () => PackageWorkflowLifecycle.Observe(request).Start(new DateTimeOffset(2026, 5, 3, 12, 7, 0, TimeSpan.Zero)),


### PR DESCRIPTION
## Summary

- Extends the workflow lifecycle start plan with reconciliation and finalization steps after scan, classification, and processing dispatch.
- Projects full lifecycle snapshots as a five-step package orchestration graph while keeping persisted package business-status projections on their existing three-step shape.
- Adds workflow smoke coverage for the full runtime lifecycle graph and the runtime/business projection split.

Refs #19

## Validation

- dotnet run --project tests/MediaIngest.Workflow.Tests/MediaIngest.Workflow.Tests.csproj failed first as expected: prepared child work count expected 5, got 3.
- dotnet run --project tests/MediaIngest.Workflow.Tests/MediaIngest.Workflow.Tests.csproj passed after implementation.
- make test-dotnet-workflow passed.
- make validate passed.
- git diff --check passed.

## Risk

Low. Changes are confined to src/MediaIngest.Workflow and workflow tests. The existing package-status projection used by persisted business state is intentionally preserved to avoid crossing persistence/API ownership boundaries.

## Follow-up Notes

- Courier, Vault, and deployment wiring for actual Dapr runtime execution remain separate lanes under USER-STORY-9.