### PR TITLE
USER-STORY-4: Add done marker reconciliation

### DIFF
--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -162,7 +162,7 @@ Components involved:
 Acceptance themes:
 
 - Work may begin before done marker exists.
-- Done marker triggers final package rescan.
+- Zero-byte `done.marker` file triggers final package rescan.
 - Late files are enqueued before package finalization.
 
 Dependencies:

--- a/src/MediaIngest.Worker.Watcher/DoneMarkerReadinessGate.cs
+++ b/src/MediaIngest.Worker.Watcher/DoneMarkerReadinessGate.cs
@@ -1,0 +1,16 @@
+namespace MediaIngest.Worker.Watcher;
+
+public sealed class DoneMarkerReadinessGate
+{
+    public const string DoneMarkerFileName = "done.marker";
+
+    public bool IsDone(IngestPackageCandidate candidate)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        var markerPath = Path.Combine(candidate.PackagePath, DoneMarkerFileName);
+
+        return File.Exists(markerPath)
+            && new FileInfo(markerPath).Length == 0;
+    }
+}

--- a/src/MediaIngest.Worker.Watcher/DoneMarkerReconciliation.cs
+++ b/src/MediaIngest.Worker.Watcher/DoneMarkerReconciliation.cs
@@ -1,0 +1,6 @@
+namespace MediaIngest.Worker.Watcher;
+
+public sealed record DoneMarkerReconciliation(
+    IngestPackageCandidate Candidate,
+    bool DoneMarkerObserved,
+    IReadOnlyList<IngestPackageFile> Files);

--- a/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
@@ -38,4 +38,16 @@ public sealed class IngestMountScanner
             .OrderBy(file => file.PackageRelativePath, StringComparer.Ordinal)
             .ToArray();
     }
+
+    public DoneMarkerReconciliation ReconcilePackageFilesOnDoneMarker(
+        IngestPackageCandidate candidate,
+        DoneMarkerReadinessGate doneMarkerGate)
+    {
+        ArgumentNullException.ThrowIfNull(doneMarkerGate);
+
+        return new DoneMarkerReconciliation(
+            candidate,
+            doneMarkerGate.IsDone(candidate),
+            FindPackageFiles(candidate));
+    }
 }

--- a/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
@@ -74,6 +74,37 @@ try
         new FileInfo(Path.Combine(readyPackageSidecarPath, "clip.en.srt")).Length,
         discoveredFileByRelativePath[Path.Combine("sidecars", "captions", "clip.en.srt")].FileSizeBytes,
         "ready package discovered sidecar file size");
+
+    var doneMarkerGate = new DoneMarkerReadinessGate();
+    var initialReconciliation = scanner.ReconcilePackageFilesOnDoneMarker(
+        new IngestPackageCandidate(readyPackagePath),
+        doneMarkerGate);
+
+    AssertFalse(initialReconciliation.DoneMarkerObserved, "ready package initial done marker state");
+    AssertSequenceEqual(
+        discoveredFiles.Select(file => file.PackageRelativePath).ToArray(),
+        initialReconciliation.Files.Select(file => file.PackageRelativePath).ToArray(),
+        "ready package initial reconciliation relative paths");
+
+    File.WriteAllText(Path.Combine(readyPackageMediaPath, "late.mov"), "late-media");
+    File.WriteAllText(Path.Combine(readyPackagePath, "done.marker"), string.Empty);
+
+    var finalReconciliation = scanner.ReconcilePackageFilesOnDoneMarker(
+        new IngestPackageCandidate(readyPackagePath),
+        doneMarkerGate);
+
+    AssertTrue(finalReconciliation.DoneMarkerObserved, "ready package final done marker state");
+    AssertSequenceEqual(
+        [
+            "done.marker",
+            "manifest.json",
+            "manifest.json.checksum",
+            Path.Combine("media", "clip.mov"),
+            Path.Combine("media", "late.mov"),
+            Path.Combine("sidecars", "captions", "clip.en.srt"),
+        ],
+        finalReconciliation.Files.Select(file => file.PackageRelativePath).ToArray(),
+        "ready package final reconciliation relative paths");
 }
 finally
 {


### PR DESCRIPTION
## Summary
- Adds watcher-owned zero-byte `done.marker` detection.
- Adds done-marker reconciliation that rescans package files and includes late-arriving files.
- Updates USER-STORY-4 acceptance wording with the concrete marker filename.

Refs #14

## Validation
- `make test-dotnet-watcher` passed.
- `make validate` passed.
- `git diff --check` passed.

## Risk
Low. The change is isolated to watcher scanning and does not wire workflow or persistence finalization yet.

## Follow-up
Workflow and persistence integration for final enqueue/finalization remains future USER-STORY-4 work.