### PR TITLE
TASK-3-3: Record resumed local integration

### DIFF
--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -24,6 +24,15 @@ epic/story granularity; detailed implementation tasks belong in plans.
   control-plane rendering slice.
 - MILESTONE-3/4/5/8: integrate the local ingest demo so discovered files create
   routed command outbox messages and real workflow command nodes.
+- MILESTONE-3 / USER-STORY-4: reconcile on `done.marker` so packages remain
+  non-terminal until a zero-byte marker appears and late files are included in
+  command outbox work.
+- MILESTONE-4 / USER-STORY-6 / USER-STORY-8: expose broker-ready command
+  publish metadata at the local outbox boundary without changing non-command
+  dispatch behavior.
+- MILESTONE-8 / USER-STORY-12 / USER-STORY-13: add package workflow selection
+  to the control plane and preserve or clear node detail state according to the
+  selected workflow.
 
 ## Ready For Planning
 
@@ -32,9 +41,6 @@ epic/story granularity; detailed implementation tasks belong in plans.
 - MILESTONE-2 / USER-STORY-16: merge the local ingest docs after the backend and
   UI draft PRs provide the documented API host, UI start action, and runtime
   ignore setup.
-- MILESTONE-3 / USER-STORY-4: deepen done-marker reconciliation beyond local
-  graph projection into package finalization behavior.
-- MILESTONE-3 / USER-STORY-5: implement essence classification.
 - MILESTONE-4 / USER-STORY-6: define Azure Service Bus topic/subscription
   adapters and local development strategy.
 - MILESTONE-5 / USER-STORY-10: expand nested workflow contracts and behavior.

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -6,8 +6,10 @@
 - Current branch: `main`.
 - Current focus: local `main` contains the first implementation foundations
   across watcher, persistence/outbox, workflow, command routing, observability,
-  and the React control plane. USER-STORY-16 local ingest docs now describe the
-  merged API, UI, runtime folder, and smoke-script flow.
+  and the React control plane. The local ingest demo now waits for a zero-byte
+  `done.marker` before terminal success, routes command publish metadata for
+  local outbox dispatch, and lets the UI select among multiple package workflow
+  graphs.
 
 ## Completed
 
@@ -93,19 +95,21 @@
   projection, and the local smoke script. Ready packages now create routed
   command envelopes for every non-metadata file and expose those command nodes
   through the workflow graph API.
-
-## Ready For Review
-
-- USER-STORY-16 local ingest documentation is ready for coordinator review
-  after docs validation.
-- USER-STORY-17 runtime readiness branch is preparing PR validation.
+- TASK-3-3 added done-marker reconciliation so manifest-ready packages can begin
+  work before `done.marker`, remain non-terminal while waiting, rescan on a
+  zero-byte marker, and enqueue late discovered files idempotently.
+- TASK-4-2 added local command dispatch boundary metadata so
+  `MediaCommandEnvelope` outbox publishes expose broker-ready `executionClass`
+  application properties while non-command messages keep existing behavior.
+- TASK-8-2 added multi-package workflow selection in the React control plane,
+  preserving node detail during same-workflow refreshes and clearing detail when
+  the operator switches workflows.
 
 ## Next
 
-- Review TASK-3-2 local integration behavior and decide whether to authorize PR
-  creation.
-- Review USER-STORY-17 static runtime readiness assets before any approved
-  cluster or Azure validation.
+- Push or open a PR for the local `main` integration when authorized.
+- Plan the next runtime slice: nested workflow drilldown, node log/timeline
+  detail, or local container runtime validation.
 
 ## Update Rule
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -133,6 +133,18 @@ messages or paste command output unless it explains a decision.
   ClusterIP-only API/UI/PostgreSQL manifests, Dapr workflow state and Azure
   Service Bus component templates, placeholder-only secret examples, and
   architecture/automation docs that keep cloud validation approval-gated.
+- Resumed the interrupted local integration coordinator after Codex remote
+  compaction timed out, then merged and validated TASK-3-3, TASK-4-2, and
+  TASK-8-2 on `main`.
+- Added TASK-3-3 done-marker reconciliation: packages can begin after manifest
+  readiness, stay non-terminal until a zero-byte `done.marker`, and enqueue
+  late files after the marker rescan without duplicating command messages.
+- Added TASK-4-2 local command dispatch boundary metadata so command outbox
+  publishes expose `executionClass` application properties while non-command
+  publishes do not receive command metadata.
+- Added TASK-8-2 UI package workflow selection so operators can choose among
+  multiple package workflow graphs, keep node details on same-workflow refresh,
+  and clear node details when switching workflows.
 
 ## Update Rule
 


### PR DESCRIPTION
## Summary
- Records the resumed TASK-3-3, TASK-4-2, and TASK-8-2 local integration in durable status docs.
- Moves completed done-marker, command dispatch metadata, and package workflow selection work out of the ready-for-planning backlog.
- Updates next actions after the interrupted coordinator session was resumed.

## Linked Work
Refs USER-STORY-4
Refs USER-STORY-6
Refs USER-STORY-8
Refs USER-STORY-12
Refs USER-STORY-13

## Validation
- make docs-check passed on this branch.
- git diff --check origin/main..HEAD passed.
- Prior integrated validation before publishing: make validate, npm test -- --run, and git diff --check HEAD~7..HEAD passed.

## Risk
- Documentation-only status update.

## Follow-up
- Plan the next runtime slice: nested workflow drilldown, node log/timeline detail, or local container runtime validation.