### PR TITLE
USER-STORY-6: Route command metadata through outbox

### DIFF
--- a/deploy/dapr/README.md
+++ b/deploy/dapr/README.md
@@ -22,6 +22,21 @@ Kubernetes component templates:
 - `k8s/kustomization.yaml` lets agents render the Dapr assets without contacting
   a Kubernetes API server.
 
+Command routing boundary:
+
+| Command intent | Topic name | Execution property |
+| --- | --- | --- |
+| Create proxy | `media.command.create_proxy` | `executionClass` |
+| Create checksum | `media.command.create_checksum` | `executionClass` |
+| Verify checksum | `media.command.verify_checksum` | `executionClass` |
+| Run security scan | `media.command.run_security_scan` | `executionClass` |
+| Archive asset | `media.command.archive_asset` | `executionClass` |
+
+`executionClass` values are stable lower-case strings: `light`, `medium`, and
+`heavy`. Azure Service Bus subscriptions are named for those values and filter
+on the application property; command topic names stay semantic and do not encode
+runner capacity.
+
 All credentials are Kubernetes Secret references. Real secret values,
 kubeconfigs, Azure subscription details, and Terraform state are intentionally
 absent from this repository.

--- a/src/MediaIngest.Api/LocalManifestTransferPublisher.cs
+++ b/src/MediaIngest.Api/LocalManifestTransferPublisher.cs
@@ -12,12 +12,12 @@ public sealed class LocalManifestTransferPublisher : IOutboxMessagePublisher
         "manifest.json.checksum"
     ];
 
-    public async Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+    public async Task PublishAsync(OutboxPublishRequest publishRequest, CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(publishRequest);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var request = JsonSerializer.Deserialize<LocalManifestTransferRequest>(message.PayloadJson)
+        var request = JsonSerializer.Deserialize<LocalManifestTransferRequest>(publishRequest.Message.PayloadJson)
             ?? throw new InvalidOperationException("Local manifest transfer payload is required.");
 
         var outputPackagePath = Path.Combine(request.OutputRootPath, request.PackageId);

--- a/src/MediaIngest.Contracts/Commands/CommandRoute.cs
+++ b/src/MediaIngest.Contracts/Commands/CommandRoute.cs
@@ -2,4 +2,13 @@ namespace MediaIngest.Contracts.Commands;
 
 public sealed record CommandRoute(
     string TopicName,
-    ExecutionClass ExecutionClass);
+    ExecutionClass ExecutionClass)
+{
+    public const string ExecutionClassPropertyName = "executionClass";
+
+    public IReadOnlyDictionary<string, string> ApplicationProperties =>
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ExecutionClassPropertyName] = ExecutionClass.ToPropertyValue()
+        };
+}

--- a/src/MediaIngest.Contracts/Commands/ExecutionClass.cs
+++ b/src/MediaIngest.Contracts/Commands/ExecutionClass.cs
@@ -1,8 +1,73 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace MediaIngest.Contracts.Commands;
 
+[JsonConverter(typeof(ExecutionClassJsonConverter))]
 public enum ExecutionClass
 {
     Light,
     Medium,
     Heavy
+}
+
+public static class ExecutionClassProperties
+{
+    public const string Light = "light";
+    public const string Medium = "medium";
+    public const string Heavy = "heavy";
+
+    public static string ToPropertyValue(this ExecutionClass executionClass)
+    {
+        return executionClass switch
+        {
+            ExecutionClass.Light => Light,
+            ExecutionClass.Medium => Medium,
+            ExecutionClass.Heavy => Heavy,
+            _ => throw new ArgumentOutOfRangeException(nameof(executionClass), executionClass, "Unknown execution class.")
+        };
+    }
+
+    public static ExecutionClass FromPropertyValue(string value)
+    {
+        return value.ToLowerInvariant() switch
+        {
+            Light => ExecutionClass.Light,
+            Medium => ExecutionClass.Medium,
+            Heavy => ExecutionClass.Heavy,
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown execution class.")
+        };
+    }
+}
+
+public sealed class ExecutionClassJsonConverter : JsonConverter<ExecutionClass>
+{
+    public override ExecutionClass Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException("Execution class must be a string.");
+        }
+
+        var value = reader.GetString();
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new JsonException("Execution class is required.");
+        }
+
+        try
+        {
+            return ExecutionClassProperties.FromPropertyValue(value);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            throw new JsonException("Execution class must be light, medium, or heavy.", ex);
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, ExecutionClass value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToPropertyValue());
+    }
 }

--- a/src/MediaIngest.Worker.Outbox/IOutboxMessagePublisher.cs
+++ b/src/MediaIngest.Worker.Outbox/IOutboxMessagePublisher.cs
@@ -4,5 +4,5 @@ namespace MediaIngest.Worker.Outbox;
 
 public interface IOutboxMessagePublisher
 {
-    Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken = default);
+    Task PublishAsync(OutboxPublishRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/MediaIngest.Worker.Outbox/OutboxDispatcher.cs
+++ b/src/MediaIngest.Worker.Outbox/OutboxDispatcher.cs
@@ -22,7 +22,7 @@ public sealed class OutboxDispatcher(
 
         foreach (var message in pendingMessages)
         {
-            await publisher.PublishAsync(message, cancellationToken);
+            await publisher.PublishAsync(OutboxPublishRequest.From(message), cancellationToken);
             await persistenceStore.MarkOutboxMessageDispatchedAsync(
                 message.MessageId,
                 dispatchClock.GetUtcNow(),

--- a/src/MediaIngest.Worker.Outbox/OutboxPublishRequest.cs
+++ b/src/MediaIngest.Worker.Outbox/OutboxPublishRequest.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using MediaIngest.Persistence;
+
+namespace MediaIngest.Worker.Outbox;
+
+public sealed record OutboxPublishRequest(
+    OutboxMessage Message,
+    IReadOnlyDictionary<string, string> ApplicationProperties)
+{
+    public const string ExecutionClassPropertyName = "executionClass";
+
+    private static readonly HashSet<string> ExecutionClassValues = new(StringComparer.Ordinal)
+    {
+        "light",
+        "medium",
+        "heavy"
+    };
+
+    public static OutboxPublishRequest From(OutboxMessage message)
+    {
+        var applicationProperties = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        if (TryReadExecutionClass(message.PayloadJson, out var executionClass))
+        {
+            applicationProperties[ExecutionClassPropertyName] = executionClass;
+        }
+        else if (IsSemanticCommandTopic(message.Destination))
+        {
+            throw new InvalidOperationException(
+                $"Command outbox message '{message.MessageId}' must include an executionClass value.");
+        }
+
+        return new OutboxPublishRequest(message, applicationProperties);
+    }
+
+    private static bool IsSemanticCommandTopic(string destination)
+    {
+        return destination.StartsWith("media.command.", StringComparison.Ordinal);
+    }
+
+    private static bool TryReadExecutionClass(string payloadJson, out string executionClass)
+    {
+        executionClass = string.Empty;
+
+        using var document = JsonDocument.Parse(payloadJson);
+        var root = document.RootElement;
+
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (!TryGetProperty(root, "executionClass", out var executionClassProperty)
+            && !TryGetProperty(root, "ExecutionClass", out executionClassProperty))
+        {
+            return false;
+        }
+
+        if (executionClassProperty.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidOperationException("Command executionClass must be a string.");
+        }
+
+        var value = executionClassProperty.GetString();
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException("Command executionClass is required.");
+        }
+
+        var normalizedValue = value.ToLowerInvariant();
+
+        if (!ExecutionClassValues.Contains(normalizedValue))
+        {
+            throw new InvalidOperationException("Command executionClass must be light, medium, or heavy.");
+        }
+
+        executionClass = normalizedValue;
+        return true;
+    }
+
+    private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement property)
+    {
+        return element.TryGetProperty(propertyName, out property);
+    }
+}

--- a/tests/MediaIngest.Contracts.Tests/Program.cs
+++ b/tests/MediaIngest.Contracts.Tests/Program.cs
@@ -81,8 +81,12 @@ var heavyRouting = CommandRoutingPolicy.Route(
 
 AssertEqual(CommandNames.CreateProxy, lightRouting.TopicName, "create proxy topic");
 AssertEqual(ExecutionClass.Light, lightRouting.ExecutionClass, "light route");
+AssertEqual("executionClass", CommandRoute.ExecutionClassPropertyName, "execution class property name");
+AssertEqual("light", lightRouting.ApplicationProperties[CommandRoute.ExecutionClassPropertyName], "light route property");
 AssertEqual(ExecutionClass.Medium, mediumRouting.ExecutionClass, "medium route");
+AssertEqual("medium", mediumRouting.ApplicationProperties[CommandRoute.ExecutionClassPropertyName], "medium route property");
 AssertEqual(ExecutionClass.Heavy, heavyRouting.ExecutionClass, "heavy route");
+AssertEqual("heavy", heavyRouting.ApplicationProperties[CommandRoute.ExecutionClassPropertyName], "heavy route property");
 
 var checksumRouting = CommandRoutingPolicy.Route(
     commandName: CommandNames.CreateChecksum,
@@ -103,6 +107,9 @@ var command = new MediaCommandEnvelope(
 
 AssertEqual("media.command.create_proxy", command.TopicName, "command topic");
 AssertEqual(ExecutionClass.Light, command.ExecutionClass, "command execution class");
+AssertJsonContains(command, """
+    "ExecutionClass":"light"
+    """, "command execution class JSON");
 AssertJsonRoundTrip(command);
 
 Console.WriteLine("MediaIngest contract smoke tests passed.");
@@ -115,6 +122,16 @@ static void AssertJsonRoundTrip<T>(T value)
     if (roundTrip is null)
     {
         throw new InvalidOperationException($"JSON round trip failed for {typeof(T).Name}.");
+    }
+}
+
+static void AssertJsonContains<T>(T value, string expectedJsonFragment, string name)
+{
+    var json = JsonSerializer.Serialize(value);
+
+    if (!json.Contains(expectedJsonFragment, StringComparison.Ordinal))
+    {
+        throw new InvalidOperationException($"{name}: expected JSON to contain '{expectedJsonFragment}', got '{json}'.");
     }
 }
 

--- a/tests/MediaIngest.Worker.Outbox.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Outbox.Tests/Program.cs
@@ -2,6 +2,8 @@ using MediaIngest.Persistence;
 using MediaIngest.Worker.Outbox;
 
 await DispatchPendingMessagesPublishesAndMarksThemWithTheDispatchTime();
+await DispatchPendingCommandMessagesPublishesExecutionClassMetadata();
+await OutboxPublishersCannotDropApplicationProperties();
 await DispatchPendingMessagesDoesNothingWhenNoMessagesArePending();
 await DispatchPendingMessagesLeavesTheMessagePendingWhenPublishFails();
 await OverlappingDispatcherRunsDoNotPublishTheSameMessageTwice();
@@ -31,9 +33,48 @@ static async Task DispatchPendingMessagesPublishesAndMarksThemWithTheDispatchTim
     AssertEqual(1, firstRun, "first dispatch count");
     AssertEqual(0, secondRun, "second dispatch count");
     AssertEqual(1, publisher.Published.Count, "published message count");
-    AssertEqual("media.command.create_proxy", publisher.Published[0].Destination, "published destination");
-    AssertEqual("MediaCommandEnvelope", publisher.Published[0].MessageType, "published message type");
+    AssertEqual("media.command.create_proxy", publisher.Published[0].Message.Destination, "published destination");
+    AssertEqual("MediaCommandEnvelope", publisher.Published[0].Message.MessageType, "published message type");
     AssertEqual(dispatchedAt, store.OutboxMessages[0].DispatchedAt, "dispatched timestamp");
+}
+
+static async Task DispatchPendingCommandMessagesPublishesExecutionClassMetadata()
+{
+    var store = new InMemoryIngestPersistenceStore();
+    var message = CreateMessage(
+        messageId: "message-command-heavy",
+        destination: "media.command.archive_asset",
+        messageType: "MediaCommandEnvelope",
+        createdAt: new DateTimeOffset(2026, 5, 3, 12, 6, 0, TimeSpan.Zero),
+        executionClass: "heavy");
+
+    await store.SaveAsync(new PersistenceBatch([], [message]));
+
+    var publisher = new RecordingOutboxPublisher();
+    var dispatcher = new OutboxDispatcher(
+        store,
+        publisher,
+        new FixedTimeProvider(new DateTimeOffset(2026, 5, 3, 12, 7, 0, TimeSpan.Zero)));
+
+    var dispatchedCount = await dispatcher.DispatchPendingAsync();
+
+    AssertEqual(1, dispatchedCount, "command dispatch count");
+    AssertEqual(1, publisher.Published.Count, "command publish request count");
+    AssertEqual("media.command.archive_asset", publisher.Published[0].Message.Destination, "command publish destination");
+    AssertEqual("heavy", publisher.Published[0].ApplicationProperties["executionClass"], "command execution class property");
+}
+
+static Task OutboxPublishersCannotDropApplicationProperties()
+{
+    var publisherMethods = typeof(IOutboxMessagePublisher)
+        .GetMethods()
+        .Where(method => method.Name == nameof(IOutboxMessagePublisher.PublishAsync))
+        .ToArray();
+
+    AssertEqual(1, publisherMethods.Length, "publisher publish overload count");
+    AssertEqual(typeof(OutboxPublishRequest), publisherMethods[0].GetParameters()[0].ParameterType, "publisher request type");
+
+    return Task.CompletedTask;
 }
 
 static async Task DispatchPendingMessagesDoesNothingWhenNoMessagesArePending()
@@ -107,7 +148,7 @@ static async Task OverlappingDispatcherRunsDoNotPublishTheSameMessageTwice()
 
     AssertEqual(1, dispatchCounts.Sum(), "overlapping dispatch count");
     AssertEqual(1, publisher.Published.Count, "overlapping published message count");
-    AssertEqual("message-003", publisher.Published[0].MessageId, "overlapping published message id");
+    AssertEqual("message-003", publisher.Published[0].Message.MessageId, "overlapping published message id");
 }
 
 static async Task ClaimedMessagesCanBeRetriedAfterTheClaimExpires()
@@ -154,13 +195,14 @@ static OutboxMessage CreateMessage(
     string messageId,
     string destination,
     string messageType,
-    DateTimeOffset createdAt)
+    DateTimeOffset createdAt,
+    string executionClass = "light")
 {
     return new OutboxMessage(
         MessageId: messageId,
         Destination: destination,
         MessageType: messageType,
-        PayloadJson: """{"packageId":"package-001"}""",
+        PayloadJson: $$"""{"packageId":"package-001","executionClass":"{{executionClass}}"}""",
         CorrelationId: "correlation-001",
         CreatedAt: createdAt);
 }
@@ -183,20 +225,20 @@ static void AssertTrue(bool condition, string name)
 
 internal sealed class RecordingOutboxPublisher : IOutboxMessagePublisher
 {
-    public List<OutboxMessage> Published { get; } = [];
+    public List<OutboxPublishRequest> Published { get; } = [];
 
-    public Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+    public Task PublishAsync(OutboxPublishRequest request, CancellationToken cancellationToken = default)
     {
-        Published.Add(message);
+        Published.Add(request);
         return Task.CompletedTask;
     }
 }
 
 internal sealed class FailingOutboxPublisher(string failureMessage) : IOutboxMessagePublisher
 {
-    public Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+    public Task PublishAsync(OutboxPublishRequest request, CancellationToken cancellationToken = default)
     {
-        _ = message;
+        _ = request;
         throw new InvalidOperationException(failureMessage);
     }
 }
@@ -205,9 +247,9 @@ internal sealed class FailsOnceOutboxPublisher(string failureMessage) : IOutboxM
 {
     public int PublishAttempts { get; private set; }
 
-    public Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+    public Task PublishAsync(OutboxPublishRequest request, CancellationToken cancellationToken = default)
     {
-        _ = message;
+        _ = request;
         cancellationToken.ThrowIfCancellationRequested();
         PublishAttempts++;
 
@@ -225,11 +267,11 @@ internal sealed class BlockingOutboxPublisher : IOutboxMessagePublisher
     private readonly TaskCompletionSource firstPublishAttempted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource allowPublishes = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    public List<OutboxMessage> Published { get; } = [];
+    public List<OutboxPublishRequest> Published { get; } = [];
 
-    public async Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+    public async Task PublishAsync(OutboxPublishRequest request, CancellationToken cancellationToken = default)
     {
-        Published.Add(message);
+        Published.Add(request);
         firstPublishAttempted.TrySetResult();
         await allowPublishes.Task.WaitAsync(cancellationToken);
     }


### PR DESCRIPTION
## Summary
- Adds stable execution-class property serialization for command routing.
- Publishes outbox messages through OutboxPublishRequest so application properties cannot be dropped.
- Documents semantic command topics and execution-class routing metadata.

Refs #16

## Validation
- make test-dotnet-contracts passed.
- make test-dotnet-outbox passed.
- make validate passed.
- git diff --check passed.

## Risk
Medium. This changes the outbox publisher interface; local implementations and smoke tests were updated and full .NET validation passed.

## Follow-up
Actual Azure Service Bus publisher wiring remains future runtime work.