### PR TITLE
USER-STORY-8: Harden outbox dispatch idempotency

### DIFF
--- a/src/MediaIngest.Persistence/IIngestPersistenceStore.cs
+++ b/src/MediaIngest.Persistence/IIngestPersistenceStore.cs
@@ -6,6 +6,11 @@ public interface IIngestPersistenceStore
 
     Task<IReadOnlyList<OutboxMessage>> GetPendingOutboxMessagesAsync(CancellationToken cancellationToken = default);
 
+    Task<IReadOnlyList<OutboxMessage>> ClaimPendingOutboxMessagesAsync(
+        DateTimeOffset claimedAt,
+        DateTimeOffset claimExpiresAt,
+        CancellationToken cancellationToken = default);
+
     Task MarkOutboxMessageDispatchedAsync(
         string messageId,
         DateTimeOffset dispatchedAt,

--- a/src/MediaIngest.Persistence/InMemoryIngestPersistenceStore.cs
+++ b/src/MediaIngest.Persistence/InMemoryIngestPersistenceStore.cs
@@ -37,8 +37,27 @@ public sealed class InMemoryIngestPersistenceStore : IIngestPersistenceStore
 
         lock (storeLock)
         {
-            packageStates.AddRange(batch.PackageStates);
-            outboxMessages.AddRange(batch.OutboxMessages);
+            foreach (var packageState in batch.PackageStates)
+            {
+                var packageIndex = packageStates.FindIndex(existing => existing.PackageId == packageState.PackageId);
+
+                if (packageIndex >= 0)
+                {
+                    packageStates[packageIndex] = packageState;
+                }
+                else
+                {
+                    packageStates.Add(packageState);
+                }
+            }
+
+            foreach (var outboxMessage in batch.OutboxMessages)
+            {
+                if (!outboxMessages.Any(existing => existing.MessageId == outboxMessage.MessageId))
+                {
+                    outboxMessages.Add(outboxMessage);
+                }
+            }
         }
 
         return Task.CompletedTask;
@@ -58,6 +77,46 @@ public sealed class InMemoryIngestPersistenceStore : IIngestPersistenceStore
         }
 
         return Task.FromResult(pendingMessages);
+    }
+
+    public Task<IReadOnlyList<OutboxMessage>> ClaimPendingOutboxMessagesAsync(
+        DateTimeOffset claimedAt,
+        DateTimeOffset claimExpiresAt,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (claimExpiresAt <= claimedAt)
+        {
+            throw new ArgumentException("Outbox message claim expiry must be after the claim time.", nameof(claimExpiresAt));
+        }
+
+        IReadOnlyList<OutboxMessage> claimedMessages;
+
+        lock (storeLock)
+        {
+            var claimableMessages = outboxMessages
+                .Select((Message, Index) => (Message, Index))
+                .Where(candidate =>
+                    candidate.Message.DispatchedAt is null &&
+                    (candidate.Message.DispatchClaimExpiresAt is null ||
+                     candidate.Message.DispatchClaimExpiresAt <= claimedAt))
+                .OrderBy(candidate => candidate.Message.CreatedAt)
+                .ThenBy(candidate => candidate.Message.MessageId)
+                .ToArray();
+
+            claimedMessages = claimableMessages
+                .Select(candidate => candidate.Message with { DispatchClaimExpiresAt = claimExpiresAt })
+                .ToArray();
+
+            foreach (var claimedMessage in claimedMessages)
+            {
+                var messageIndex = outboxMessages.FindIndex(message => message.MessageId == claimedMessage.MessageId);
+                outboxMessages[messageIndex] = claimedMessage;
+            }
+        }
+
+        return Task.FromResult(claimedMessages);
     }
 
     public Task MarkOutboxMessageDispatchedAsync(
@@ -81,7 +140,14 @@ public sealed class InMemoryIngestPersistenceStore : IIngestPersistenceStore
                 throw new InvalidOperationException($"Outbox message '{messageId}' was not found.");
             }
 
-            outboxMessages[messageIndex] = outboxMessages[messageIndex] with { DispatchedAt = dispatchedAt };
+            if (outboxMessages[messageIndex].DispatchedAt is null)
+            {
+                outboxMessages[messageIndex] = outboxMessages[messageIndex] with
+                {
+                    DispatchedAt = dispatchedAt,
+                    DispatchClaimExpiresAt = null
+                };
+            }
         }
 
         return Task.CompletedTask;

--- a/src/MediaIngest.Persistence/OutboxMessage.cs
+++ b/src/MediaIngest.Persistence/OutboxMessage.cs
@@ -7,4 +7,5 @@ public sealed record OutboxMessage(
     string PayloadJson,
     string CorrelationId,
     DateTimeOffset CreatedAt,
-    DateTimeOffset? DispatchedAt = null);
+    DateTimeOffset? DispatchedAt = null,
+    DateTimeOffset? DispatchClaimExpiresAt = null);

--- a/src/MediaIngest.Persistence/PostgresIngestPersistenceStore.cs
+++ b/src/MediaIngest.Persistence/PostgresIngestPersistenceStore.cs
@@ -76,7 +76,8 @@ public sealed class PostgresIngestPersistenceStore(
                     payload_json,
                     correlation_id,
                     created_at,
-                    dispatched_at
+                    dispatched_at,
+                    dispatch_claim_expires_at
                 )
                 VALUES (
                     @message_id,
@@ -85,8 +86,10 @@ public sealed class PostgresIngestPersistenceStore(
                     @payload_json,
                     @correlation_id,
                     @created_at,
-                    @dispatched_at
-                );
+                    @dispatched_at,
+                    @dispatch_claim_expires_at
+                )
+                ON CONFLICT (message_id) DO NOTHING;
                 """,
                 [
                     ("@message_id", outboxMessage.MessageId),
@@ -95,7 +98,8 @@ public sealed class PostgresIngestPersistenceStore(
                     ("@payload_json", outboxMessage.PayloadJson),
                     ("@correlation_id", outboxMessage.CorrelationId),
                     ("@created_at", outboxMessage.CreatedAt),
-                    ("@dispatched_at", outboxMessage.DispatchedAt)
+                    ("@dispatched_at", outboxMessage.DispatchedAt),
+                    ("@dispatch_claim_expires_at", outboxMessage.DispatchClaimExpiresAt)
                 ],
                 cancellationToken);
         }
@@ -118,26 +122,73 @@ public sealed class PostgresIngestPersistenceStore(
                 payload_json,
                 correlation_id,
                 created_at,
-                dispatched_at
+                dispatched_at,
+                dispatch_claim_expires_at
             FROM outbox_messages
             WHERE dispatched_at IS NULL
             ORDER BY created_at, message_id;
             """;
 
-        var messages = new List<OutboxMessage>();
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
 
-        while (await reader.ReadAsync(cancellationToken))
+        return await ReadOutboxMessagesAsync(reader, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<OutboxMessage>> ClaimPendingOutboxMessagesAsync(
+        DateTimeOffset claimedAt,
+        DateTimeOffset claimExpiresAt,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (claimExpiresAt <= claimedAt)
         {
-            messages.Add(new OutboxMessage(
-                MessageId: reader.GetString(0),
-                Destination: reader.GetString(1),
-                MessageType: reader.GetString(2),
-                PayloadJson: reader.GetString(3),
-                CorrelationId: reader.GetString(4),
-                CreatedAt: ReadDateTimeOffset(reader, 5),
-                DispatchedAt: reader.IsDBNull(6) ? null : ReadDateTimeOffset(reader, 6)));
+            throw new ArgumentException("Outbox message claim expiry must be after the claim time.", nameof(claimExpiresAt));
         }
+
+        await using var connection = await openConnection(cancellationToken);
+        await OpenIfNeededAsync(connection, cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            WITH claimable_messages AS (
+                SELECT message_id
+                FROM outbox_messages
+                WHERE dispatched_at IS NULL
+                  AND (
+                      dispatch_claim_expires_at IS NULL OR
+                      dispatch_claim_expires_at <= @claimed_at
+                  )
+                ORDER BY created_at, message_id
+                FOR UPDATE SKIP LOCKED
+            )
+            UPDATE outbox_messages AS outbox_message
+            SET dispatch_claim_expires_at = @claim_expires_at
+            FROM claimable_messages
+            WHERE outbox_message.message_id = claimable_messages.message_id
+            RETURNING
+                outbox_message.message_id,
+                outbox_message.destination,
+                outbox_message.message_type,
+                outbox_message.payload_json,
+                outbox_message.correlation_id,
+                outbox_message.created_at,
+                outbox_message.dispatched_at,
+                outbox_message.dispatch_claim_expires_at;
+            """;
+
+        AddParameter(command, "@claimed_at", claimedAt);
+        AddParameter(command, "@claim_expires_at", claimExpiresAt);
+
+        IReadOnlyList<OutboxMessage> messages;
+
+        await using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+        {
+            messages = await ReadOutboxMessagesAsync(reader, cancellationToken);
+        }
+
+        await transaction.CommitAsync(cancellationToken);
 
         return messages;
     }
@@ -161,7 +212,9 @@ public sealed class PostgresIngestPersistenceStore(
             transaction: null,
             """
             UPDATE outbox_messages
-            SET dispatched_at = @dispatched_at
+            SET
+                dispatched_at = COALESCE(dispatched_at, @dispatched_at),
+                dispatch_claim_expires_at = NULL
             WHERE message_id = @message_id;
             """,
             [
@@ -204,6 +257,36 @@ public sealed class PostgresIngestPersistenceStore(
         }
 
         return await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static void AddParameter(DbCommand command, string name, object? value)
+    {
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = name;
+        parameter.Value = value ?? DBNull.Value;
+        command.Parameters.Add(parameter);
+    }
+
+    private static async Task<IReadOnlyList<OutboxMessage>> ReadOutboxMessagesAsync(
+        DbDataReader reader,
+        CancellationToken cancellationToken)
+    {
+        var messages = new List<OutboxMessage>();
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            messages.Add(new OutboxMessage(
+                MessageId: reader.GetString(0),
+                Destination: reader.GetString(1),
+                MessageType: reader.GetString(2),
+                PayloadJson: reader.GetString(3),
+                CorrelationId: reader.GetString(4),
+                CreatedAt: ReadDateTimeOffset(reader, 5),
+                DispatchedAt: reader.IsDBNull(6) ? null : ReadDateTimeOffset(reader, 6),
+                DispatchClaimExpiresAt: reader.IsDBNull(7) ? null : ReadDateTimeOffset(reader, 7)));
+        }
+
+        return messages;
     }
 
     private static DateTimeOffset ReadDateTimeOffset(DbDataReader reader, int ordinal)

--- a/src/MediaIngest.Persistence/PostgresIngestSchema.cs
+++ b/src/MediaIngest.Persistence/PostgresIngestSchema.cs
@@ -17,8 +17,12 @@ public static class PostgresIngestSchema
             payload_json jsonb NOT NULL,
             correlation_id text NOT NULL,
             created_at timestamptz NOT NULL,
-            dispatched_at timestamptz NULL
+            dispatched_at timestamptz NULL,
+            dispatch_claim_expires_at timestamptz NULL
         );
+
+        ALTER TABLE outbox_messages
+            ADD COLUMN IF NOT EXISTS dispatch_claim_expires_at timestamptz NULL;
 
         CREATE INDEX IF NOT EXISTS idx_outbox_messages_pending
             ON outbox_messages (created_at, message_id)

--- a/src/MediaIngest.Worker.Outbox/OutboxDispatcher.cs
+++ b/src/MediaIngest.Worker.Outbox/OutboxDispatcher.cs
@@ -5,13 +5,19 @@ namespace MediaIngest.Worker.Outbox;
 public sealed class OutboxDispatcher(
     IIngestPersistenceStore persistenceStore,
     IOutboxMessagePublisher publisher,
-    TimeProvider? timeProvider = null)
+    TimeProvider? timeProvider = null,
+    TimeSpan? dispatchClaimDuration = null)
 {
     private readonly TimeProvider dispatchClock = timeProvider ?? TimeProvider.System;
+    private readonly TimeSpan claimDuration = dispatchClaimDuration ?? TimeSpan.FromMinutes(5);
 
     public async Task<int> DispatchPendingAsync(CancellationToken cancellationToken = default)
     {
-        var pendingMessages = await persistenceStore.GetPendingOutboxMessagesAsync(cancellationToken);
+        var claimedAt = dispatchClock.GetUtcNow();
+        var pendingMessages = await persistenceStore.ClaimPendingOutboxMessagesAsync(
+            claimedAt,
+            claimedAt.Add(claimDuration),
+            cancellationToken);
         var dispatchedCount = 0;
 
         foreach (var message in pendingMessages)

--- a/tests/MediaIngest.Persistence.Tests/Program.cs
+++ b/tests/MediaIngest.Persistence.Tests/Program.cs
@@ -25,6 +25,11 @@ AssertEqual(1, store.OutboxMessages.Count, "saved outbox message count");
 AssertEqual("package-001", store.PackageStates[0].PackageId, "business state package id");
 AssertEqual("message-001", store.OutboxMessages[0].MessageId, "outbox message id");
 
+await store.SaveAsync(new PersistenceBatch([], [command]));
+
+AssertEqual(1, store.OutboxMessages.Count, "duplicate outbox message id is idempotent");
+AssertEqual("message-001", store.OutboxMessages[0].MessageId, "idempotent outbox message id");
+
 var rejected = false;
 
 try
@@ -57,6 +62,7 @@ AssertTrue(recordingConnection.Committed, "postgres save commits transaction");
 AssertEqual(2, recordingConnection.ExecutedCommands.Count, "postgres save command count");
 AssertContains("INSERT INTO ingest_package_states", recordingConnection.ExecutedCommands[0].CommandText, "postgres package upsert command");
 AssertContains("INSERT INTO outbox_messages", recordingConnection.ExecutedCommands[1].CommandText, "postgres outbox insert command");
+AssertContains("ON CONFLICT (message_id) DO NOTHING", recordingConnection.ExecutedCommands[1].CommandText, "postgres outbox insert idempotency");
 AssertEqual("package-001", recordingConnection.ExecutedCommands[0].Parameters["@package_id"], "postgres package id parameter");
 AssertEqual("message-001", recordingConnection.ExecutedCommands[1].Parameters["@message_id"], "postgres message id parameter");
 

--- a/tests/MediaIngest.Worker.Outbox.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Outbox.Tests/Program.cs
@@ -4,6 +4,8 @@ using MediaIngest.Worker.Outbox;
 await DispatchPendingMessagesPublishesAndMarksThemWithTheDispatchTime();
 await DispatchPendingMessagesDoesNothingWhenNoMessagesArePending();
 await DispatchPendingMessagesLeavesTheMessagePendingWhenPublishFails();
+await OverlappingDispatcherRunsDoNotPublishTheSameMessageTwice();
+await ClaimedMessagesCanBeRetriedAfterTheClaimExpires();
 
 Console.WriteLine("MediaIngest outbox dispatcher smoke tests passed.");
 
@@ -77,6 +79,77 @@ static async Task DispatchPendingMessagesLeavesTheMessagePendingWhenPublishFails
     AssertEqual(null, store.OutboxMessages[0].DispatchedAt, "failed publish leaves message pending");
 }
 
+static async Task OverlappingDispatcherRunsDoNotPublishTheSameMessageTwice()
+{
+    var store = new InMemoryIngestPersistenceStore();
+    var message = CreateMessage(
+        messageId: "message-003",
+        destination: "media.command.inspect",
+        messageType: "MediaCommandEnvelope",
+        createdAt: new DateTimeOffset(2026, 5, 3, 12, 20, 0, TimeSpan.Zero));
+
+    await store.SaveAsync(new PersistenceBatch([], [message]));
+
+    var publisher = new BlockingOutboxPublisher();
+    var dispatchClock = new FixedTimeProvider(new DateTimeOffset(2026, 5, 3, 12, 25, 0, TimeSpan.Zero));
+    var firstDispatcher = new OutboxDispatcher(store, publisher, dispatchClock);
+    var secondDispatcher = new OutboxDispatcher(store, publisher, dispatchClock);
+
+    var firstRun = firstDispatcher.DispatchPendingAsync();
+    await publisher.WaitForFirstPublishAttemptAsync();
+
+    var secondRun = secondDispatcher.DispatchPendingAsync();
+    await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+    publisher.AllowPublishes();
+
+    var dispatchCounts = await Task.WhenAll(firstRun, secondRun);
+
+    AssertEqual(1, dispatchCounts.Sum(), "overlapping dispatch count");
+    AssertEqual(1, publisher.Published.Count, "overlapping published message count");
+    AssertEqual("message-003", publisher.Published[0].MessageId, "overlapping published message id");
+}
+
+static async Task ClaimedMessagesCanBeRetriedAfterTheClaimExpires()
+{
+    var store = new InMemoryIngestPersistenceStore();
+    var message = CreateMessage(
+        messageId: "message-004",
+        destination: "media.command.retry",
+        messageType: "MediaCommandEnvelope",
+        createdAt: new DateTimeOffset(2026, 5, 3, 12, 30, 0, TimeSpan.Zero));
+
+    await store.SaveAsync(new PersistenceBatch([], [message]));
+
+    var timeProvider = new MutableTimeProvider(new DateTimeOffset(2026, 5, 3, 12, 35, 0, TimeSpan.Zero));
+    var publisher = new FailsOnceOutboxPublisher("broker unavailable");
+    var dispatcher = new OutboxDispatcher(store, publisher, timeProvider, TimeSpan.FromSeconds(5));
+
+    var failed = false;
+
+    try
+    {
+        await dispatcher.DispatchPendingAsync();
+    }
+    catch (InvalidOperationException ex) when (ex.Message == "broker unavailable")
+    {
+        failed = true;
+    }
+
+    AssertTrue(failed, "first publish failure is surfaced");
+
+    var claimedRunCount = await dispatcher.DispatchPendingAsync();
+
+    timeProvider.UtcNow = timeProvider.UtcNow.AddSeconds(5);
+
+    var retryRunCount = await dispatcher.DispatchPendingAsync();
+
+    AssertEqual(0, claimedRunCount, "claimed message dispatch count before expiry");
+    AssertEqual(1, retryRunCount, "expired claim retry dispatch count");
+    AssertEqual(2, publisher.PublishAttempts, "expired claim retry publish attempts");
+    AssertEqual(timeProvider.UtcNow, store.OutboxMessages[0].DispatchedAt, "expired claim retry dispatched timestamp");
+}
+
 static OutboxMessage CreateMessage(
     string messageId,
     string destination,
@@ -128,10 +201,58 @@ internal sealed class FailingOutboxPublisher(string failureMessage) : IOutboxMes
     }
 }
 
+internal sealed class FailsOnceOutboxPublisher(string failureMessage) : IOutboxMessagePublisher
+{
+    public int PublishAttempts { get; private set; }
+
+    public Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+    {
+        _ = message;
+        cancellationToken.ThrowIfCancellationRequested();
+        PublishAttempts++;
+
+        if (PublishAttempts == 1)
+        {
+            throw new InvalidOperationException(failureMessage);
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class BlockingOutboxPublisher : IOutboxMessagePublisher
+{
+    private readonly TaskCompletionSource firstPublishAttempted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource allowPublishes = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public List<OutboxMessage> Published { get; } = [];
+
+    public async Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+    {
+        Published.Add(message);
+        firstPublishAttempted.TrySetResult();
+        await allowPublishes.Task.WaitAsync(cancellationToken);
+    }
+
+    public Task WaitForFirstPublishAttemptAsync() => firstPublishAttempted.Task;
+
+    public void AllowPublishes() => allowPublishes.TrySetResult();
+}
+
 internal sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
 {
     public override DateTimeOffset GetUtcNow()
     {
         return utcNow;
+    }
+}
+
+internal sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+{
+    public DateTimeOffset UtcNow { get; set; } = utcNow;
+
+    public override DateTimeOffset GetUtcNow()
+    {
+        return UtcNow;
     }
 }


### PR DESCRIPTION
## Summary
- Adds persistence-level outbox claim leases so overlapping dispatcher runs do not publish the same decided message twice.
- Makes duplicate outbox `MessageId` saves idempotent inside the persistence abstraction while preserving package state upsert behavior.
- Extends the PostgreSQL outbox schema and store to track claim expiry, claim rows with `FOR UPDATE SKIP LOCKED`, and clear claims when messages are marked dispatched.
- Adds focused persistence and outbox tests for duplicate message saves, overlapping dispatch, and retry after claim expiry.

Refs #18

## Validation
- RED: `dotnet run --project tests/MediaIngest.Persistence.Tests/MediaIngest.Persistence.Tests.csproj` failed as expected with `duplicate outbox message id is idempotent: expected '1', got '2'`.
- RED: `make test-dotnet-outbox` failed as expected with `overlapping dispatch count: expected '1', got '2'`.
- PASS: `make test-dotnet-persistence`.
- PASS: `make test-dotnet-outbox`.
- PASS: `make validate`.
- PASS: `git diff --check`.

## Risk
- Outbox rows that are claimed but not dispatched are hidden from other dispatchers until the claim lease expires; the default dispatcher lease is 5 minutes.
- Existing local PostgreSQL databases need `CreateSchemaAsync` to run so `dispatch_claim_expires_at` is added before the new store queries execute.

## Follow-up Notes
- Broker-level exactly-once delivery is still outside this local foundation; downstream consumers should continue treating message identifiers as idempotency keys.
- No dependency, cloud, secret, deploy, watcher, workflow, essence, or web changes were made.