### PR TITLE
USER-STORY-1: Add watcher observation loop

### DIFF
--- a/src/MediaIngest.Worker.Watcher/CallbackIngestPackageCandidateSink.cs
+++ b/src/MediaIngest.Worker.Watcher/CallbackIngestPackageCandidateSink.cs
@@ -1,0 +1,16 @@
+namespace MediaIngest.Worker.Watcher;
+
+public sealed class CallbackIngestPackageCandidateSink(
+    Func<IngestPackageCandidate, CancellationToken, ValueTask> observe)
+    : IIngestPackageCandidateSink
+{
+    private readonly Func<IngestPackageCandidate, CancellationToken, ValueTask> observe =
+        observe ?? throw new ArgumentNullException(nameof(observe));
+
+    public ValueTask ObserveAsync(IngestPackageCandidate candidate, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        return observe(candidate, cancellationToken);
+    }
+}

--- a/src/MediaIngest.Worker.Watcher/IIngestPackageCandidateSink.cs
+++ b/src/MediaIngest.Worker.Watcher/IIngestPackageCandidateSink.cs
@@ -1,0 +1,6 @@
+namespace MediaIngest.Worker.Watcher;
+
+public interface IIngestPackageCandidateSink
+{
+    ValueTask ObserveAsync(IngestPackageCandidate candidate, CancellationToken cancellationToken);
+}

--- a/src/MediaIngest.Worker.Watcher/IngestMountObservationLoop.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestMountObservationLoop.cs
@@ -1,0 +1,72 @@
+namespace MediaIngest.Worker.Watcher;
+
+public sealed class IngestMountObservationLoop
+{
+    private readonly IngestMountObservationLoopOptions options;
+    private readonly IIngestPackageCandidateSink sink;
+    private readonly IngestMountScanner scanner;
+    private readonly Func<TimeSpan, CancellationToken, ValueTask> delay;
+    private readonly HashSet<string> observedPackagePaths = new(StringComparer.Ordinal);
+
+    public IngestMountObservationLoop(
+        IngestMountObservationLoopOptions options,
+        IIngestPackageCandidateSink sink)
+        : this(options, sink, static (interval, cancellationToken) =>
+            new ValueTask(Task.Delay(interval, cancellationToken)))
+    {
+    }
+
+    public IngestMountObservationLoop(
+        IngestMountObservationLoopOptions options,
+        IIngestPackageCandidateSink sink,
+        Func<TimeSpan, CancellationToken, ValueTask> delay)
+        : this(options, sink, new IngestMountScanner(), delay)
+    {
+    }
+
+    public IngestMountObservationLoop(
+        IngestMountObservationLoopOptions options,
+        IIngestPackageCandidateSink sink,
+        IngestMountScanner scanner,
+        Func<TimeSpan, CancellationToken, ValueTask> delay)
+    {
+        this.options = options ?? throw new ArgumentNullException(nameof(options));
+        this.sink = sink ?? throw new ArgumentNullException(nameof(sink));
+        this.scanner = scanner ?? throw new ArgumentNullException(nameof(scanner));
+        this.delay = delay ?? throw new ArgumentNullException(nameof(delay));
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await ScanOnceAsync(cancellationToken);
+
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    await delay(options.ScanInterval, cancellationToken);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task ScanOnceAsync(CancellationToken cancellationToken)
+    {
+        foreach (var candidate in scanner.FindPackageCandidates(options.IngestMountPath))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!observedPackagePaths.Add(candidate.PackagePath))
+            {
+                continue;
+            }
+
+            await sink.ObserveAsync(candidate, cancellationToken);
+        }
+    }
+}

--- a/src/MediaIngest.Worker.Watcher/IngestMountObservationLoopOptions.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestMountObservationLoopOptions.cs
@@ -1,0 +1,21 @@
+namespace MediaIngest.Worker.Watcher;
+
+public sealed record IngestMountObservationLoopOptions
+{
+    public IngestMountObservationLoopOptions(string ingestMountPath, TimeSpan scanInterval)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ingestMountPath);
+
+        if (scanInterval < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(scanInterval), scanInterval, "Scan interval cannot be negative.");
+        }
+
+        IngestMountPath = Path.GetFullPath(ingestMountPath);
+        ScanInterval = scanInterval;
+    }
+
+    public string IngestMountPath { get; }
+
+    public TimeSpan ScanInterval { get; }
+}

--- a/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
@@ -105,6 +105,11 @@ try
         ],
         finalReconciliation.Files.Select(file => file.PackageRelativePath).ToArray(),
         "ready package final reconciliation relative paths");
+
+    await VerifyObservationLoopUsesConfiguredMountPath();
+    await VerifyObservationLoopScansRepeatedlyUntilCancelled();
+    await VerifyObservationLoopDoesNotReportUnchangedPackageTwice();
+    await VerifyObservationLoopStopsWhenCancellationIsRequested();
 }
 finally
 {
@@ -115,6 +120,180 @@ finally
 }
 
 Console.WriteLine("MediaIngest watcher smoke tests passed.");
+
+static async Task VerifyObservationLoopUsesConfiguredMountPath()
+{
+    var firstMountPath = CreateTestDirectory();
+    var secondMountPath = CreateTestDirectory();
+
+    try
+    {
+        var ignoredPackagePath = Directory.CreateDirectory(Path.Combine(firstMountPath, "ignored-package")).FullName;
+        var observedPackagePath = Directory.CreateDirectory(Path.Combine(secondMountPath, "observed-package")).FullName;
+        var reports = new List<IngestPackageCandidate>();
+        using var cancellation = new CancellationTokenSource();
+
+        var loop = new IngestMountObservationLoop(
+            new IngestMountObservationLoopOptions(secondMountPath, TimeSpan.FromMilliseconds(50)),
+            new CallbackIngestPackageCandidateSink((candidate, _) =>
+            {
+                reports.Add(candidate);
+                cancellation.Cancel();
+                return ValueTask.CompletedTask;
+            }));
+
+        await loop.RunAsync(cancellation.Token);
+
+        AssertSequenceEqual(
+            [observedPackagePath],
+            reports.Select(report => report.PackagePath).ToArray(),
+            "observation loop configured mount reports");
+        AssertFalse(
+            reports.Any(report => report.PackagePath == ignoredPackagePath),
+            "observation loop ignored mount reports");
+    }
+    finally
+    {
+        DeleteTestDirectory(firstMountPath);
+        DeleteTestDirectory(secondMountPath);
+    }
+}
+
+static async Task VerifyObservationLoopScansRepeatedlyUntilCancelled()
+{
+    var mountPath = CreateTestDirectory();
+
+    try
+    {
+        var firstPackagePath = Directory.CreateDirectory(Path.Combine(mountPath, "package-a")).FullName;
+        var secondPackagePath = Path.Combine(mountPath, "package-b");
+        var reports = new List<IngestPackageCandidate>();
+        var delayCalls = 0;
+        using var cancellation = new CancellationTokenSource();
+
+        var loop = new IngestMountObservationLoop(
+            new IngestMountObservationLoopOptions(mountPath, TimeSpan.FromMilliseconds(50)),
+            new CallbackIngestPackageCandidateSink((candidate, _) =>
+            {
+                reports.Add(candidate);
+                return ValueTask.CompletedTask;
+            }),
+            (_, _) =>
+            {
+                delayCalls++;
+
+                if (delayCalls == 1)
+                {
+                    Directory.CreateDirectory(secondPackagePath);
+                }
+                else
+                {
+                    cancellation.Cancel();
+                }
+
+                return ValueTask.CompletedTask;
+            });
+
+        await loop.RunAsync(cancellation.Token);
+
+        AssertSequenceEqual(
+            [firstPackagePath, Path.GetFullPath(secondPackagePath)],
+            reports.Select(report => report.PackagePath).ToArray(),
+            "observation loop repeated scan reports");
+        AssertEqual(2, delayCalls, "observation loop repeated scan delay count");
+    }
+    finally
+    {
+        DeleteTestDirectory(mountPath);
+    }
+}
+
+static async Task VerifyObservationLoopDoesNotReportUnchangedPackageTwice()
+{
+    var mountPath = CreateTestDirectory();
+
+    try
+    {
+        var packagePath = Directory.CreateDirectory(Path.Combine(mountPath, "package-a")).FullName;
+        var reports = new List<IngestPackageCandidate>();
+        var delayCalls = 0;
+        using var cancellation = new CancellationTokenSource();
+
+        var loop = new IngestMountObservationLoop(
+            new IngestMountObservationLoopOptions(mountPath, TimeSpan.FromMilliseconds(50)),
+            new CallbackIngestPackageCandidateSink((candidate, _) =>
+            {
+                reports.Add(candidate);
+                return ValueTask.CompletedTask;
+            }),
+            (_, _) =>
+            {
+                delayCalls++;
+
+                if (delayCalls == 2)
+                {
+                    cancellation.Cancel();
+                }
+
+                return ValueTask.CompletedTask;
+            });
+
+        await loop.RunAsync(cancellation.Token);
+
+        AssertSequenceEqual(
+            [packagePath],
+            reports.Select(report => report.PackagePath).ToArray(),
+            "observation loop unchanged package reports");
+        AssertEqual(2, delayCalls, "observation loop unchanged package delay count");
+    }
+    finally
+    {
+        DeleteTestDirectory(mountPath);
+    }
+}
+
+static async Task VerifyObservationLoopStopsWhenCancellationIsRequested()
+{
+    var mountPath = CreateTestDirectory();
+
+    try
+    {
+        var reports = new List<IngestPackageCandidate>();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var loop = new IngestMountObservationLoop(
+            new IngestMountObservationLoopOptions(mountPath, TimeSpan.FromMilliseconds(50)),
+            new CallbackIngestPackageCandidateSink((candidate, _) =>
+            {
+                reports.Add(candidate);
+                return ValueTask.CompletedTask;
+            }));
+
+        await loop.RunAsync(cancellation.Token);
+
+        AssertEqual(0, reports.Count, "observation loop cancelled report count");
+    }
+    finally
+    {
+        DeleteTestDirectory(mountPath);
+    }
+}
+
+static string CreateTestDirectory()
+{
+    var path = Path.Combine(Path.GetTempPath(), "media-ingest-watcher-tests", Guid.NewGuid().ToString("N"));
+    Directory.CreateDirectory(path);
+    return path;
+}
+
+static void DeleteTestDirectory(string path)
+{
+    if (Directory.Exists(path))
+    {
+        Directory.Delete(path, recursive: true);
+    }
+}
 
 static void AssertEqual<T>(T expected, T actual, string name)
 {


### PR DESCRIPTION
Refs #11

## Summary
- Adds a library-level watcher observation loop that scans the configured ingest mount and reports package candidates to an injected sink.
- Tracks observed package paths for the loop lifetime so unchanged package directories are not reported repeatedly.
- Adds watcher smoke coverage for configured path use, repeated scans, cancellation, and duplicate suppression.

## Validation
- `make test-dotnet-watcher` passed.
- `make validate` passed.
- `git diff --check` passed.

## Risk
- Low: this is not wired into API hosting yet and remains scoped to `MediaIngest.Worker.Watcher`.
- The loop currently keeps in-memory observed state for a single process lifetime only.

## Follow-ups
- Wire the watcher-owned loop into worker hosting when the runtime host boundary is ready.
- Decide how observed package candidates should become durable business state or commands in the next Mount/Gauge slice.