### PR TITLE
USER-STORY-13: Add workflow node detail inspection

### DIFF
--- a/src/MediaIngest.Api/IngestApiApplication.cs
+++ b/src/MediaIngest.Api/IngestApiApplication.cs
@@ -96,6 +96,7 @@ public sealed class IngestApiApplication : IAsyncDisposable
         app.MapPost("/api/ingest/start", StartIngestAsync);
         app.MapGet("/api/ingest/status", GetStatus);
         app.MapGet("/api/workflows/{workflowInstanceId}/graph", GetWorkflowGraph);
+        app.MapGet("/api/workflows/{workflowInstanceId}/nodes/{nodeId}", GetWorkflowNodeDetails);
     }
 
     private static async Task<IResult> StartIngestAsync(
@@ -123,6 +124,18 @@ public sealed class IngestApiApplication : IAsyncDisposable
         return graph is null
             ? Results.NotFound()
             : Results.Ok(graph);
+    }
+
+    private static IResult GetWorkflowNodeDetails(
+        string workflowInstanceId,
+        string nodeId,
+        IngestRuntimeService runtimeService)
+    {
+        var details = runtimeService.GetWorkflowNodeDetails(workflowInstanceId, nodeId);
+
+        return details is null
+            ? Results.NotFound()
+            : Results.Ok(details);
     }
 
     private static string FindRepoRoot()

--- a/src/MediaIngest.Api/IngestRuntimeService.cs
+++ b/src/MediaIngest.Api/IngestRuntimeService.cs
@@ -170,6 +170,59 @@ public sealed class IngestRuntimeService(
                 packageState.Status);
     }
 
+    public WorkflowNodeDetailsDto? GetWorkflowNodeDetails(string workflowInstanceId, string nodeId)
+    {
+        if (string.IsNullOrWhiteSpace(workflowInstanceId) || string.IsNullOrWhiteSpace(nodeId))
+        {
+            return null;
+        }
+
+        var graph = GetWorkflowGraph(workflowInstanceId);
+        var node = graph?.Nodes.SingleOrDefault(candidate =>
+            string.Equals(candidate.NodeId, nodeId, StringComparison.Ordinal));
+
+        if (graph is null || node is null)
+        {
+            return null;
+        }
+
+        var packageState = store.PackageStates
+            .Where(packageState =>
+                string.Equals(packageState.WorkflowInstanceId, workflowInstanceId, StringComparison.Ordinal))
+            .OrderBy(packageState => packageState.UpdatedAt)
+            .LastOrDefault();
+
+        if (packageState is null)
+        {
+            return null;
+        }
+
+        var correlationId = $"correlation-{graph.PackageId}";
+        var occurredAt = packageState.UpdatedAt;
+
+        return new WorkflowNodeDetailsDto(
+            WorkflowInstanceId: graph.WorkflowInstanceId,
+            NodeId: node.NodeId,
+            Timeline:
+            [
+                new WorkflowTimelineEntryDto(
+                    OccurredAt: occurredAt,
+                    Status: node.Status,
+                    Message: $"{node.DisplayName} is {node.Status.ToString().ToLowerInvariant()}",
+                    CorrelationId: correlationId)
+            ],
+            Logs:
+            [
+                new WorkflowNodeLogEntryDto(
+                    OccurredAt: occurredAt,
+                    Level: node.Status == WorkflowNodeStatus.Failed ? "Error" : "Information",
+                    Message: $"{node.DisplayName} projected from in-memory workflow state.",
+                    CorrelationId: correlationId,
+                    TraceId: null,
+                    SpanId: null)
+            ]);
+    }
+
     public async ValueTask DisposeAsync()
     {
         CancellationTokenSource? cancellation;

--- a/tests/MediaIngest.Api.Tests/Program.cs
+++ b/tests/MediaIngest.Api.Tests/Program.cs
@@ -50,6 +50,18 @@ try
     var missingGraph = runtimeService.GetWorkflowGraph("missing-workflow");
     AssertNull(missingGraph, "missing graph");
 
+    var nodeDetails = runtimeService.GetWorkflowNodeDetails("package-asset-001", "scan-package")
+        ?? throw new InvalidOperationException("workflow node details endpoint source returned null.");
+    AssertEqual("package-asset-001", nodeDetails.WorkflowInstanceId, "node details workflow instance id");
+    AssertEqual("scan-package", nodeDetails.NodeId, "node details node id");
+    AssertEqual("Succeeded", nodeDetails.Timeline.Single().Status.ToString(), "node details timeline status");
+    AssertEqual("correlation-asset-001", nodeDetails.Timeline.Single().CorrelationId, "node details timeline correlation");
+    AssertEqual("Information", nodeDetails.Logs.Single().Level, "node details log level");
+    AssertEqual("correlation-asset-001", nodeDetails.Logs.Single().CorrelationId, "node details log correlation");
+
+    var missingNodeDetails = runtimeService.GetWorkflowNodeDetails("package-asset-001", "missing-node");
+    AssertNull(missingNodeDetails, "missing node details");
+
     AssertTrue(File.Exists(Path.Combine(outputPath, "asset-001", "manifest.json")), "manifest copied");
     AssertTrue(File.Exists(Path.Combine(outputPath, "asset-001", "manifest.json.checksum")), "checksum copied");
     AssertFalse(File.Exists(Path.Combine(outputPath, "asset-001", "source.mov")), "source file not copied");
@@ -101,6 +113,17 @@ try
     var graphJson = await graphResponse.Content.ReadAsStringAsync();
     AssertContains("\"workflowInstanceId\":\"package-asset-001\"", graphJson, "graph endpoint workflow instance id");
     AssertContains("\"packageId\":\"asset-001\"", graphJson, "graph endpoint package id");
+
+    using var nodeDetailsResponse = await apiHost.HttpClient.GetAsync("/api/workflows/package-asset-001/nodes/scan-package");
+    AssertEqual(System.Net.HttpStatusCode.OK, nodeDetailsResponse.StatusCode, "node details endpoint status");
+    var nodeDetailsJson = await nodeDetailsResponse.Content.ReadAsStringAsync();
+    AssertContains("\"workflowInstanceId\":\"package-asset-001\"", nodeDetailsJson, "node details endpoint workflow instance id");
+    AssertContains("\"nodeId\":\"scan-package\"", nodeDetailsJson, "node details endpoint node id");
+    AssertContains("\"timeline\":[", nodeDetailsJson, "node details endpoint timeline");
+    AssertContains("\"logs\":[", nodeDetailsJson, "node details endpoint logs");
+
+    using var missingNodeDetailsResponse = await apiHost.HttpClient.GetAsync("/api/workflows/package-asset-001/nodes/missing-node");
+    AssertEqual(System.Net.HttpStatusCode.NotFound, missingNodeDetailsResponse.StatusCode, "missing node details endpoint status");
 
     using var missingGraphResponse = await apiHost.HttpClient.GetAsync("/api/workflows/missing-workflow/graph");
     AssertEqual(System.Net.HttpStatusCode.NotFound, missingGraphResponse.StatusCode, "missing graph endpoint status");

--- a/web/ingest-control-plane/src/App.test.tsx
+++ b/web/ingest-control-plane/src/App.test.tsx
@@ -46,16 +46,16 @@ describe("workflow graph control plane", () => {
     expect(graph).toHaveClass("workflow-diagram__svg");
     expect(graph.innerHTML).toContain("<svg");
     expect(
-      screen.getByRole("listitem", { name: /manifest detected succeeded/i })
+      screen.getByRole("button", { name: /manifest detected succeeded/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("listitem", { name: /classify package running/i })
+      screen.getByRole("button", { name: /classify package running/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("listitem", { name: /proxy workflow waiting/i })
+      screen.getByRole("button", { name: /proxy workflow waiting/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("listitem", { name: /audio essence pending/i })
+      screen.getByRole("button", { name: /audio essence pending/i })
     ).toBeInTheDocument();
 
     expect(screen.getByText(/pending: 1/i)).toBeInTheDocument();
@@ -152,6 +152,143 @@ describe("workflow graph control plane", () => {
       expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/graph");
     });
     expect(await screen.findByRole("img", { name: /workflow diagram/i })).toBeInTheDocument();
+  });
+
+  it("loads node details when the operator selects a workflow graph node", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            packages: [
+              {
+                packageId: "PKG-LOCAL-001",
+                workflowInstanceId: "workflow-local-001",
+                status: "Running",
+                updatedAt: "2026-05-03T18:42:00Z"
+              }
+            ]
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 200
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(liveWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(classifyNodeDetailsResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      );
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/graph");
+    });
+    fireEvent.click(await screen.findByRole("button", { name: /classify package running/i }));
+
+    const details = await screen.findByRole("region", {
+      name: /selected workflow node details/i
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/nodes/classify");
+    expect(within(details).getByRole("heading", { name: /classify package/i })).toBeInTheDocument();
+    expect(within(details).getAllByText("node-classify")).toHaveLength(2);
+    expect(within(details).getByText(/Classification started/i)).toBeInTheDocument();
+    expect(within(details).getByText(/Command runner accepted classify work/i)).toBeInTheDocument();
+    expect(within(details).getByText(/trace-classify-001/i)).toBeInTheDocument();
+  });
+
+  it("keeps selected node details visible when package status refreshes for the same workflow", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            packages: [
+              {
+                packageId: "PKG-LOCAL-001",
+                workflowInstanceId: "workflow-local-001",
+                status: "Running",
+                updatedAt: "2026-05-03T18:42:00Z"
+              }
+            ]
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 200
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(liveWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(classifyNodeDetailsResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            packages: [
+              {
+                packageId: "PKG-LOCAL-001",
+                workflowInstanceId: "workflow-local-001",
+                status: "Running",
+                updatedAt: "2026-05-03T18:42:05Z"
+              }
+            ]
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 200
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(liveWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      );
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/graph");
+    });
+    fireEvent.click(await screen.findByRole("button", { name: /classify package running/i }));
+
+    const details = await screen.findByRole("region", {
+      name: /selected workflow node details/i
+    });
+
+    expect(within(details).getByRole("heading", { name: /classify package/i })).toBeInTheDocument();
+    expect(within(details).getByText(/Classification started/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /start ingest/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/ingest/start", { method: "POST" });
+    });
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/graph");
+    });
+
+    expect(within(details).getByRole("heading", { name: /classify package/i })).toBeInTheDocument();
+    expect(within(details).getByText(/Classification started/i)).toBeInTheDocument();
   });
 
   it("refreshes real package status while the operator watches ingest progress", async () => {
@@ -314,5 +451,28 @@ const liveWorkflowGraphResponse = {
     { edgeId: "classify-subtitle", sourceNodeId: "classify", targetNodeId: "subtitle" },
     { edgeId: "classify-video", sourceNodeId: "classify", targetNodeId: "video" },
     { edgeId: "video-done", sourceNodeId: "video", targetNodeId: "done" }
+  ]
+};
+
+const classifyNodeDetailsResponse = {
+  workflowInstanceId: "workflow-local-001",
+  nodeId: "classify",
+  timeline: [
+    {
+      occurredAt: "2026-05-03T18:42:00Z",
+      status: "Running",
+      message: "Classification started",
+      correlationId: "node-classify"
+    }
+  ],
+  logs: [
+    {
+      occurredAt: "2026-05-03T18:42:03Z",
+      level: "Information",
+      message: "Command runner accepted classify work",
+      correlationId: "node-classify",
+      traceId: "trace-classify-001",
+      spanId: "span-classify-001"
+    }
   ]
 };

--- a/web/ingest-control-plane/src/App.tsx
+++ b/web/ingest-control-plane/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import mermaid from "mermaid";
 
 import {
@@ -6,12 +6,14 @@ import {
   mockedWorkflowGraph,
   summarizeStatuses,
   type WorkflowGraph,
-  type WorkflowNode
+  type WorkflowNode,
+  type WorkflowNodeDetails
 } from "./workflowGraph";
 
 type LocalWatcherStatus = "idle" | "starting" | "watching" | "error";
 type PackageStatusLoadState = "loading" | "ready" | "error";
 type WorkflowGraphLoadState = "ready" | "loading" | "error";
+type WorkflowNodeDetailsLoadState = "idle" | "loading" | "ready" | "error";
 
 type IngestPackageStatus = {
   packageId: string;
@@ -66,6 +68,18 @@ async function fetchWorkflowGraph(workflowInstanceId: string) {
   return (await response.json()) as WorkflowGraph;
 }
 
+async function fetchWorkflowNodeDetails(workflowInstanceId: string, nodeId: string) {
+  const response = await fetch(
+    `/api/workflows/${encodeURIComponent(workflowInstanceId)}/nodes/${encodeURIComponent(nodeId)}`
+  );
+
+  if (!response.ok) {
+    throw new Error(`Workflow node details failed with ${response.status}`);
+  }
+
+  return (await response.json()) as WorkflowNodeDetails;
+}
+
 function formatStatus(status: WorkflowNode["status"]) {
   return status.toLowerCase();
 }
@@ -78,17 +92,91 @@ function formatUpdatedAt(updatedAt: string) {
   }).format(new Date(updatedAt));
 }
 
-function NodeCard({ node }: { node: WorkflowNode }) {
+function NodeCard({
+  node,
+  selected,
+  onSelect
+}: {
+  node: WorkflowNode;
+  selected: boolean;
+  onSelect: (node: WorkflowNode) => void;
+}) {
   return (
-    <li
-      className={`workflow-node workflow-node--${formatStatus(node.status)}`}
-      aria-label={`${node.displayName} ${formatStatus(node.status)}`}
-    >
-      <span className="workflow-node__status">{node.status}</span>
-      <strong>{node.displayName}</strong>
-      <span>{node.kind}</span>
-      <code>{node.workItemId ?? node.childWorkflowInstanceId ?? node.nodeId}</code>
+    <li>
+      <button
+        type="button"
+        className={`workflow-node workflow-node--${formatStatus(node.status)}`}
+        aria-label={`${node.displayName} ${formatStatus(node.status)}`}
+        aria-pressed={selected}
+        onClick={() => onSelect(node)}
+      >
+        <span className="workflow-node__status">{node.status}</span>
+        <strong>{node.displayName}</strong>
+        <span>{node.kind}</span>
+        <code>{node.workItemId ?? node.childWorkflowInstanceId ?? node.nodeId}</code>
+      </button>
     </li>
+  );
+}
+
+function NodeDetailsPanel({
+  selectedNode,
+  details,
+  loadState
+}: {
+  selectedNode?: WorkflowNode;
+  details?: WorkflowNodeDetails;
+  loadState: WorkflowNodeDetailsLoadState;
+}) {
+  return (
+    <section className="node-details-panel" aria-label="selected workflow node details">
+      <div className="section-heading">
+        <div>
+          <h2>{selectedNode?.displayName ?? "Node details"}</h2>
+          {selectedNode && <span>{selectedNode.nodeId}</span>}
+        </div>
+        {selectedNode && <span>{selectedNode.status}</span>}
+      </div>
+      {!selectedNode && <p>Select a workflow node to inspect details.</p>}
+      {selectedNode && loadState === "loading" && (
+        <p role="status">Loading node details...</p>
+      )}
+      {selectedNode && loadState === "error" && (
+        <p role="status">Node details unavailable</p>
+      )}
+      {selectedNode && loadState === "ready" && details && (
+        <div className="node-details-grid">
+          <div>
+            <h3>Timeline</h3>
+            <ol className="node-detail-rows">
+              {details.timeline.map((entry) => (
+                <li key={`${entry.occurredAt}-${entry.message}`}>
+                  <time dateTime={entry.occurredAt}>{formatUpdatedAt(entry.occurredAt)}</time>
+                  <strong>{entry.status}</strong>
+                  <span>{entry.message}</span>
+                  <code>{entry.correlationId}</code>
+                </li>
+              ))}
+            </ol>
+          </div>
+          <div>
+            <h3>Logs</h3>
+            <ol className="node-detail-rows">
+              {details.logs.map((entry) => (
+                <li key={`${entry.occurredAt}-${entry.message}`}>
+                  <time dateTime={entry.occurredAt}>{formatUpdatedAt(entry.occurredAt)}</time>
+                  <strong>{entry.level}</strong>
+                  <span>{entry.message}</span>
+                  <code>{entry.correlationId}</code>
+                  {entry.traceId && <code>{entry.traceId}</code>}
+                  {entry.spanId && <code>{entry.spanId}</code>}
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -141,6 +229,11 @@ export function App() {
     useState<WorkflowGraphLoadState>("ready");
   const [packageStatuses, setPackageStatuses] = useState<IngestPackageStatus[]>([]);
   const [graph, setGraph] = useState<WorkflowGraph>(mockedWorkflowGraph);
+  const [selectedNode, setSelectedNode] = useState<WorkflowNode>();
+  const [workflowNodeDetailsLoadState, setWorkflowNodeDetailsLoadState] =
+    useState<WorkflowNodeDetailsLoadState>("idle");
+  const [workflowNodeDetails, setWorkflowNodeDetails] = useState<WorkflowNodeDetails>();
+  const activeWorkflowInstanceIdRef = useRef(graph.workflowInstanceId);
   const statusSummary = summarizeStatuses(graph.nodes);
   const progressedNodeCount = graph.nodes.filter((node) =>
     progressedStatuses.has(node.status)
@@ -160,13 +253,35 @@ export function App() {
   const loadWorkflowGraph = useCallback(async (workflowInstanceId: string) => {
     setWorkflowGraphLoadState("loading");
 
+    if (activeWorkflowInstanceIdRef.current !== workflowInstanceId) {
+      setSelectedNode(undefined);
+      setWorkflowNodeDetails(undefined);
+      setWorkflowNodeDetailsLoadState("idle");
+    }
+
     try {
       const workflowGraph = await fetchWorkflowGraph(workflowInstanceId);
 
+      activeWorkflowInstanceIdRef.current = workflowGraph.workflowInstanceId;
       setGraph(workflowGraph);
       setWorkflowGraphLoadState("ready");
     } catch {
       setWorkflowGraphLoadState("error");
+    }
+  }, []);
+
+  const loadWorkflowNodeDetails = useCallback(async (node: WorkflowNode) => {
+    setSelectedNode(node);
+    setWorkflowNodeDetails(undefined);
+    setWorkflowNodeDetailsLoadState("loading");
+
+    try {
+      const details = await fetchWorkflowNodeDetails(node.workflowInstanceId, node.nodeId);
+
+      setWorkflowNodeDetails(details);
+      setWorkflowNodeDetailsLoadState("ready");
+    } catch {
+      setWorkflowNodeDetailsLoadState("error");
     }
   }, []);
 
@@ -297,10 +412,21 @@ export function App() {
         </div>
         <ol className="workflow-graph" aria-label="workflow graph node status">
           {graph.nodes.map((node) => (
-            <NodeCard key={node.nodeId} node={node} />
+            <NodeCard
+              key={node.nodeId}
+              node={node}
+              selected={selectedNode?.nodeId === node.nodeId}
+              onSelect={loadWorkflowNodeDetails}
+            />
           ))}
         </ol>
       </section>
+
+      <NodeDetailsPanel
+        selectedNode={selectedNode}
+        details={workflowNodeDetails}
+        loadState={workflowNodeDetailsLoadState}
+      />
     </main>
   );
 }

--- a/web/ingest-control-plane/src/styles.css
+++ b/web/ingest-control-plane/src/styles.css
@@ -73,7 +73,8 @@ h2 {
 .local-ingest-panel,
 .package-status-panel,
 .summary-band,
-.graph-section {
+.graph-section,
+.node-details-panel {
   border: 1px solid #d6dde5;
   border-radius: 8px;
   background: #ffffff;
@@ -215,7 +216,7 @@ h2 {
 }
 
 .graph-section {
-  margin: 0 auto;
+  margin: 0 auto 24px;
   max-width: 1180px;
   padding: 20px;
 }
@@ -257,14 +258,31 @@ h2 {
 
 .workflow-node {
   display: grid;
+  width: 100%;
+  height: 100%;
   gap: 8px;
+  text-align: left;
   min-height: 154px;
   border: 1px solid #cfd8e3;
   border-left: 8px solid #7b8794;
   border-radius: 8px;
   background: #ffffff;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
   padding: 14px;
   box-shadow: 0 8px 18px rgb(17 24 39 / 7%);
+}
+
+.workflow-node:hover,
+.workflow-node[aria-pressed="true"] {
+  border-color: #93b8d8;
+  box-shadow: 0 10px 22px rgb(17 24 39 / 11%);
+}
+
+.workflow-node:focus-visible {
+  outline: 3px solid #93c5fd;
+  outline-offset: 2px;
 }
 
 .workflow-node strong {
@@ -347,6 +365,58 @@ h2 {
   color: #4b5563;
 }
 
+.node-details-panel {
+  margin: 0 auto;
+  max-width: 1180px;
+  padding: 20px;
+}
+
+.node-details-panel p {
+  margin: 0;
+  color: #516170;
+  font-weight: 700;
+}
+
+.node-details-panel h3 {
+  margin: 0 0 10px;
+  font-size: 0.95rem;
+}
+
+.node-details-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.node-detail-rows {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.node-detail-rows li {
+  display: grid;
+  gap: 6px;
+  border: 1px solid #d6dde5;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.node-detail-rows time,
+.node-detail-rows span,
+.node-detail-rows code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.node-detail-rows time,
+.node-detail-rows code {
+  color: #576574;
+  font-size: 0.82rem;
+}
+
 @media (max-width: 900px) {
   .control-plane-header {
     flex-direction: column;
@@ -354,7 +424,8 @@ h2 {
 
   .workflow-metadata,
   .workflow-graph,
-  .package-status-item {
+  .package-status-item,
+  .node-details-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -371,7 +442,8 @@ h2 {
 
   .workflow-metadata,
   .workflow-graph,
-  .package-status-item {
+  .package-status-item,
+  .node-details-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/web/ingest-control-plane/src/workflowGraph.ts
+++ b/web/ingest-control-plane/src/workflowGraph.ts
@@ -40,6 +40,29 @@ export type WorkflowGraph = {
   edges: WorkflowEdge[];
 };
 
+export type WorkflowTimelineEntry = {
+  occurredAt: string;
+  status: WorkflowNodeStatus;
+  message: string;
+  correlationId: string;
+};
+
+export type WorkflowNodeLogEntry = {
+  occurredAt: string;
+  level: string;
+  message: string;
+  correlationId: string;
+  traceId?: string | null;
+  spanId?: string | null;
+};
+
+export type WorkflowNodeDetails = {
+  workflowInstanceId: string;
+  nodeId: string;
+  timeline: WorkflowTimelineEntry[];
+  logs: WorkflowNodeLogEntry[];
+};
+
 type WorkflowStatusStyle = {
   fill: string;
   stroke: string;


### PR DESCRIPTION
## Summary
- Adds an API route for workflow node details using existing node detail DTOs.
- Lets the React control plane select workflow graph nodes and show timeline/log rows.
- Preserves selected node details across same-workflow package status refreshes.

Refs #23

## Validation
- make test-dotnet-api passed.
- npm test --prefix web/ingest-control-plane passed.
- npm run build --prefix web/ingest-control-plane passed.
- make validate passed.
- git diff --check passed.

## Risk
Medium. This changes API/UI behavior in the local control plane; tests cover 200/404 API behavior and UI selection refresh behavior.

## Follow-up
Persistent timeline/log storage remains future USER-STORY-11/13 work.