### PR TITLE
TASK-4-2: Add local command dispatch boundary

### DIFF
--- a/src/MediaIngest.Worker.Outbox/MediaIngest.Worker.Outbox.csproj
+++ b/src/MediaIngest.Worker.Outbox/MediaIngest.Worker.Outbox.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../MediaIngest.Contracts/MediaIngest.Contracts.csproj" />
     <ProjectReference Include="../MediaIngest.Persistence/MediaIngest.Persistence.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MediaIngest.Worker.Outbox/OutboxPublishRequest.cs
+++ b/src/MediaIngest.Worker.Outbox/OutboxPublishRequest.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using MediaIngest.Contracts.Commands;
 using MediaIngest.Persistence;
 
 namespace MediaIngest.Worker.Outbox;
@@ -7,53 +8,39 @@ public sealed record OutboxPublishRequest(
     OutboxMessage Message,
     IReadOnlyDictionary<string, string> ApplicationProperties)
 {
-    public const string ExecutionClassPropertyName = "executionClass";
-
-    private static readonly HashSet<string> ExecutionClassValues = new(StringComparer.Ordinal)
-    {
-        "light",
-        "medium",
-        "heavy"
-    };
-
     public static OutboxPublishRequest From(OutboxMessage message)
     {
         var applicationProperties = new Dictionary<string, string>(StringComparer.Ordinal);
 
-        if (TryReadExecutionClass(message.PayloadJson, out var executionClass))
+        if (IsMediaCommandEnvelope(message))
         {
-            applicationProperties[ExecutionClassPropertyName] = executionClass;
-        }
-        else if (IsSemanticCommandTopic(message.Destination))
-        {
-            throw new InvalidOperationException(
-                $"Command outbox message '{message.MessageId}' must include an executionClass value.");
+            applicationProperties[CommandRoute.ExecutionClassPropertyName] = ReadExecutionClass(message);
         }
 
         return new OutboxPublishRequest(message, applicationProperties);
     }
 
-    private static bool IsSemanticCommandTopic(string destination)
+    private static bool IsMediaCommandEnvelope(OutboxMessage message)
     {
-        return destination.StartsWith("media.command.", StringComparison.Ordinal);
+        return string.Equals(message.MessageType, nameof(MediaCommandEnvelope), StringComparison.Ordinal);
     }
 
-    private static bool TryReadExecutionClass(string payloadJson, out string executionClass)
+    private static string ReadExecutionClass(OutboxMessage message)
     {
-        executionClass = string.Empty;
-
-        using var document = JsonDocument.Parse(payloadJson);
+        using var document = JsonDocument.Parse(message.PayloadJson);
         var root = document.RootElement;
 
         if (root.ValueKind != JsonValueKind.Object)
         {
-            return false;
+            throw new InvalidOperationException(
+                $"Command outbox message '{message.MessageId}' must contain a JSON object payload.");
         }
 
         if (!TryGetProperty(root, "executionClass", out var executionClassProperty)
             && !TryGetProperty(root, "ExecutionClass", out executionClassProperty))
         {
-            return false;
+            throw new InvalidOperationException(
+                $"Command outbox message '{message.MessageId}' must include an executionClass value.");
         }
 
         if (executionClassProperty.ValueKind != JsonValueKind.String)
@@ -68,15 +55,14 @@ public sealed record OutboxPublishRequest(
             throw new InvalidOperationException("Command executionClass is required.");
         }
 
-        var normalizedValue = value.ToLowerInvariant();
-
-        if (!ExecutionClassValues.Contains(normalizedValue))
+        try
         {
-            throw new InvalidOperationException("Command executionClass must be light, medium, or heavy.");
+            return ExecutionClassProperties.FromPropertyValue(value).ToPropertyValue();
         }
-
-        executionClass = normalizedValue;
-        return true;
+        catch (ArgumentOutOfRangeException ex)
+        {
+            throw new InvalidOperationException("Command executionClass must be light, medium, or heavy.", ex);
+        }
     }
 
     private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement property)

--- a/tests/MediaIngest.Worker.Outbox.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Outbox.Tests/Program.cs
@@ -1,8 +1,11 @@
+using System.Text.Json;
+using MediaIngest.Contracts.Commands;
 using MediaIngest.Persistence;
 using MediaIngest.Worker.Outbox;
 
 await DispatchPendingMessagesPublishesAndMarksThemWithTheDispatchTime();
 await DispatchPendingCommandMessagesPublishesExecutionClassMetadata();
+await NonCommandMessagesDoNotPublishCommandApplicationProperties();
 await OutboxPublishersCannotDropApplicationProperties();
 await DispatchPendingMessagesDoesNothingWhenNoMessagesArePending();
 await DispatchPendingMessagesLeavesTheMessagePendingWhenPublishFails();
@@ -46,7 +49,16 @@ static async Task DispatchPendingCommandMessagesPublishesExecutionClassMetadata(
         destination: "media.command.archive_asset",
         messageType: "MediaCommandEnvelope",
         createdAt: new DateTimeOffset(2026, 5, 3, 12, 6, 0, TimeSpan.Zero),
-        executionClass: "heavy");
+        payloadJson: JsonSerializer.Serialize(new MediaCommandEnvelope(
+            CommandId: "command-heavy",
+            CommandName: CommandNames.ArchiveAsset,
+            TopicName: CommandNames.ArchiveAsset,
+            ExecutionClass: ExecutionClass.Heavy,
+            CommandLine: "archive package-001",
+            WorkingDirectory: "/mnt/work/package-001",
+            InputPaths: ["/mnt/ingest/package-001/source.mov"],
+            OutputPaths: ["/mnt/archive/package-001/source.mov"],
+            CorrelationId: "correlation-001")));
 
     await store.SaveAsync(new PersistenceBatch([], [message]));
 
@@ -61,7 +73,35 @@ static async Task DispatchPendingCommandMessagesPublishesExecutionClassMetadata(
     AssertEqual(1, dispatchedCount, "command dispatch count");
     AssertEqual(1, publisher.Published.Count, "command publish request count");
     AssertEqual("media.command.archive_asset", publisher.Published[0].Message.Destination, "command publish destination");
-    AssertEqual("heavy", publisher.Published[0].ApplicationProperties["executionClass"], "command execution class property");
+    AssertEqual(
+        "heavy",
+        publisher.Published[0].ApplicationProperties[CommandRoute.ExecutionClassPropertyName],
+        "command execution class property");
+}
+
+static async Task NonCommandMessagesDoNotPublishCommandApplicationProperties()
+{
+    var store = new InMemoryIngestPersistenceStore();
+    var message = CreateMessage(
+        messageId: "message-event-with-execution-class",
+        destination: "media.event.package_scanned",
+        messageType: "PackageScannedEvent",
+        createdAt: new DateTimeOffset(2026, 5, 3, 12, 8, 0, TimeSpan.Zero),
+        executionClass: "heavy");
+
+    await store.SaveAsync(new PersistenceBatch([], [message]));
+
+    var publisher = new RecordingOutboxPublisher();
+    var dispatcher = new OutboxDispatcher(
+        store,
+        publisher,
+        new FixedTimeProvider(new DateTimeOffset(2026, 5, 3, 12, 9, 0, TimeSpan.Zero)));
+
+    var dispatchedCount = await dispatcher.DispatchPendingAsync();
+
+    AssertEqual(1, dispatchedCount, "non-command dispatch count");
+    AssertEqual(1, publisher.Published.Count, "non-command publish request count");
+    AssertEqual(0, publisher.Published[0].ApplicationProperties.Count, "non-command application property count");
 }
 
 static Task OutboxPublishersCannotDropApplicationProperties()
@@ -196,13 +236,14 @@ static OutboxMessage CreateMessage(
     string destination,
     string messageType,
     DateTimeOffset createdAt,
-    string executionClass = "light")
+    string executionClass = "light",
+    string? payloadJson = null)
 {
     return new OutboxMessage(
         MessageId: messageId,
         Destination: destination,
         MessageType: messageType,
-        PayloadJson: $$"""{"packageId":"package-001","executionClass":"{{executionClass}}"}""",
+        PayloadJson: payloadJson ?? $$"""{"packageId":"package-001","executionClass":"{{executionClass}}"}""",
         CorrelationId: "correlation-001",
         CreatedAt: createdAt);
 }


### PR DESCRIPTION
## Summary
- Adds broker-ready application properties for command outbox publishes.
- Uses the command route execution class property name and lower-case execution class values.
- Preserves existing behavior for non-command outbox messages.

## Linked Work
Refs USER-STORY-6
Refs USER-STORY-8

## Validation
- make validate passed on the integrated local branch.
- npm test -- --run passed for the control plane.
- git diff --check HEAD~7..HEAD passed.

## Risk
- No Azure SDK or external broker dependency added; this remains a local dispatch boundary.

## Follow-up
- Define Azure Service Bus topic/subscription adapters in a later approved slice.