### PR TITLE
TASK-8-3: Make Mermaid workflow graph interactive

### DIFF
--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -33,6 +33,9 @@ epic/story granularity; detailed implementation tasks belong in plans.
 - MILESTONE-8 / USER-STORY-12 / USER-STORY-13: add package workflow selection
   to the control plane and preserve or clear node detail state according to the
   selected workflow.
+- MILESTONE-8 / USER-STORY-13 / USER-STORY-14 / USER-STORY-15: make the
+  Mermaid workflow diagram interactive, remove the duplicated node-card graph,
+  and support child workflow drilldown with parent back navigation.
 
 ## Ready For Planning
 
@@ -44,8 +47,6 @@ epic/story granularity; detailed implementation tasks belong in plans.
 - MILESTONE-4 / USER-STORY-6: define Azure Service Bus topic/subscription
   adapters and local development strategy.
 - MILESTONE-5 / USER-STORY-10: expand nested workflow contracts and behavior.
-- MILESTONE-8 / USER-STORY-13 / USER-STORY-14 / USER-STORY-15: add node log
-  inspection, nested workflow drilldown, and back traversal.
 
 ## Later
 

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -104,12 +104,15 @@
 - TASK-8-2 added multi-package workflow selection in the React control plane,
   preserving node detail during same-workflow refreshes and clearing detail when
   the operator switches workflows.
+- TASK-8-3 made the Mermaid diagram the only workflow graph UI, with
+  React-managed SVG node activation, compact keyboard-accessible node
+  selection, child workflow drilldown, and parent back navigation.
 
 ## Next
 
 - Push or open a PR for the local `main` integration when authorized.
-- Plan the next runtime slice: nested workflow drilldown, node log/timeline
-  detail, or local container runtime validation.
+- Plan the next runtime slice: richer node log/timeline data sources or local
+  container runtime validation.
 
 ## Update Rule
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -145,6 +145,10 @@ messages or paste command output unless it explains a decision.
 - Added TASK-8-2 UI package workflow selection so operators can choose among
   multiple package workflow graphs, keep node details on same-workflow refresh,
   and clear node details when switching workflows.
+- Added TASK-8-3 interactive Mermaid workflow graph behavior: removed the
+  duplicated node-card list, bound React-managed activation handlers to rendered
+  Mermaid SVG nodes, added compact accessible node selection, and enabled child
+  workflow drilldown with parent back navigation.
 
 ## Update Rule
 

--- a/web/ingest-control-plane/src/App.test.tsx
+++ b/web/ingest-control-plane/src/App.test.tsx
@@ -7,10 +7,28 @@ vi.mock("mermaid", () => ({
   default: {
     initialize: vi.fn(),
     render: vi.fn(async (_id: string, diagram: string) => ({
-      svg: `<svg role="img" data-diagram="${encodeURIComponent(diagram)}"></svg>`
+      svg: renderMockMermaidSvg(diagram)
     }))
   }
 }));
+
+function renderMockMermaidSvg(diagram: string) {
+  const nodes = diagram
+    .split("\n")
+    .map((line) => line.match(/^\s+([A-Za-z_][A-Za-z0-9_]*)\["(.+)"\]:::/))
+    .filter((match): match is RegExpMatchArray => Boolean(match))
+    .map((match) => {
+      const label = match[2]
+        .replace(/#quot;/g, "\"")
+        .replace(/#91;/g, "[")
+        .replace(/#93;/g, "]");
+
+      return `<g id="flowchart-${match[1]}-0" class="node"><text>${label}</text></g>`;
+    })
+    .join("");
+
+  return `<svg role="img" data-diagram="${encodeURIComponent(diagram)}">${nodes}</svg>`;
+}
 
 describe("workflow graph control plane", () => {
   afterEach(() => {
@@ -33,7 +51,7 @@ describe("workflow graph control plane", () => {
         })
       );
 
-    render(<App />);
+    const { container } = render(<App />);
 
     expect(
       screen.getByRole("heading", { name: /workflow control plane/i })
@@ -45,17 +63,14 @@ describe("workflow graph control plane", () => {
 
     expect(graph).toHaveClass("workflow-diagram__svg");
     expect(graph.innerHTML).toContain("<svg");
+    expect(screen.queryByRole("list", { name: /workflow graph node status/i })).not.toBeInTheDocument();
+    expect(container.querySelector(".workflow-node")).not.toBeInTheDocument();
+    expect(graph.innerHTML).toContain("Manifest detected");
+    expect(graph.innerHTML).toContain("Classify package");
+    expect(graph.innerHTML).toContain("Proxy workflow");
+    expect(graph.innerHTML).toContain("Audio essence");
     expect(
-      screen.getByRole("button", { name: /manifest detected succeeded/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /classify package running/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /proxy workflow waiting/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /audio essence pending/i })
+      screen.getByRole("combobox", { name: /inspect workflow diagram node/i })
     ).toBeInTheDocument();
 
     expect(screen.getByText(/pending: 1/i)).toBeInTheDocument();
@@ -211,11 +226,11 @@ describe("workflow graph control plane", () => {
 
     expect(await screen.findByText(/Package PKG-2026-05-03-002/i)).toBeInTheDocument();
     expect(
-      await screen.findByRole("button", { name: /transcode proxy queued/i })
+      await screen.findByRole("button", { name: /transcode proxy queued work item/i })
     ).toBeInTheDocument();
   });
 
-  it("loads node details when the operator selects a workflow graph node", async () => {
+  it("loads node details when the operator clicks a Mermaid workflow graph node", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
         new Response(
@@ -253,7 +268,9 @@ describe("workflow graph control plane", () => {
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/graph");
     });
-    fireEvent.click(await screen.findByRole("button", { name: /classify package running/i }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: /classify package running activity/i })
+    );
 
     const details = await screen.findByRole("region", {
       name: /selected workflow node details/i
@@ -265,6 +282,113 @@ describe("workflow graph control plane", () => {
     expect(within(details).getByText(/Classification started/i)).toBeInTheDocument();
     expect(within(details).getByText(/Command runner accepted classify work/i)).toBeInTheDocument();
     expect(within(details).getByText(/trace-classify-001/i)).toBeInTheDocument();
+  });
+
+  it("drills into a child workflow when the operator clicks a Mermaid child workflow node", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            packages: [
+              {
+                packageId: "PKG-LOCAL-001",
+                workflowInstanceId: "workflow-local-001",
+                status: "Running",
+                updatedAt: "2026-05-03T18:42:00Z"
+              }
+            ]
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 200
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(liveWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(childWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      );
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/graph");
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: /proxy workflow waiting child workflow/i })
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-proxy-001/graph");
+    });
+
+    expect(await screen.findByRole("heading", { name: /proxy child workflow/i })).toBeInTheDocument();
+    expect(screen.getByText(/Package PKG-2026-05-03-001/i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /generate proxy command running activity/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/select a workflow node to inspect details/i)).toBeInTheDocument();
+  });
+
+  it("returns to the parent workflow with back navigation after child workflow drilldown", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            packages: [
+              {
+                packageId: "PKG-LOCAL-001",
+                workflowInstanceId: "workflow-local-001",
+                status: "Running",
+                updatedAt: "2026-05-03T18:42:00Z"
+              }
+            ]
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 200
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(liveWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(childWorkflowGraphResponse), {
+          headers: { "Content-Type": "application/json" },
+          status: 200
+        })
+      );
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/graph");
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: /proxy workflow waiting child workflow/i })
+    );
+
+    expect(await screen.findByRole("heading", { name: /proxy child workflow/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /back to package ingest workflow/i }));
+
+    expect(screen.getByRole("heading", { name: /package ingest workflow/i })).toBeInTheDocument();
+    expect(screen.getByText(/Package PKG-2026-05-03-001/i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /proxy workflow waiting child workflow/i })
+    ).toBeInTheDocument();
   });
 
   it("keeps selected node details visible when package status refreshes for the same workflow", async () => {
@@ -330,7 +454,9 @@ describe("workflow graph control plane", () => {
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/graph");
     });
-    fireEvent.click(await screen.findByRole("button", { name: /classify package running/i }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: /classify package running activity/i })
+    );
 
     const details = await screen.findByRole("region", {
       name: /selected workflow node details/i
@@ -402,7 +528,9 @@ describe("workflow graph control plane", () => {
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/workflows/workflow-local-001/graph");
     });
-    fireEvent.click(await screen.findByRole("button", { name: /classify package running/i }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: /classify package running activity/i })
+    );
 
     const details = await screen.findByRole("region", {
       name: /selected workflow node details/i
@@ -645,4 +773,24 @@ const secondWorkflowGraphResponse = {
       targetNodeId: "proxy-command"
     }
   ]
+};
+
+const childWorkflowGraphResponse = {
+  workflowInstanceId: "workflow-proxy-001",
+  workflowName: "Proxy child workflow",
+  packageId: "PKG-2026-05-03-001",
+  parentWorkflowInstanceId: "workflow-local-001",
+  nodes: [
+    {
+      nodeId: "generate-command",
+      displayName: "Generate proxy command",
+      kind: "Activity",
+      status: "Running",
+      workflowInstanceId: "workflow-proxy-001",
+      packageId: "PKG-2026-05-03-001",
+      workItemId: null,
+      childWorkflowInstanceId: null
+    }
+  ],
+  edges: []
 };

--- a/web/ingest-control-plane/src/App.tsx
+++ b/web/ingest-control-plane/src/App.tsx
@@ -5,6 +5,7 @@ import {
   buildMermaidFlowchart,
   mockedWorkflowGraph,
   summarizeStatuses,
+  toMermaidNodeId,
   type WorkflowGraph,
   type WorkflowNode,
   type WorkflowNodeDetails
@@ -110,33 +111,6 @@ function formatUpdatedAt(updatedAt: string) {
   }).format(new Date(updatedAt));
 }
 
-function NodeCard({
-  node,
-  selected,
-  onSelect
-}: {
-  node: WorkflowNode;
-  selected: boolean;
-  onSelect: (node: WorkflowNode) => void;
-}) {
-  return (
-    <li>
-      <button
-        type="button"
-        className={`workflow-node workflow-node--${formatStatus(node.status)}`}
-        aria-label={`${node.displayName} ${formatStatus(node.status)} ${formatNodeKind(node.kind)}`}
-        aria-pressed={selected}
-        onClick={() => onSelect(node)}
-      >
-        <span className="workflow-node__status">{node.status}</span>
-        <strong>{node.displayName}</strong>
-        <span>{formatNodeKind(node.kind)}</span>
-        <code>{formatNodeReference(node)}</code>
-      </button>
-    </li>
-  );
-}
-
 function NodeDetailsPanel({
   selectedNode,
   details,
@@ -198,12 +172,22 @@ function NodeDetailsPanel({
   );
 }
 
-function MermaidWorkflowDiagram({ graph }: { graph: WorkflowGraph }) {
+function MermaidWorkflowDiagram({
+  graph,
+  selectedNodeId,
+  onNodeActivate
+}: {
+  graph: WorkflowGraph;
+  selectedNodeId?: string;
+  onNodeActivate: (node: WorkflowNode) => void;
+}) {
   const [diagramSvg, setDiagramSvg] = useState("");
+  const diagramRef = useRef<HTMLDivElement>(null);
   const diagramSyntax = useMemo(() => buildMermaidFlowchart(graph), [graph]);
 
   useEffect(() => {
     let cancelled = false;
+    setDiagramSvg("");
 
     mermaid.initialize({
       startOnLoad: false,
@@ -224,12 +208,58 @@ function MermaidWorkflowDiagram({ graph }: { graph: WorkflowGraph }) {
     };
   }, [diagramSyntax, graph.workflowInstanceId]);
 
+  useEffect(() => {
+    const diagramElement = diagramRef.current;
+
+    if (!diagramElement || !diagramSvg) {
+      return undefined;
+    }
+
+    const cleanups = graph.nodes.flatMap((node) => {
+      const mermaidId = toMermaidNodeId(node.nodeId);
+      const svgNodes = Array.from(
+        diagramElement.querySelectorAll<SVGGElement>(`[id^="flowchart-${mermaidId}-"]`)
+      );
+
+      return svgNodes.map((svgNode) => {
+        const activateNode = () => onNodeActivate(node);
+        const activateNodeFromKeyboard = (event: KeyboardEvent) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            activateNode();
+          }
+        };
+
+        svgNode.classList.add("workflow-diagram__node");
+        svgNode.setAttribute("role", "button");
+        svgNode.setAttribute("tabindex", "0");
+        svgNode.setAttribute(
+          "aria-label",
+          `${node.displayName} ${formatStatus(node.status)} ${formatNodeKind(node.kind)}`
+        );
+        svgNode.setAttribute("aria-pressed", String(selectedNodeId === node.nodeId));
+        svgNode.addEventListener("click", activateNode);
+        svgNode.addEventListener("keydown", activateNodeFromKeyboard);
+
+        return () => {
+          svgNode.removeEventListener("click", activateNode);
+          svgNode.removeEventListener("keydown", activateNodeFromKeyboard);
+        };
+      });
+    });
+
+    return () => {
+      cleanups.forEach((cleanup) => cleanup());
+    };
+  }, [diagramSvg, graph.nodes, onNodeActivate, selectedNodeId]);
+
   if (!diagramSvg) {
     return <p role="status">Rendering workflow diagram...</p>;
   }
 
   return (
     <div
+      ref={diagramRef}
       role="img"
       aria-label="workflow diagram"
       className="workflow-diagram__svg"
@@ -248,11 +278,11 @@ export function App() {
   const [packageStatuses, setPackageStatuses] = useState<IngestPackageStatus[]>([]);
   const [selectedWorkflowInstanceId, setSelectedWorkflowInstanceId] = useState<string>();
   const [graph, setGraph] = useState<WorkflowGraph>(mockedWorkflowGraph);
+  const [workflowNavigationStack, setWorkflowNavigationStack] = useState<WorkflowGraph[]>([]);
   const [selectedNode, setSelectedNode] = useState<WorkflowNode>();
   const [workflowNodeDetailsLoadState, setWorkflowNodeDetailsLoadState] =
     useState<WorkflowNodeDetailsLoadState>("idle");
   const [workflowNodeDetails, setWorkflowNodeDetails] = useState<WorkflowNodeDetails>();
-  const activeWorkflowInstanceIdRef = useRef(graph.workflowInstanceId);
   const statusSummary = summarizeStatuses(graph.nodes);
   const progressedNodeCount = graph.nodes.filter((node) =>
     progressedStatuses.has(node.status)
@@ -269,25 +299,25 @@ export function App() {
     }
   }, []);
 
+  const clearNodeDetails = useCallback(() => {
+    setSelectedNode(undefined);
+    setWorkflowNodeDetails(undefined);
+    setWorkflowNodeDetailsLoadState("idle");
+  }, []);
+
   const loadWorkflowGraph = useCallback(async (workflowInstanceId: string) => {
     setWorkflowGraphLoadState("loading");
-
-    if (activeWorkflowInstanceIdRef.current !== workflowInstanceId) {
-      setSelectedNode(undefined);
-      setWorkflowNodeDetails(undefined);
-      setWorkflowNodeDetailsLoadState("idle");
-    }
+    clearNodeDetails();
 
     try {
       const workflowGraph = await fetchWorkflowGraph(workflowInstanceId);
 
-      activeWorkflowInstanceIdRef.current = workflowGraph.workflowInstanceId;
       setGraph(workflowGraph);
       setWorkflowGraphLoadState("ready");
     } catch {
       setWorkflowGraphLoadState("error");
     }
-  }, []);
+  }, [clearNodeDetails]);
 
   const loadWorkflowNodeDetails = useCallback(async (node: WorkflowNode) => {
     setSelectedNode(node);
@@ -304,15 +334,38 @@ export function App() {
     }
   }, []);
 
-  const selectPackageWorkflow = useCallback((workflowInstanceId: string) => {
-    if (selectedWorkflowInstanceId !== workflowInstanceId) {
-      setSelectedNode(undefined);
-      setWorkflowNodeDetails(undefined);
-      setWorkflowNodeDetailsLoadState("idle");
+  const activateWorkflowNode = useCallback((node: WorkflowNode) => {
+    if (node.kind === "ChildWorkflow" && node.childWorkflowInstanceId) {
+      setWorkflowNavigationStack((navigationStack) => [...navigationStack, graph]);
+      void loadWorkflowGraph(node.childWorkflowInstanceId);
+      return;
     }
 
+    void loadWorkflowNodeDetails(node);
+  }, [graph, loadWorkflowGraph, loadWorkflowNodeDetails]);
+
+  const navigateToParentWorkflow = useCallback(() => {
+    setWorkflowNavigationStack((navigationStack) => {
+      const parentGraph = navigationStack.at(-1);
+
+      if (!parentGraph) {
+        return navigationStack;
+      }
+
+      setGraph(parentGraph);
+      setWorkflowGraphLoadState("ready");
+      clearNodeDetails();
+
+      return navigationStack.slice(0, -1);
+    });
+  }, [clearNodeDetails]);
+
+  const selectPackageWorkflow = useCallback((workflowInstanceId: string) => {
+    clearNodeDetails();
+    setWorkflowNavigationStack([]);
+
     setSelectedWorkflowInstanceId(workflowInstanceId);
-  }, [selectedWorkflowInstanceId]);
+  }, [clearNodeDetails]);
 
   useEffect(() => {
     void loadPackageStatuses();
@@ -340,7 +393,7 @@ export function App() {
     if (packageStatusLoadState === "ready" && selectedWorkflowInstanceId) {
       void loadWorkflowGraph(selectedWorkflowInstanceId);
     }
-  }, [loadWorkflowGraph, packageStatusLoadState, packageStatuses, selectedWorkflowInstanceId]);
+  }, [loadWorkflowGraph, packageStatusLoadState, selectedWorkflowInstanceId]);
 
   async function startLocalIngest() {
     setLocalWatcherStatus("starting");
@@ -455,18 +508,46 @@ export function App() {
           <p role="status">Workflow graph unavailable</p>
         )}
         <div className="workflow-diagram">
-          <MermaidWorkflowDiagram graph={graph} />
+          <MermaidWorkflowDiagram
+            graph={graph}
+            selectedNodeId={selectedNode?.nodeId}
+            onNodeActivate={activateWorkflowNode}
+          />
         </div>
-        <ol className="workflow-graph" aria-label="workflow graph node status">
-          {graph.nodes.map((node) => (
-            <NodeCard
-              key={node.nodeId}
-              node={node}
-              selected={selectedNode?.nodeId === node.nodeId}
-              onSelect={loadWorkflowNodeDetails}
-            />
-          ))}
-        </ol>
+        <div className="workflow-diagram-actions">
+          {workflowNavigationStack.length > 0 && (
+            <button
+              type="button"
+              className="workflow-back-button"
+              onClick={navigateToParentWorkflow}
+            >
+              Back to {workflowNavigationStack.at(-1)?.workflowName}
+            </button>
+          )}
+          <label>
+            <span>Inspect workflow diagram node</span>
+            <select
+              aria-label="Inspect workflow diagram node"
+              value={selectedNode?.nodeId ?? ""}
+              onChange={(event) => {
+                const node = graph.nodes.find(
+                  (candidate) => candidate.nodeId === event.target.value
+                );
+
+                if (node) {
+                  activateWorkflowNode(node);
+                }
+              }}
+            >
+              <option value="">Choose a node</option>
+              {graph.nodes.map((node) => (
+                <option key={node.nodeId} value={node.nodeId}>
+                  {node.displayName} - {node.status} - {formatNodeReference(node)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
       </section>
 
       <NodeDetailsPanel

--- a/web/ingest-control-plane/src/styles.css
+++ b/web/ingest-control-plane/src/styles.css
@@ -250,15 +250,6 @@ h2 {
   color: #516170;
 }
 
-.workflow-graph {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 14px;
-  margin: 18px 0 0;
-  padding: 0;
-  list-style: none;
-}
-
 .workflow-diagram {
   overflow: auto;
   border: 1px solid #d6dde5;
@@ -277,113 +268,69 @@ h2 {
   min-height: 260px;
 }
 
-.workflow-node {
-  display: grid;
-  width: 100%;
-  height: 100%;
-  gap: 8px;
-  text-align: left;
-  min-height: 154px;
-  border: 1px solid #cfd8e3;
-  border-left: 8px solid #7b8794;
-  border-radius: 8px;
-  background: #ffffff;
-  color: inherit;
+.workflow-diagram__node {
   cursor: pointer;
-  font: inherit;
-  padding: 14px;
-  box-shadow: 0 8px 18px rgb(17 24 39 / 7%);
 }
 
-.workflow-node:hover,
-.workflow-node[aria-pressed="true"] {
-  border-color: #93b8d8;
-  box-shadow: 0 10px 22px rgb(17 24 39 / 11%);
+.workflow-diagram__node:hover {
+  filter: drop-shadow(0 6px 10px rgb(17 24 39 / 18%));
 }
 
-.workflow-node:focus-visible {
-  outline: 3px solid #93c5fd;
-  outline-offset: 2px;
+.workflow-diagram__node:focus {
+  outline: none;
 }
 
-.workflow-node strong {
-  color: #111827;
-  font-size: 1rem;
+.workflow-diagram__node:focus-visible,
+.workflow-diagram__node[aria-pressed="true"] {
+  filter: drop-shadow(0 0 0.35rem rgb(37 99 235 / 65%));
 }
 
-.workflow-node span:not(.workflow-node__status),
-.workflow-node code {
-  color: #576574;
-  font-size: 0.84rem;
+.workflow-diagram-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-top: 14px;
 }
 
-.workflow-node__status {
-  justify-self: start;
-  border-radius: 999px;
-  padding: 4px 8px;
-  font-size: 0.75rem;
+.workflow-diagram-actions label {
+  display: grid;
+  gap: 6px;
+  min-width: min(100%, 340px);
+  color: #516170;
+  font-size: 0.82rem;
   font-weight: 800;
 }
 
-.workflow-node--pending {
-  border-left-color: #7b8794;
+.workflow-diagram-actions select,
+.workflow-back-button {
+  min-height: 40px;
+  border: 1px solid #cfd8e3;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #17202a;
+  font: inherit;
 }
 
-.workflow-node--pending .workflow-node__status,
-.workflow-node--queued .workflow-node__status {
-  background: #e5eaf0;
-  color: #344054;
+.workflow-diagram-actions select {
+  padding: 8px 10px;
 }
 
-.workflow-node--queued {
-  border-left-color: #7b8794;
+.workflow-back-button {
+  cursor: pointer;
+  padding: 8px 12px;
+  font-weight: 800;
 }
 
-.workflow-node--running {
-  border-left-color: #2563eb;
+.workflow-back-button:hover {
+  border-color: #93b8d8;
 }
 
-.workflow-node--running .workflow-node__status {
-  background: #dbeafe;
-  color: #1e3a8a;
-}
-
-.workflow-node--succeeded {
-  border-left-color: #18865b;
-}
-
-.workflow-node--succeeded .workflow-node__status {
-  background: #d9f0e4;
-  color: #07583d;
-}
-
-.workflow-node--failed {
-  border-left-color: #c2410c;
-}
-
-.workflow-node--failed .workflow-node__status {
-  background: #ffedd5;
-  color: #9a3412;
-}
-
-.workflow-node--waiting {
-  border-left-color: #8b5cf6;
-}
-
-.workflow-node--waiting .workflow-node__status {
-  background: #ede9fe;
-  color: #5b21b6;
-}
-
-.workflow-node--skipped,
-.workflow-node--cancelled {
-  border-left-color: #8a94a3;
-}
-
-.workflow-node--skipped .workflow-node__status,
-.workflow-node--cancelled .workflow-node__status {
-  background: #eef2f5;
-  color: #4b5563;
+.workflow-diagram-actions select:focus-visible,
+.workflow-back-button:focus-visible {
+  outline: 3px solid #93c5fd;
+  outline-offset: 2px;
 }
 
 .node-details-panel {
@@ -444,7 +391,6 @@ h2 {
   }
 
   .workflow-metadata,
-  .workflow-graph,
   .package-status-button,
   .node-details-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -462,7 +408,6 @@ h2 {
   }
 
   .workflow-metadata,
-  .workflow-graph,
   .package-status-button,
   .node-details-grid {
     grid-template-columns: 1fr;

--- a/web/ingest-control-plane/src/workflowGraph.test.ts
+++ b/web/ingest-control-plane/src/workflowGraph.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildMermaidFlowchart,
   mockedWorkflowGraph,
+  toMermaidNodeId,
   workflowStatusPalette
 } from "./workflowGraph";
 
@@ -60,5 +61,10 @@ describe("workflow graph mermaid syntax", () => {
     expect(diagram).toContain(
       `linkStyle 0 stroke:${workflowStatusPalette.Queued.stroke}`
     );
+  });
+
+  it("exposes the stable Mermaid node identifier used for SVG interaction", () => {
+    expect(toMermaidNodeId("scan.package/1")).toBe("scan_package_1");
+    expect(toMermaidNodeId("2026-start")).toBe("node_2026_start");
   });
 });

--- a/web/ingest-control-plane/src/workflowGraph.ts
+++ b/web/ingest-control-plane/src/workflowGraph.ts
@@ -177,20 +177,20 @@ export function summarizeStatuses(nodes: WorkflowNode[]) {
 
 export function buildMermaidFlowchart(graph: WorkflowGraph) {
   const nodeIdMap = new Map(
-    graph.nodes.map((node) => [node.nodeId, sanitizeMermaidId(node.nodeId)])
+    graph.nodes.map((node) => [node.nodeId, toMermaidNodeId(node.nodeId)])
   );
   const lines = ["flowchart LR"];
 
   for (const node of graph.nodes) {
-    const mermaidId = nodeIdMap.get(node.nodeId) ?? sanitizeMermaidId(node.nodeId);
+    const mermaidId = nodeIdMap.get(node.nodeId) ?? toMermaidNodeId(node.nodeId);
     lines.push(
       `  ${mermaidId}["${escapeMermaidLabel(node.displayName)}"]:::${formatStatusClass(node.status)}`
     );
   }
 
   graph.edges.forEach((edge) => {
-    const sourceId = nodeIdMap.get(edge.sourceNodeId) ?? sanitizeMermaidId(edge.sourceNodeId);
-    const targetId = nodeIdMap.get(edge.targetNodeId) ?? sanitizeMermaidId(edge.targetNodeId);
+    const sourceId = nodeIdMap.get(edge.sourceNodeId) ?? toMermaidNodeId(edge.sourceNodeId);
+    const targetId = nodeIdMap.get(edge.targetNodeId) ?? toMermaidNodeId(edge.targetNodeId);
     lines.push(`  ${sourceId} --> ${targetId}`);
   });
 
@@ -209,7 +209,7 @@ export function buildMermaidFlowchart(graph: WorkflowGraph) {
   return lines.join("\n");
 }
 
-function sanitizeMermaidId(nodeId: string) {
+export function toMermaidNodeId(nodeId: string) {
   const sanitized = nodeId.replace(/[^A-Za-z0-9_]/g, "_");
 
   return /^[A-Za-z_]/.test(sanitized) ? sanitized : `node_${sanitized}`;


### PR DESCRIPTION
## Summary
- Makes the rendered Mermaid diagram the only workflow graph UI by removing the duplicated node-card list.
- Adds React-managed SVG node activation for node details, child workflow drilldown, and parent back navigation.
- Keeps a compact accessible node selector for keyboard fallback and updates status/backlog docs.

## Validation
- `cd web/ingest-control-plane && npm test -- --run`
- `make validate`
- `git diff --check`

## Notes
- Mermaid remains configured with `securityLevel: "strict"`.
- Branch was created in `.worktrees/TASK-8-3-interactive-mermaid-graph` from commit `ac6086e`.