### PR TITLE
TASK-8-2: Add package workflow selection

### DIFF
--- a/web/ingest-control-plane/src/App.test.tsx
+++ b/web/ingest-control-plane/src/App.test.tsx
@@ -154,6 +154,67 @@ describe("workflow graph control plane", () => {
     expect(await screen.findByRole("img", { name: /workflow diagram/i })).toBeInTheDocument();
   });
 
+  it("loads the selected package workflow graph when the operator chooses the second package", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            packages: [
+              {
+                packageId: "PKG-LOCAL-001",
+                workflowInstanceId: "workflow-local-001",
+                status: "Running",
+                updatedAt: "2026-05-03T18:42:00Z"
+              },
+              {
+                packageId: "PKG-LOCAL-002",
+                workflowInstanceId: "workflow-local-002",
+                status: "Failed",
+                updatedAt: "2026-05-03T18:45:00Z"
+              }
+            ]
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 200
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(liveWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(secondWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      );
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/graph");
+    });
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /select package PKG-LOCAL-002 workflow workflow-local-002/i
+      })
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-002/graph");
+    });
+
+    expect(await screen.findByText(/Package PKG-2026-05-03-002/i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /transcode proxy queued/i })
+    ).toBeInTheDocument();
+  });
+
   it("loads node details when the operator selects a workflow graph node", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
@@ -289,6 +350,79 @@ describe("workflow graph control plane", () => {
 
     expect(within(details).getByRole("heading", { name: /classify package/i })).toBeInTheDocument();
     expect(within(details).getByText(/Classification started/i)).toBeInTheDocument();
+  });
+
+  it("clears selected node details when the operator switches workflows", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            packages: [
+              {
+                packageId: "PKG-LOCAL-001",
+                workflowInstanceId: "workflow-local-001",
+                status: "Running",
+                updatedAt: "2026-05-03T18:42:00Z"
+              },
+              {
+                packageId: "PKG-LOCAL-002",
+                workflowInstanceId: "workflow-local-002",
+                status: "Failed",
+                updatedAt: "2026-05-03T18:45:00Z"
+              }
+            ]
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 200
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(liveWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(classifyNodeDetailsResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(secondWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      );
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/graph");
+    });
+    fireEvent.click(await screen.findByRole("button", { name: /classify package running/i }));
+
+    const details = await screen.findByRole("region", {
+      name: /selected workflow node details/i
+    });
+
+    expect(within(details).getByText(/Classification started/i)).toBeInTheDocument();
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /select package PKG-LOCAL-002 workflow workflow-local-002/i
+      })
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-002/graph");
+    });
+
+    expect(within(details).getByRole("heading", { name: /node details/i })).toBeInTheDocument();
+    expect(within(details).getByText(/select a workflow node to inspect details/i)).toBeInTheDocument();
+    expect(within(details).queryByText(/Classification started/i)).not.toBeInTheDocument();
   });
 
   it("refreshes real package status while the operator watches ingest progress", async () => {
@@ -473,6 +607,42 @@ const classifyNodeDetailsResponse = {
       correlationId: "node-classify",
       traceId: "trace-classify-001",
       spanId: "span-classify-001"
+    }
+  ]
+};
+
+const secondWorkflowGraphResponse = {
+  workflowInstanceId: "workflow-local-002",
+  workflowName: "Package ingest workflow",
+  packageId: "PKG-2026-05-03-002",
+  parentWorkflowInstanceId: null,
+  nodes: [
+    {
+      nodeId: "manifest",
+      displayName: "Manifest detected",
+      kind: "WorkflowStep",
+      status: "Succeeded",
+      workflowInstanceId: "workflow-local-002",
+      packageId: "PKG-2026-05-03-002",
+      workItemId: null,
+      childWorkflowInstanceId: null
+    },
+    {
+      nodeId: "proxy-command",
+      displayName: "Transcode proxy",
+      kind: "WorkItem",
+      status: "Queued",
+      workflowInstanceId: "workflow-local-002",
+      packageId: "PKG-2026-05-03-002",
+      workItemId: "command-proxy-002",
+      childWorkflowInstanceId: null
+    }
+  ],
+  edges: [
+    {
+      edgeId: "manifest-proxy-command",
+      sourceNodeId: "manifest",
+      targetNodeId: "proxy-command"
     }
   ]
 };

--- a/web/ingest-control-plane/src/App.tsx
+++ b/web/ingest-control-plane/src/App.tsx
@@ -84,6 +84,24 @@ function formatStatus(status: WorkflowNode["status"]) {
   return status.toLowerCase();
 }
 
+function formatNodeKind(kind: WorkflowNode["kind"] | string) {
+  return kind
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/^./, (firstCharacter) => firstCharacter.toUpperCase());
+}
+
+function formatNodeReference(node: WorkflowNode) {
+  if (node.workItemId) {
+    return `Work item ${node.workItemId}`;
+  }
+
+  if (node.childWorkflowInstanceId) {
+    return `Child workflow ${node.childWorkflowInstanceId}`;
+  }
+
+  return `Node ${node.nodeId}`;
+}
+
 function formatUpdatedAt(updatedAt: string) {
   return new Intl.DateTimeFormat("en", {
     dateStyle: "medium",
@@ -106,14 +124,14 @@ function NodeCard({
       <button
         type="button"
         className={`workflow-node workflow-node--${formatStatus(node.status)}`}
-        aria-label={`${node.displayName} ${formatStatus(node.status)}`}
+        aria-label={`${node.displayName} ${formatStatus(node.status)} ${formatNodeKind(node.kind)}`}
         aria-pressed={selected}
         onClick={() => onSelect(node)}
       >
         <span className="workflow-node__status">{node.status}</span>
         <strong>{node.displayName}</strong>
-        <span>{node.kind}</span>
-        <code>{node.workItemId ?? node.childWorkflowInstanceId ?? node.nodeId}</code>
+        <span>{formatNodeKind(node.kind)}</span>
+        <code>{formatNodeReference(node)}</code>
       </button>
     </li>
   );
@@ -228,6 +246,7 @@ export function App() {
   const [workflowGraphLoadState, setWorkflowGraphLoadState] =
     useState<WorkflowGraphLoadState>("ready");
   const [packageStatuses, setPackageStatuses] = useState<IngestPackageStatus[]>([]);
+  const [selectedWorkflowInstanceId, setSelectedWorkflowInstanceId] = useState<string>();
   const [graph, setGraph] = useState<WorkflowGraph>(mockedWorkflowGraph);
   const [selectedNode, setSelectedNode] = useState<WorkflowNode>();
   const [workflowNodeDetailsLoadState, setWorkflowNodeDetailsLoadState] =
@@ -285,6 +304,16 @@ export function App() {
     }
   }, []);
 
+  const selectPackageWorkflow = useCallback((workflowInstanceId: string) => {
+    if (selectedWorkflowInstanceId !== workflowInstanceId) {
+      setSelectedNode(undefined);
+      setWorkflowNodeDetails(undefined);
+      setWorkflowNodeDetailsLoadState("idle");
+    }
+
+    setSelectedWorkflowInstanceId(workflowInstanceId);
+  }, [selectedWorkflowInstanceId]);
+
   useEffect(() => {
     void loadPackageStatuses();
     const refreshIntervalId = window.setInterval(
@@ -298,12 +327,20 @@ export function App() {
   }, [loadPackageStatuses]);
 
   useEffect(() => {
-    const selectedWorkflowInstanceId = packageStatuses[0]?.workflowInstanceId;
+    if (
+      packageStatusLoadState === "ready" &&
+      !selectedWorkflowInstanceId &&
+      packageStatuses[0]?.workflowInstanceId
+    ) {
+      setSelectedWorkflowInstanceId(packageStatuses[0].workflowInstanceId);
+    }
+  }, [packageStatusLoadState, packageStatuses, selectedWorkflowInstanceId]);
 
+  useEffect(() => {
     if (packageStatusLoadState === "ready" && selectedWorkflowInstanceId) {
       void loadWorkflowGraph(selectedWorkflowInstanceId);
     }
-  }, [loadWorkflowGraph, packageStatusLoadState, packageStatuses]);
+  }, [loadWorkflowGraph, packageStatusLoadState, packageStatuses, selectedWorkflowInstanceId]);
 
   async function startLocalIngest() {
     setLocalWatcherStatus("starting");
@@ -372,12 +409,22 @@ export function App() {
           <ol className="package-status-list">
             {packageStatuses.map((packageStatus) => (
               <li key={packageStatus.packageId} className="package-status-item">
-                <span className="package-status-item__state">
-                  {packageStatus.status}
-                </span>
-                <strong>{packageStatus.packageId}</strong>
-                <code>{packageStatus.workflowInstanceId}</code>
-                <span>Updated {formatUpdatedAt(packageStatus.updatedAt)}</span>
+                <button
+                  type="button"
+                  className="package-status-button"
+                  aria-label={`Select package ${packageStatus.packageId} workflow ${packageStatus.workflowInstanceId}`}
+                  aria-pressed={
+                    selectedWorkflowInstanceId === packageStatus.workflowInstanceId
+                  }
+                  onClick={() => selectPackageWorkflow(packageStatus.workflowInstanceId)}
+                >
+                  <span className="package-status-item__state">
+                    {packageStatus.status}
+                  </span>
+                  <strong>{packageStatus.packageId}</strong>
+                  <code>{packageStatus.workflowInstanceId}</code>
+                  <span>Updated {formatUpdatedAt(packageStatus.updatedAt)}</span>
+                </button>
               </li>
             ))}
           </ol>

--- a/web/ingest-control-plane/src/styles.css
+++ b/web/ingest-control-plane/src/styles.css
@@ -133,25 +133,46 @@ h2 {
 }
 
 .package-status-item {
+  display: block;
+}
+
+.package-status-button {
   display: grid;
   grid-template-columns:
     minmax(160px, 1.2fr) minmax(180px, 1.4fr) minmax(160px, 1fr) auto;
   gap: 12px;
   align-items: center;
+  width: 100%;
   border: 1px solid #d6dde5;
   border-radius: 8px;
+  background: #ffffff;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
   padding: 12px;
+  text-align: left;
 }
 
-.package-status-item strong,
-.package-status-item code,
-.package-status-item span {
+.package-status-button:hover,
+.package-status-button[aria-pressed="true"] {
+  border-color: #93b8d8;
+  box-shadow: 0 8px 18px rgb(17 24 39 / 8%);
+}
+
+.package-status-button:focus-visible {
+  outline: 3px solid #93c5fd;
+  outline-offset: 2px;
+}
+
+.package-status-button strong,
+.package-status-button code,
+.package-status-button span {
   min-width: 0;
   overflow-wrap: anywhere;
 }
 
-.package-status-item code,
-.package-status-item span:not(.package-status-item__state) {
+.package-status-button code,
+.package-status-button span:not(.package-status-item__state) {
   color: #576574;
   font-size: 0.84rem;
 }
@@ -424,7 +445,7 @@ h2 {
 
   .workflow-metadata,
   .workflow-graph,
-  .package-status-item,
+  .package-status-button,
   .node-details-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -442,7 +463,7 @@ h2 {
 
   .workflow-metadata,
   .workflow-graph,
-  .package-status-item,
+  .package-status-button,
   .node-details-grid {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## Summary
- Lets operators choose which package workflow graph to inspect when status returns multiple packages.
- Keeps first-package auto-selection as the initial default.
- Preserves node detail during same-workflow refresh and clears it when switching workflows.

## Linked Work
Refs USER-STORY-12
Refs USER-STORY-13

## Validation
- `make validate` passed on the integrated local branch.
- `npm test -- --run` passed for the control plane.
- `git diff --check HEAD~7..HEAD` passed.

## Risk
- UI-only behavior with no backend DTO changes or new dependencies.

## Follow-up
- Expand node log/timeline detail in the next Canvas slice.