### PR TITLE
USER-STORY-16: Document local ingest workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ introduced.
 
 ## Local Manifest Ingest Demo
 
-This draft workflow is an in-process local demo. It exercises the manifest start
-path through local folders and does not yet use real Dapr Workflow runtime,
-PostgreSQL, Azure Service Bus, or command runner services.
+This local workflow exercises the manifest start path through the API, React
+control plane, and repo-root runtime folders. It still runs in process for local
+development and does not use the real Dapr Workflow runtime, PostgreSQL, Azure
+Service Bus, or command runner services.
 
 Start the local ingest API on a fixed development port:
 
@@ -68,9 +69,9 @@ Start the local ingest API on a fixed development port:
 dotnet run --project src/MediaIngest.Api --urls http://127.0.0.1:5000
 ```
 
-Start the UI in another terminal. The UI sends `POST /api/ingest/start` as a
-same-origin request, so the Vite development server must proxy `/api` requests
-to `http://127.0.0.1:5000`.
+Start the UI in another terminal. The Vite development server proxies `/api`
+requests to `http://127.0.0.1:5000`, so the UI can call the API as a
+same-origin `/api/ingest/start` request.
 
 ```bash
 cd web/ingest-control-plane
@@ -79,9 +80,9 @@ npm run dev
 
 Open the Vite URL printed by the UI and press **Start ingest**. That starts the
 local watcher against the repo-root `input/` folder. After the watcher is
-running, create a package under the local runtime input folder. The manifest
-contents are opaque to this slice; the presence of `manifest.json` and
-`manifest.json.checksum` is the package start signal.
+running, create a package under `input/<asset>/`. The manifest contents are
+metadata; the presence of both `manifest.json` and `manifest.json.checksum` is
+the package start signal.
 
 ```bash
 mkdir -p input/asset-001
@@ -89,7 +90,8 @@ printf '%s\n' '{"asset":"asset-001"}' > input/asset-001/manifest.json
 printf '%s\n' 'local-demo-checksum' > input/asset-001/manifest.json.checksum
 ```
 
-The expected local output is:
+The expected local output is the matching manifest pair under
+`output/<asset>/`:
 
 ```text
 output/asset-001/manifest.json
@@ -98,6 +100,18 @@ output/asset-001/manifest.json.checksum
 
 The `input/` and `output/` directories are local runtime folders. Backend runtime
 setup owns the Git ignore rules for those folders.
+
+For a script-backed smoke path that matches this flow, start the API and run:
+
+```bash
+sh scripts/dev/local-e2e-smoke.sh
+```
+
+To validate the smoke plan without starting the API or touching files:
+
+```bash
+sh scripts/dev/local-e2e-smoke.sh --dry-run
+```
 
 ## Agent Tooling
 

--- a/docs/automation/commands.md
+++ b/docs/automation/commands.md
@@ -16,6 +16,8 @@
 | `make validate` | Run cheap repository validation. | cheap | no | no |
 | `make validate-docs` | Run documentation validation only. | cheap | no | no |
 | `make validate-automation` | Run shell syntax checks and GitHub helper wrapper tests. | cheap | no | no |
+| `dotnet run --project src/MediaIngest.Api --urls http://127.0.0.1:5000` | Start the local ingest API on the fixed development port. | cheap | no | no |
+| `cd web/ingest-control-plane && npm run dev` | Start the React control plane with Vite `/api` proxying to the local API. | cheap | no | no |
 | `sh scripts/dev/local-e2e-smoke.sh --dry-run` | Print the local manifest ingest E2E smoke plan without changing files or calling the API. | cheap | no | no |
 | `sh scripts/dev/local-e2e-smoke.sh` | Post local ingest start, create a smoke package, and assert manifest output files. Requires the API to be running locally. | cheap | no | no |
 | `make test-dotnet` | Build and smoke-test the .NET solution using host `dotnet` or the .NET SDK container. | moderate | yes when host `dotnet` is unavailable | no |

--- a/docs/automation/local-smoke-tests.md
+++ b/docs/automation/local-smoke-tests.md
@@ -2,8 +2,9 @@
 
 ## Manifest Ingest E2E
 
-Use `scripts/dev/local-e2e-smoke.sh` to exercise the draft local manifest ingest
-path from the repo-root `input/` folder to the repo-root `output/` folder.
+Use the manual UI flow or `scripts/dev/local-e2e-smoke.sh` to exercise the local
+manifest ingest path from the repo-root `input/` folder to the repo-root
+`output/` folder.
 
 Start the API first:
 
@@ -11,15 +12,43 @@ Start the API first:
 dotnet run --project src/MediaIngest.Api --urls http://127.0.0.1:5000
 ```
 
-Then run the smoke script from another terminal:
+### Manual UI Flow
+
+Start the React control plane in another terminal:
+
+```bash
+cd web/ingest-control-plane
+npm run dev
+```
+
+The Vite development server proxies `/api` requests to
+`http://127.0.0.1:5000`. Open the Vite URL, press **Start ingest**, then create
+the manifest package after the watcher has started:
+
+```bash
+mkdir -p input/asset-001
+printf '%s\n' '{"asset":"asset-001"}' > input/asset-001/manifest.json
+printf '%s\n' 'local-demo-checksum' > input/asset-001/manifest.json.checksum
+```
+
+The expected output is the matching manifest pair:
+
+```text
+output/asset-001/manifest.json
+output/asset-001/manifest.json.checksum
+```
+
+### Scripted Smoke
+
+Run the smoke script from another terminal after the API is listening:
 
 ```bash
 sh scripts/dev/local-e2e-smoke.sh
 ```
 
-The script resets only its selected package directory, posts
-`POST /api/ingest/start`, creates `manifest.json` and
-`manifest.json.checksum`, and waits for matching files under `output/`.
+The script resets only its selected `input/<asset>/` and `output/<asset>/`
+directories, posts `POST /api/ingest/start`, creates `manifest.json` and
+`manifest.json.checksum`, and waits for matching files under `output/<asset>/`.
 
 For dry-run validation without starting the API or changing files:
 

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -6,8 +6,8 @@
 - Current branch: `main`.
 - Current focus: local `main` contains the first implementation foundations
   across watcher, persistence/outbox, workflow, command routing, observability,
-  and the React control plane. Draft local ingest docs are tracking the sibling
-  backend and UI PRs until those branches merge.
+  and the React control plane. USER-STORY-16 local ingest docs now describe the
+  merged API, UI, runtime folder, and smoke-script flow.
 
 ## Completed
 
@@ -68,8 +68,8 @@
 - Agent execution tooling now includes focused .NET smoke-test targets, focused
   validation targets, an agent preflight command, and a repo-local ignored
   Docker .NET cache for faster repeated validation.
-- Draft README quickstart text documents the intended local manifest ingest
-  flow: run the API host on the fixed development port, run the UI with `/api`
+- README and automation docs document the current local manifest ingest flow:
+  run the API host on the fixed development port, run the UI with `/api`
   proxied to that API, press **Start ingest** to begin watching, then add
   `manifest.json` plus `manifest.json.checksum` under `input/<asset>/` and
   expect both manifest files under `output/<asset>/`.
@@ -91,13 +91,14 @@
 
 ## Ready For Review
 
+- USER-STORY-16 local ingest documentation is ready for coordinator review
+  after docs validation.
 - USER-STORY-17 runtime readiness branch is preparing PR validation.
 
 ## Next
 
-- Keep the local ingest docs PR in draft until the backend and UI slice PRs
-  merge the API host, UI **Start ingest** action, Vite `/api` proxy, and runtime
-  folder ignore setup.
+- Coordinator can review the USER-STORY-16 local ingest documentation branch
+  and decide whether to authorize PR creation.
 - Review USER-STORY-17 static runtime readiness assets before any approved
   cluster or Azure validation.
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -5,6 +5,10 @@ messages or paste command output unless it explains a decision.
 
 ## 2026-05-04
 
+- Updated USER-STORY-16 local ingest documentation after the backend, UI, and
+  runtime support slices merged, including the fixed API port, Vite `/api`
+  proxy, **Start ingest** flow, `input/<asset>/` manifest pair, expected
+  `output/<asset>/` output, and dry-run smoke-script path.
 - Completed the USER-STORY-2 Mount readiness gate so watcher code can observe
   package directories while exposing only manifest-plus-checksum packages as
   ready to start.


### PR DESCRIPTION
## Summary
- Updates README local manifest ingest instructions from draft to current flow.
- Documents API port, Vite /api proxy, Start ingest action, input manifest pair, and output manifest pair.
- Adds the manual UI flow to local smoke-test docs and command index entries.

Refs #26

## Validation
- make validate-docs passed.
- sh scripts/dev/local-e2e-smoke.sh --dry-run passed.
- git diff --check passed.

## Risk
Low. Docs-only update.

## Follow-up
Run the full local E2E smoke with the API running when runtime behavior changes again.