### PR TITLE
TASK-4-3: Add command bus topology readiness

### DIFF
--- a/deploy/dapr/README.md
+++ b/deploy/dapr/README.md
@@ -37,6 +37,11 @@ Command routing boundary:
 on the application property; command topic names stay semantic and do not encode
 runner capacity.
 
+TASK-4-3 defines static topology readiness only. The command contracts enumerate
+the semantic topics and the `light`, `medium`, and `heavy` subscription filters
+that Azure Service Bus resources must eventually use, but these Dapr assets do
+not create topics or subscriptions and do not require paid Azure validation.
+
 All credentials are Kubernetes Secret references. Real secret values,
 kubeconfigs, Azure subscription details, and Terraform state are intentionally
 absent from this repository.

--- a/docs/architecture/003-messaging-and-outbox.md
+++ b/docs/architecture/003-messaging-and-outbox.md
@@ -18,6 +18,12 @@ Each command message carries an `executionClass` application property. Topic
 subscriptions named `light`, `medium`, and `heavy` filter on that property, and
 matching command-runner deployments consume only their subscription.
 
+The static command-bus topology is represented in the command contracts so
+application, outbox, and deployment slices can validate the same semantic topic
+and subscription names before Azure resources exist. This readiness model is a
+contract and documentation boundary only: it does not provision Azure Service Bus
+topics, create subscriptions, or perform paid cloud validation.
+
 The first routing policy is:
 
 - `light`: input size below 512 MB

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -30,6 +30,9 @@ epic/story granularity; detailed implementation tasks belong in plans.
 - MILESTONE-4 / USER-STORY-6 / USER-STORY-8: expose broker-ready command
   publish metadata at the local outbox boundary without changing non-command
   dispatch behavior.
+- MILESTONE-4 / USER-STORY-6 / USER-STORY-8: define static command-bus topology
+  readiness for semantic Azure Service Bus command topics and light, medium,
+  and heavy subscriptions.
 - MILESTONE-8 / USER-STORY-12 / USER-STORY-13: add package workflow selection
   to the control plane and preserve or clear node detail state according to the
   selected workflow.

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -101,6 +101,9 @@
 - TASK-4-2 added local command dispatch boundary metadata so
   `MediaCommandEnvelope` outbox publishes expose broker-ready `executionClass`
   application properties while non-command messages keep existing behavior.
+- TASK-4-3 defined the static command-bus topology readiness model for semantic
+  command topics and the `light`, `medium`, and `heavy` execution-class
+  subscriptions without provisioning Azure resources.
 - TASK-8-2 added multi-package workflow selection in the React control plane,
   preserving node detail during same-workflow refreshes and clearing detail when
   the operator switches workflows.

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -145,6 +145,9 @@ messages or paste command output unless it explains a decision.
 - Added TASK-8-2 UI package workflow selection so operators can choose among
   multiple package workflow graphs, keep node details on same-workflow refresh,
   and clear node details when switching workflows.
+- Added TASK-4-3 static command-bus topology readiness in the Courier contract
+  lane, covering semantic command topics, light/medium/heavy subscription
+  filters, and documentation that keeps Azure resource creation out of scope.
 
 ## Update Rule
 

--- a/src/MediaIngest.Contracts/Commands/CommandBusTopology.cs
+++ b/src/MediaIngest.Contracts/Commands/CommandBusTopology.cs
@@ -1,0 +1,51 @@
+namespace MediaIngest.Contracts.Commands;
+
+public sealed record CommandBusTopicTopology(
+    string TopicName,
+    IReadOnlyList<CommandBusSubscriptionTopology> Subscriptions);
+
+public sealed record CommandBusSubscriptionTopology(
+    string SubscriptionName,
+    string FilterPropertyName,
+    string FilterPropertyValue)
+{
+    public string SqlFilterExpression => $"{FilterPropertyName} = '{FilterPropertyValue}'";
+}
+
+public static class CommandBusTopology
+{
+    public const string LightSubscriptionName = ExecutionClassProperties.Light;
+    public const string MediumSubscriptionName = ExecutionClassProperties.Medium;
+    public const string HeavySubscriptionName = ExecutionClassProperties.Heavy;
+
+    public static IReadOnlyList<string> CommandTopics { get; } =
+    [
+        CommandNames.CreateProxy,
+        CommandNames.CreateChecksum,
+        CommandNames.VerifyChecksum,
+        CommandNames.RunSecurityScan,
+        CommandNames.ArchiveAsset
+    ];
+
+    public static IReadOnlyList<CommandBusSubscriptionTopology> Subscriptions { get; } =
+    [
+        CreateSubscription(LightSubscriptionName),
+        CreateSubscription(MediumSubscriptionName),
+        CreateSubscription(HeavySubscriptionName)
+    ];
+
+    public static IReadOnlyList<CommandBusTopicTopology> Topics { get; } =
+        CommandTopics
+            .Select(topicName => new CommandBusTopicTopology(
+                TopicName: topicName,
+                Subscriptions: Subscriptions))
+            .ToArray();
+
+    private static CommandBusSubscriptionTopology CreateSubscription(string executionClass)
+    {
+        return new CommandBusSubscriptionTopology(
+            SubscriptionName: executionClass,
+            FilterPropertyName: CommandRoute.ExecutionClassPropertyName,
+            FilterPropertyValue: executionClass);
+    }
+}

--- a/tests/MediaIngest.Contracts.Tests/Program.cs
+++ b/tests/MediaIngest.Contracts.Tests/Program.cs
@@ -88,6 +88,37 @@ AssertEqual("medium", mediumRouting.ApplicationProperties[CommandRoute.Execution
 AssertEqual(ExecutionClass.Heavy, heavyRouting.ExecutionClass, "heavy route");
 AssertEqual("heavy", heavyRouting.ApplicationProperties[CommandRoute.ExecutionClassPropertyName], "heavy route property");
 
+var expectedCommandTopics = new[]
+{
+    CommandNames.CreateProxy,
+    CommandNames.CreateChecksum,
+    CommandNames.VerifyChecksum,
+    CommandNames.RunSecurityScan,
+    CommandNames.ArchiveAsset
+};
+
+var topology = CommandBusTopology.Topics;
+AssertSequenceEqual(expectedCommandTopics, topology.Select(topic => topic.TopicName).ToArray(), "command bus topics");
+
+foreach (var topic in topology)
+{
+    AssertEqual(3, topic.Subscriptions.Count, $"{topic.TopicName} subscription count");
+    AssertSequenceEqual(
+        ["light", "medium", "heavy"],
+        topic.Subscriptions.Select(subscription => subscription.SubscriptionName).ToArray(),
+        $"{topic.TopicName} subscription names");
+
+    foreach (var subscription in topic.Subscriptions)
+    {
+        AssertEqual("executionClass", subscription.FilterPropertyName, $"{topic.TopicName}/{subscription.SubscriptionName} filter property");
+        AssertEqual(subscription.SubscriptionName, subscription.FilterPropertyValue, $"{topic.TopicName}/{subscription.SubscriptionName} filter value");
+        AssertEqual(
+            $"executionClass = '{subscription.SubscriptionName}'",
+            subscription.SqlFilterExpression,
+            $"{topic.TopicName}/{subscription.SubscriptionName} filter expression");
+    }
+}
+
 var checksumRouting = CommandRoutingPolicy.Route(
     commandName: CommandNames.CreateChecksum,
     inputBytes: 25L * 1024L * 1024L * 1024L);
@@ -140,5 +171,14 @@ static void AssertEqual<T>(T expected, T actual, string name)
     if (!EqualityComparer<T>.Default.Equals(expected, actual))
     {
         throw new InvalidOperationException($"{name}: expected '{expected}', got '{actual}'.");
+    }
+}
+
+static void AssertSequenceEqual<T>(IReadOnlyList<T> expected, IReadOnlyList<T> actual, string name)
+{
+    if (!expected.SequenceEqual(actual))
+    {
+        throw new InvalidOperationException(
+            $"{name}: expected '{string.Join(", ", expected)}', got '{string.Join(", ", actual)}'.");
     }
 }


### PR DESCRIPTION
## Summary

- Adds a dependency-free Courier command-bus topology contract for existing semantic command topics.
- Defines `light`, `medium`, and `heavy` subscription filters over the `executionClass` application property.
- Adds contract smoke coverage and documents that this is static topology readiness only, with no Azure resource creation or paid cloud validation.

## Linked Work

Refs #16
Refs #18

## Validation

- `make test-dotnet-contracts` - passed; contract project built with 0 warnings/errors and smoke tests passed.
- `kubectl kustomize deploy/dapr/k8s` - passed; rendered Dapr Service Bus pub/sub, workflow state store, and configuration manifests locally.
- `make docs-check` - passed; documentation checks passed.
- `git diff --check` - passed; no whitespace errors.
- `make validate` - passed; docs checks, GitHub helper tests, .NET build, and smoke tests passed.

## Risk

Low. The change adds static contract metadata and smoke assertions only; it does not change outbox publish behavior, create Azure resources, or add dependencies.

## Follow-up Notes

- A later Azure or deployment slice can use this contract topology when provisioning actual Service Bus topics and subscriptions.
- Cloud validation remains approval-gated and was not run for this task.