### PR TITLE
TASK-3-3: Add done-marker reconciliation

### DIFF
--- a/src/MediaIngest.Api/IngestRuntimeService.cs
+++ b/src/MediaIngest.Api/IngestRuntimeService.cs
@@ -18,6 +18,7 @@ public sealed class IngestRuntimeService(
     OutboxDispatcher outboxDispatcher) : IAsyncDisposable
 {
     private static readonly TimeSpan WatchInterval = TimeSpan.FromMilliseconds(100);
+    private readonly DoneMarkerReadinessGate doneMarkerGate = new();
 
     private readonly object watcherLock = new();
     private readonly HashSet<string> terminalPackageIds = new(StringComparer.Ordinal);
@@ -80,52 +81,36 @@ public sealed class IngestRuntimeService(
             foreach (var candidate in candidates.Where(readinessGate.IsReady))
             {
                 var packageId = Path.GetFileName(candidate.PackagePath);
+                var latestState = GetLatestPackageState(packageId);
 
-                if (terminalPackageIds.Contains(packageId))
+                if (terminalPackageIds.Contains(packageId) || IsTerminal(latestState?.Status))
                 {
+                    terminalPackageIds.Add(packageId);
                     continue;
                 }
 
-                var acceptedAt = DateTimeOffset.UtcNow;
-                var workflowStart = workflowStarter.Start(new PackageIngestRequest(
-                    PackageId: packageId,
-                    PackagePath: candidate.PackagePath,
-                    CorrelationId: $"correlation-{packageId}",
-                    AcceptedAt: acceptedAt));
+                var workflowStart = CreateWorkflowStart(packageId, candidate.PackagePath);
 
-                var message = CreateLocalTransferMessage(workflowStart, paths.OutputPath);
-                var mediaCommandMessages = CreateMediaCommandMessages(
+                if (latestState is null)
+                {
+                    var message = CreateLocalTransferMessage(workflowStart, paths.OutputPath);
+                    var mediaCommandMessages = CreateMediaCommandMessages(
+                        workflowStart,
+                        scanner.FindPackageFiles(candidate));
+
+                    await store.SaveAsync(new PersistenceBatch(
+                        [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Started", workflowStart.AcceptedAt)],
+                        [message, .. mediaCommandMessages]), cancellationToken);
+
+                    startedPackages.Add(new StartedIngestPackageResponse(
+                        packageId,
+                        workflowStart.WorkflowInstanceId));
+                }
+
+                hadTransferConflict |= await DispatchAndMaybeCompleteAsync(
+                    candidate,
                     workflowStart,
-                    scanner.FindPackageFiles(candidate));
-
-                await store.SaveAsync(new PersistenceBatch(
-                    [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Started", acceptedAt)],
-                    [message, .. mediaCommandMessages]), cancellationToken);
-
-                startedPackages.Add(new StartedIngestPackageResponse(
-                    packageId,
-                    workflowStart.WorkflowInstanceId));
-
-                try
-                {
-                    await outboxDispatcher.DispatchPendingAsync(cancellationToken);
-                    await store.SaveAsync(new PersistenceBatch(
-                        [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Succeeded", DateTimeOffset.UtcNow)],
-                        []), cancellationToken);
-                    terminalPackageIds.Add(packageId);
-                }
-                catch (LocalManifestTransferConflictException)
-                {
-                    hadTransferConflict = true;
-                    await store.MarkOutboxMessageDispatchedAsync(
-                        message.MessageId,
-                        DateTimeOffset.UtcNow,
-                        cancellationToken);
-                    await store.SaveAsync(new PersistenceBatch(
-                        [new IngestPackageState(packageId, workflowStart.WorkflowInstanceId, "Failed", DateTimeOffset.UtcNow)],
-                        []), cancellationToken);
-                    terminalPackageIds.Add(packageId);
-                }
+                    cancellationToken);
             }
 
             return new IngestStartResult(
@@ -136,6 +121,94 @@ public sealed class IngestRuntimeService(
         {
             scanLock.Release();
         }
+    }
+
+    private PackageWorkflowStart CreateWorkflowStart(string packageId, string packagePath)
+    {
+        return workflowStarter.Start(new PackageIngestRequest(
+            PackageId: packageId,
+            PackagePath: packagePath,
+            CorrelationId: $"correlation-{packageId}",
+            AcceptedAt: DateTimeOffset.UtcNow));
+    }
+
+    private async Task<bool> DispatchAndMaybeCompleteAsync(
+        IngestPackageCandidate candidate,
+        PackageWorkflowStart workflowStart,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await outboxDispatcher.DispatchPendingAsync(cancellationToken);
+
+            if (!doneMarkerGate.IsDone(candidate))
+            {
+                return false;
+            }
+
+            var mediaCommandMessages = CreateMediaCommandMessages(
+                workflowStart,
+                scanner.FindPackageFiles(candidate));
+
+            await store.SaveAsync(new PersistenceBatch(
+                [],
+                mediaCommandMessages), cancellationToken);
+            await outboxDispatcher.DispatchPendingAsync(cancellationToken);
+
+            await store.SaveAsync(new PersistenceBatch(
+                [new IngestPackageState(workflowStart.PackageId, workflowStart.WorkflowInstanceId, "Succeeded", DateTimeOffset.UtcNow)],
+                []), cancellationToken);
+            terminalPackageIds.Add(workflowStart.PackageId);
+
+            return false;
+        }
+        catch (LocalManifestTransferConflictException)
+        {
+            var messageId = GetPendingLocalTransferMessageId(workflowStart.PackageId);
+
+            if (messageId is null)
+            {
+                throw;
+            }
+
+            await store.MarkOutboxMessageDispatchedAsync(
+                messageId,
+                DateTimeOffset.UtcNow,
+                cancellationToken);
+            await store.SaveAsync(new PersistenceBatch(
+                [new IngestPackageState(workflowStart.PackageId, workflowStart.WorkflowInstanceId, "Failed", DateTimeOffset.UtcNow)],
+                []), cancellationToken);
+            terminalPackageIds.Add(workflowStart.PackageId);
+
+            return true;
+        }
+    }
+
+    private string? GetPendingLocalTransferMessageId(string packageId)
+    {
+        return store.OutboxMessages
+            .Where(message =>
+                message.MessageType == nameof(LocalManifestTransferRequest)
+                && string.Equals(message.CorrelationId, $"correlation-{packageId}", StringComparison.Ordinal)
+                && string.Equals(message.Destination, "local.manifest.transfer", StringComparison.Ordinal)
+                && message.DispatchedAt is null)
+            .OrderBy(message => message.CreatedAt)
+            .Select(message => message.MessageId)
+            .FirstOrDefault();
+    }
+
+    private IngestPackageState? GetLatestPackageState(string packageId)
+    {
+        return store.PackageStates
+            .Where(packageState => string.Equals(packageState.PackageId, packageId, StringComparison.Ordinal))
+            .OrderBy(packageState => packageState.UpdatedAt)
+            .LastOrDefault();
+    }
+
+    private static bool IsTerminal(string? status)
+    {
+        return string.Equals(status, "Succeeded", StringComparison.Ordinal)
+            || string.Equals(status, "Failed", StringComparison.Ordinal);
     }
 
     public IngestStatusResponse GetStatus()

--- a/tests/MediaIngest.Api.Tests/Program.cs
+++ b/tests/MediaIngest.Api.Tests/Program.cs
@@ -33,8 +33,17 @@ try
     File.WriteAllText(Path.Combine(packagePath, "notes.bin"), "unknown essence");
 
     await WaitForAsync(
+        () => runtimeService.GetStatus().Packages.SingleOrDefault() is not null,
+        "package created after start");
+
+    AssertEqual("Started", runtimeService.GetStatus().Packages.Single().Status, "status before done marker");
+
+    File.WriteAllText(Path.Combine(mediaPath, "late.mov"), "late video before done marker");
+    File.WriteAllText(Path.Combine(packagePath, "done.marker"), string.Empty);
+
+    await WaitForAsync(
         () => runtimeService.GetStatus().Packages.SingleOrDefault()?.Status == "Succeeded",
-        "package created after start to succeed");
+        "package to succeed after done marker");
 
     var startedStatus = runtimeService.GetStatus();
     AssertEqual(1, startedStatus.Packages.Count, "started package count");
@@ -46,13 +55,14 @@ try
     AssertEqual("package-asset-001", graph.WorkflowInstanceId, "graph workflow instance id");
     AssertEqual("PackageIngestWorkflow", graph.WorkflowName, "graph workflow name");
     AssertEqual("asset-001", graph.PackageId, "graph package id");
-    AssertEqual(10, graph.Nodes.Count, "graph node count");
-    AssertEqual(9, graph.Edges.Count, "graph edge count");
+    AssertEqual(11, graph.Nodes.Count, "graph node count");
+    AssertEqual(10, graph.Edges.Count, "graph edge count");
     AssertEqual("package-start", graph.Nodes[0].NodeId, "graph first node id");
     AssertEqual("scan-package", graph.Nodes[1].NodeId, "graph scan node id");
     AssertEqual("classify-files", graph.Nodes[2].NodeId, "graph classify node id");
     AssertEqual("dispatch-processing", graph.Nodes[3].NodeId, "graph dispatch node id");
     AssertTrue(graph.Nodes.Any(node => node.NodeId == "command-media-mix-wav"), "audio command graph node");
+    AssertTrue(graph.Nodes.Any(node => node.NodeId == "command-media-late-mov"), "late video command graph node");
     AssertTrue(graph.Nodes.Any(node => node.NodeId == "command-media-source-mov"), "video command graph node");
     AssertTrue(graph.Nodes.Any(node => node.NodeId == "command-sidecars-caption-srt"), "text command graph node");
     AssertTrue(graph.Nodes.Any(node => node.NodeId == "command-notes-bin"), "other command graph node");
@@ -64,7 +74,7 @@ try
         .Where(message => message.MessageType == nameof(MediaCommandEnvelope))
         .OrderBy(message => message.MessageId, StringComparer.Ordinal)
         .ToArray();
-    AssertEqual(4, mediaCommandMessages.Length, "media command message count");
+    AssertEqual(5, mediaCommandMessages.Length, "media command message count");
     AssertTrue(mediaCommandMessages.All(message => message.DispatchedAt is not null), "media command messages dispatched");
 
     var commands = mediaCommandMessages
@@ -73,15 +83,17 @@ try
         .OrderBy(command => command.InputPaths.Single(), StringComparer.Ordinal)
         .ToArray();
 
-    AssertEqual(Path.Combine(packagePath, "media", "mix.wav"), commands[0].InputPaths.Single(), "audio command input");
-    AssertEqual(CommandNames.CreateProxy, commands[0].CommandName, "audio command name");
-    AssertEqual(ExecutionClass.Light, commands[0].ExecutionClass, "audio command execution class");
-    AssertEqual(Path.Combine(packagePath, "media", "source.mov"), commands[1].InputPaths.Single(), "video command input");
-    AssertEqual(CommandNames.CreateProxy, commands[1].CommandName, "video command name");
-    AssertEqual(Path.Combine(packagePath, "notes.bin"), commands[2].InputPaths.Single(), "other command input");
-    AssertEqual(CommandNames.CreateChecksum, commands[2].CommandName, "other command name");
-    AssertEqual(Path.Combine(packagePath, "sidecars", "caption.srt"), commands[3].InputPaths.Single(), "text command input");
-    AssertEqual(CommandNames.RunSecurityScan, commands[3].CommandName, "text command name");
+    AssertEqual(Path.Combine(packagePath, "media", "late.mov"), commands[0].InputPaths.Single(), "late video command input");
+    AssertEqual(CommandNames.CreateProxy, commands[0].CommandName, "late video command name");
+    AssertEqual(ExecutionClass.Light, commands[0].ExecutionClass, "late video command execution class");
+    AssertEqual(Path.Combine(packagePath, "media", "mix.wav"), commands[1].InputPaths.Single(), "audio command input");
+    AssertEqual(CommandNames.CreateProxy, commands[1].CommandName, "audio command name");
+    AssertEqual(Path.Combine(packagePath, "media", "source.mov"), commands[2].InputPaths.Single(), "video command input");
+    AssertEqual(CommandNames.CreateProxy, commands[2].CommandName, "video command name");
+    AssertEqual(Path.Combine(packagePath, "notes.bin"), commands[3].InputPaths.Single(), "other command input");
+    AssertEqual(CommandNames.CreateChecksum, commands[3].CommandName, "other command name");
+    AssertEqual(Path.Combine(packagePath, "sidecars", "caption.srt"), commands[4].InputPaths.Single(), "text command input");
+    AssertEqual(CommandNames.RunSecurityScan, commands[4].CommandName, "text command name");
 
     var missingGraph = runtimeService.GetWorkflowGraph("missing-workflow");
     AssertNull(missingGraph, "missing graph");


### PR DESCRIPTION
## Summary
- Allows manifest-ready packages to begin work before done.marker exists.
- Keeps packages non-terminal until a zero-byte done.marker is observed.
- Rescans on marker arrival and idempotently enqueues late non-metadata files.

## Linked Work
Refs USER-STORY-4

## Validation
- make validate passed on the integrated local branch.
- npm test -- --run passed for the control plane.
- git diff --check HEAD~7..HEAD passed.

## Risk
- Local in-memory runtime behavior only; no cloud resources or paid validation.

## Follow-up
- Continue with node log/timeline detail or nested workflow drilldown planning.