### PR TITLE
USER-STORY-17: Add Kubernetes runtime readiness assets

### DIFF
--- a/deploy/dapr/README.md
+++ b/deploy/dapr/README.md
@@ -1,8 +1,8 @@
-# Dapr Workflow Skeleton
+# Dapr Workflow Runtime Assets
 
 This directory records the local Dapr lane for workflow runtime assets. TASK-5-1
-does not add runtime components or Azure-backed state stores; those remain
-deferred until the local runtime slice defines the Dapr sidecar wiring.
+added the workflow skeleton. USER-STORY-17 adds static Kubernetes-oriented Dapr
+component templates while keeping cloud execution deferred.
 
 Current workflow skeleton:
 
@@ -10,3 +10,18 @@ Current workflow skeleton:
 - workflow application lane: `MediaIngest.Workflow`
 - workflow instance id shape: `package-<packageId>`
 - workflow runtime state remains separate from PostgreSQL business state
+
+Kubernetes component templates:
+
+- `k8s/configuration.yaml` defines the Dapr sidecar configuration name used by
+  Kubernetes workload annotations.
+- `k8s/postgres-state.yaml` defines the Dapr workflow state store as a
+  PostgreSQL-backed component named `workflowstatestore`.
+- `k8s/servicebus-pubsub.yaml` defines the Azure Service Bus topic pub/sub
+  component named `commandbus`.
+- `k8s/kustomization.yaml` lets agents render the Dapr assets without contacting
+  a Kubernetes API server.
+
+All credentials are Kubernetes Secret references. Real secret values,
+kubeconfigs, Azure subscription details, and Terraform state are intentionally
+absent from this repository.

--- a/deploy/dapr/k8s/configuration.yaml
+++ b/deploy/dapr/k8s/configuration.yaml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: media-ingest-dapr
+  namespace: media-ingest
+spec:
+  tracing:
+    samplingRate: "1"

--- a/deploy/dapr/k8s/kustomization.yaml
+++ b/deploy/dapr/k8s/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: media-ingest
+resources:
+  - configuration.yaml
+  - postgres-state.yaml
+  - servicebus-pubsub.yaml

--- a/deploy/dapr/k8s/postgres-state.yaml
+++ b/deploy/dapr/k8s/postgres-state.yaml
@@ -1,0 +1,17 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: workflowstatestore
+  namespace: media-ingest
+spec:
+  type: state.postgresql
+  version: v1
+  metadata:
+    - name: connectionString
+      secretKeyRef:
+        name: media-ingest-postgres
+        key: connection-string
+    - name: tableName
+      value: dapr_workflow_state
+auth:
+  secretStore: kubernetes

--- a/deploy/dapr/k8s/servicebus-pubsub.yaml
+++ b/deploy/dapr/k8s/servicebus-pubsub.yaml
@@ -1,0 +1,15 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: commandbus
+  namespace: media-ingest
+spec:
+  type: pubsub.azure.servicebus.topics
+  version: v1
+  metadata:
+    - name: connectionString
+      secretKeyRef:
+        name: media-ingest-servicebus
+        key: connection-string
+auth:
+  secretStore: kubernetes

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -1,0 +1,21 @@
+# Docker Runtime Assets
+
+This directory contains the current container build and local compose assets.
+
+## Current Containers
+
+- `api.Dockerfile` builds `src/MediaIngest.Api`.
+- `ui.Dockerfile` builds `web/ingest-control-plane` and serves it through
+  nginx.
+- `compose.yaml` runs API, UI, and PostgreSQL for local development with the
+  ingest input and output paths mounted as plain filesystem directories.
+
+The watcher, workflow, outbox, command-runner, persistence, observability, and
+essence projects are currently libraries or foundation slices rather than
+standalone runnable container services. Add service Dockerfiles when those
+projects gain executable hosts.
+
+## Boundary
+
+Docker assets are local/runtime scaffolding. They do not create Azure resources,
+publish images, store credentials, or validate a production deployment.

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,52 @@
+# Kubernetes Readiness Assets
+
+This directory contains static Kubernetes assets for the intended local and
+Azure-ready runtime shape. They are readiness assets, not a production release
+bundle.
+
+## Boundary
+
+- Manifests are safe to review and validate locally.
+- Services use `ClusterIP`; no load balancer or ingress is created.
+- Images use placeholder repository names and tags.
+- Azure Service Bus and PostgreSQL credentials are referenced by Kubernetes
+  Secret names only. Real secret values, kubeconfigs, subscription ids, and
+  Terraform state stay outside the repository.
+- Paid cloud execution requires explicit approval before any `kubectl`, `az`,
+  Helm, or Dapr command targets a paid cluster or Azure resource.
+
+## Apply Order
+
+Use these commands only against an approved local cluster or approved Azure
+cluster context:
+
+```bash
+kubectl apply -f deploy/k8s/namespace.yaml
+kubectl apply -k deploy/k8s
+kubectl apply -k deploy/dapr/k8s
+```
+
+Before applying to a cluster, copy `secrets.example.yaml` outside the repository
+or manage equivalent secrets through the approved environment's secret manager.
+Do not commit the filled-in copy.
+
+## Static Validation
+
+The expected validation for this slice is static review:
+
+```bash
+make validate
+git diff --check
+```
+
+Optional local validation, when `kubectl` is installed and a disposable local
+cluster is selected and reachable:
+
+```bash
+kubectl kustomize deploy/k8s
+kubectl kustomize deploy/dapr/k8s
+kubectl apply --dry-run=client -k deploy/k8s
+kubectl apply --dry-run=client -k deploy/dapr/k8s
+```
+
+Do not run cloud validation without explicit approval.

--- a/deploy/k8s/api.yaml
+++ b/deploy/k8s/api.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/part-of: media-asset-ingest
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: api
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/part-of: media-asset-ingest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: api
+        app.kubernetes.io/part-of: media-asset-ingest
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: media-ingest-api
+        dapr.io/app-port: "8080"
+        dapr.io/config: media-ingest-dapr
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/example/media-ingest-api:replace-with-image-tag
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: media-ingest-runtime
+          env:
+            - name: ConnectionStrings__Postgres
+              valueFrom:
+                secretKeyRef:
+                  name: media-ingest-postgres
+                  key: connection-string
+          volumeMounts:
+            - name: ingest-input
+              mountPath: /mnt/ingest/input
+            - name: ingest-output
+              mountPath: /mnt/ingest/output
+      volumes:
+        - name: ingest-input
+          emptyDir: {}
+        - name: ingest-output
+          emptyDir: {}

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: media-ingest
+resources:
+  - namespace.yaml
+  - postgres.yaml
+  - api.yaml
+  - ui.yaml
+configMapGenerator:
+  - name: media-ingest-runtime
+    literals:
+      - ASPNETCORE_URLS=http://+:8080
+      - Ingest__InputPath=/mnt/ingest/input
+      - Ingest__OutputPath=/mnt/ingest/output
+generatorOptions:
+  disableNameSuffixHash: true
+images:
+  - name: ghcr.io/example/media-ingest-api
+    newName: ghcr.io/example/media-ingest-api
+    newTag: replace-with-image-tag
+  - name: ghcr.io/example/media-ingest-ui
+    newName: ghcr.io/example/media-ingest-ui
+    newTag: replace-with-image-tag

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: media-ingest
+  labels:
+    app.kubernetes.io/name: media-ingest
+    app.kubernetes.io/part-of: media-asset-ingest

--- a/deploy/k8s/postgres.yaml
+++ b/deploy/k8s/postgres.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: media-asset-ingest
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: media-asset-ingest
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/part-of: media-asset-ingest
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: media_ingest
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: media-ingest-postgres
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: media-ingest-postgres
+                  key: password
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/deploy/k8s/secrets.example.yaml
+++ b/deploy/k8s/secrets.example.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: media-ingest-postgres
+  namespace: media-ingest
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: media-asset-ingest
+type: Opaque
+stringData:
+  username: replace-with-postgres-user
+  password: replace-with-postgres-password
+  connection-string: Host=postgres;Port=5432;Database=media_ingest;Username=replace-with-postgres-user;Password=replace-with-postgres-password
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: media-ingest-servicebus
+  namespace: media-ingest
+  labels:
+    app.kubernetes.io/name: servicebus
+    app.kubernetes.io/part-of: media-asset-ingest
+type: Opaque
+stringData:
+  connection-string: Endpoint=sb://replace-with-namespace.servicebus.windows.net/;SharedAccessKeyName=replace-with-policy;SharedAccessKey=replace-with-key

--- a/deploy/k8s/ui.yaml
+++ b/deploy/k8s/ui.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  labels:
+    app.kubernetes.io/name: ui
+    app.kubernetes.io/part-of: media-asset-ingest
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: ui
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ui
+  labels:
+    app.kubernetes.io/name: ui
+    app.kubernetes.io/part-of: media-asset-ingest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ui
+        app.kubernetes.io/part-of: media-asset-ingest
+    spec:
+      containers:
+        - name: ui
+          image: ghcr.io/example/media-ingest-ui:replace-with-image-tag
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 80

--- a/docs/architecture/000-system-overview.md
+++ b/docs/architecture/000-system-overview.md
@@ -40,6 +40,19 @@ distributes command work. Command runners execute supplied commands in
 appropriately sized containers. PostgreSQL stores business truth. Dapr stores
 workflow runtime state in its own state store.
 
+## Runtime Readiness Boundary
+
+The repository includes Docker and static Kubernetes readiness assets for the
+API, UI, PostgreSQL dependency, Dapr sidecar configuration, Dapr workflow state
+store, and Azure Service Bus pub/sub component. These assets document the
+intended container runtime shape without creating Azure resources by default.
+
+Kubernetes services stay internal by default with `ClusterIP` networking. Image
+repository names, image tags, secret values, kubeconfigs, Azure subscription
+details, and Terraform state are placeholders or omitted. Applying manifests to
+an Azure cluster, creating Azure Service Bus, or binding managed storage remains
+a manual step that requires explicit approval.
+
 ## Deferred Decisions
 
 - Production mount backing: Azure Files, Blob CSI, or another Azure-backed option.

--- a/docs/automation/validation.md
+++ b/docs/automation/validation.md
@@ -10,7 +10,8 @@
 | GitHub tracker change | GitHub plugin inspection, `make github-project-summary`, and `make github-project-active` | targeted GitHub plugin issue/PR inspection, `make github-project-hierarchy` only when parent/child navigation changed | no | no | cheap |
 | .NET code change | focused `make test-dotnet-*` target for the touched component | `make test-dotnet`, then `make validate` before PR | yes when host `dotnet` is unavailable | no | moderate |
 | Local ingest smoke script change | `sh -n scripts/dev/local-e2e-smoke.sh` and `sh scripts/dev/local-e2e-smoke.sh --dry-run` | Run `dotnet run --project src/MediaIngest.Api --urls http://127.0.0.1:5000`, then `sh scripts/dev/local-e2e-smoke.sh` from another terminal | no | no | cheap |
-| Docker/Kubernetes change | relevant local smoke test once scripts exist | full local runtime validation | yes | no | moderate |
+| Docker/Kubernetes static asset change | `make docs-check`, `kubectl kustomize deploy/k8s`, `kubectl kustomize deploy/dapr/k8s`, and `git diff --check` | `kubectl apply --dry-run=client -k deploy/k8s` only when kubectl has an approved reachable local context | optional | no | cheap |
+| Docker/Kubernetes runtime behavior change | relevant local smoke test once scripts exist | full local runtime validation | yes | no | moderate |
 | Azure deployment change | static manifest/terraform validation only | manual cloud validation after approval | maybe | yes | paid/approval |
 
 Do not run expensive Docker or cloud validation for docs-only edits.

--- a/docs/product/milestones.md
+++ b/docs/product/milestones.md
@@ -262,7 +262,7 @@ Components:
 
 ## MILESTONE-9: Kubernetes And Azure Readiness
 
-Status: Planned
+Status: In Review
 
 Purpose: Add Kubernetes manifests, Dapr components, and Azure deployment
 documentation without requiring paid cloud execution by default.
@@ -287,6 +287,14 @@ Components:
 
 - `deploy/k8s`
 - `deploy/dapr`
-- `deploy/azure`
 - `docs/architecture`
 - `docs/automation`
+
+Current readiness boundary:
+
+- Static Kubernetes manifests cover internal API, UI, PostgreSQL, and Dapr
+  sidecar wiring without load balancers.
+- Dapr component templates cover PostgreSQL workflow state and Azure Service Bus
+  pub/sub through Kubernetes Secret references.
+- Azure resource creation and cloud validation remain deferred until explicitly
+  approved.

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -23,7 +23,7 @@ ownership lanes. Keep detailed implementation tasks in `docs/plans/tasks`.
 | USER-STORY-14 | Drill into nested workflows | MILESTONE-8 | Workflow UI | Canvas | Planned |
 | USER-STORY-15 | Navigate back from child workflows | MILESTONE-8 | Workflow UI | Canvas | Planned |
 | USER-STORY-16 | Develop with Docker-first tooling | MILESTONE-1, MILESTONE-2 | Developer experience | Forge | In Progress |
-| USER-STORY-17 | Deploy to Kubernetes | MILESTONE-2, MILESTONE-9 | Platform | Forge | Planned |
+| USER-STORY-17 | Deploy to Kubernetes | MILESTONE-2, MILESTONE-9 | Platform | Forge | In Review |
 
 ## USER-STORY-1: Watch Ingest Mount
 
@@ -628,14 +628,16 @@ Components involved:
 - `deploy/docker`
 - `deploy/k8s`
 - `deploy/dapr`
-- `deploy/azure`
 - `docs/architecture`
 - `docs/automation`
 
 Acceptance themes:
 
-- Services are containerized.
-- Kubernetes manifests or Helm assets are documented.
+- API and UI services have container build assets.
+- Static Kubernetes manifests document the internal API, UI, PostgreSQL, and
+  Dapr sidecar runtime shape.
+- Dapr component templates represent PostgreSQL workflow state and Azure Service
+  Bus command topics through placeholder secret references.
 - Azure deployment guidance avoids paid actions by default.
 - Cloud execution requires explicit approval.
 

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -79,16 +79,21 @@
   exposes workflow graph DTOs by workflow instance, workflow lifecycle state
   projects to graph node statuses, and the React UI renders Mermaid diagrams
   while keeping package status and local start controls intact.
+- USER-STORY-17 added static Kubernetes and Dapr readiness assets for the API,
+  UI, PostgreSQL dependency, internal service networking, workflow state, and
+  Azure Service Bus pub/sub placeholders without running cloud validation.
 
 ## Ready For Review
 
-- No active PR is awaiting review.
+- USER-STORY-17 runtime readiness branch is preparing PR validation.
 
 ## Next
 
 - Keep the local ingest docs PR in draft until the backend and UI slice PRs
   merge the API host, UI **Start ingest** action, Vite `/api` proxy, and runtime
   folder ignore setup.
+- Review USER-STORY-17 static runtime readiness assets before any approved
+  cluster or Azure validation.
 
 ## Update Rule
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -116,6 +116,10 @@ messages or paste command output unless it explains a decision.
   state now projects to graph DTO statuses, `/api/workflows/{id}/graph` serves
   those DTOs, and the React control plane renders Mermaid diagrams from live
   graph data with focused API, workflow, and UI tests.
+- Added USER-STORY-17 static Kubernetes and Dapr readiness assets with
+  ClusterIP-only API/UI/PostgreSQL manifests, Dapr workflow state and Azure
+  Service Bus component templates, placeholder-only secret examples, and
+  architecture/automation docs that keep cloud validation approval-gated.
 
 ## Update Rule
 


### PR DESCRIPTION
## Summary

- Adds static Kubernetes readiness assets for the media ingest namespace, internal API/UI services, API Dapr sidecar annotations, PostgreSQL StatefulSet, runtime ConfigMap, and placeholder-only Secret example.
- Adds Kubernetes-oriented Dapr component templates for workflow PostgreSQL state and Azure Service Bus pub/sub through Kubernetes Secret references.
- Documents the Docker/Kubernetes/Dapr runtime boundary, no-load-balancer default, no secret or kubeconfig commits, and approval-gated Azure/cloud validation.
- Updates architecture, automation validation, story, milestone, status, and work-log docs for USER-STORY-17 readiness scope.

Closes #27

## Validation

- `kubectl kustomize deploy/k8s` passed and rendered the static Kubernetes base without contacting a cluster.
- `kubectl kustomize deploy/dapr/k8s` passed and rendered the Dapr component templates without contacting a cluster.
- `make validate` passed: docs check, GitHub helper wrapper tests, .NET build, and all smoke targets completed successfully.
- `git diff --check HEAD` passed.

## Risk

- These are static readiness assets only; no Docker image build, image publish, cluster apply, Azure resource creation, or paid cloud validation was run.
- `kubectl apply --dry-run=client` was not used as final evidence because kubectl still attempted API discovery in this sandbox where no reachable Kubernetes API exists.
- Image repository names, tags, and Secret values remain placeholders and must be supplied by an approved deployment environment.

## Follow-up Notes

- Add executable service Dockerfiles and Kubernetes workloads for watcher/outbox/command-runner hosts only after those projects become standalone runnable services.
- Run approved local-cluster or Azure-cluster dry-run/apply validation in a later task after explicit approval and environment setup.