### PR TITLE
USER-STORY-6: Add Dapr outbox publisher boundary

### DIFF
--- a/deploy/dapr/README.md
+++ b/deploy/dapr/README.md
@@ -42,6 +42,14 @@ the semantic topics and the `light`, `medium`, and `heavy` subscription filters
 that Azure Service Bus resources must eventually use, but these Dapr assets do
 not create topics or subscriptions and do not require paid Azure validation.
 
+USER-STORY-6 adds the local outbox publisher boundary through the Dapr sidecar
+HTTP API. The outbox worker publishes each pending message to
+`/v1.0/publish/commandbus/{topic}`, where `{topic}` is the outbox message
+destination. Existing outbox application properties, including
+`executionClass`, are forwarded as Dapr publish metadata query parameters such
+as `metadata.executionClass=heavy`. This keeps the local publisher independent
+of Azure SDKs and Azure resource provisioning.
+
 All credentials are Kubernetes Secret references. Real secret values,
 kubeconfigs, Azure subscription details, and Terraform state are intentionally
 absent from this repository.

--- a/docs/architecture/003-messaging-and-outbox.md
+++ b/docs/architecture/003-messaging-and-outbox.md
@@ -39,6 +39,19 @@ Use a transactional outbox in PostgreSQL. Business state changes and outbound
 messages are committed in the same transaction. A dedicated outbox dispatcher
 publishes pending messages to Azure Service Bus.
 
+The local publisher boundary uses Dapr pub/sub over the sidecar HTTP API instead
+of an Azure SDK. The dispatcher passes an `OutboxPublishRequest` to an
+`IOutboxMessagePublisher`; the Dapr implementation posts the message JSON to
+`/v1.0/publish/commandbus/{destination}`, where `destination` is the semantic
+command topic stored on the outbox message. Application properties that were
+already computed for the outbox request are forwarded as Dapr metadata query
+parameters, so command metadata such as `executionClass=heavy` reaches the
+broker boundary without the dispatcher making routing decisions.
+
+This boundary is local runtime plumbing only. It does not provision Azure
+Service Bus topics, create subscriptions, run paid cloud validation, or add Azure
+SDK dependencies.
+
 ## Responsibility Split
 
 - Domain/application logic decides which command should be sent and which

--- a/src/MediaIngest.Worker.Outbox/DaprOutboxMessagePublisher.cs
+++ b/src/MediaIngest.Worker.Outbox/DaprOutboxMessagePublisher.cs
@@ -1,0 +1,46 @@
+using System.Text;
+
+namespace MediaIngest.Worker.Outbox;
+
+public sealed class DaprOutboxMessagePublisher(HttpClient httpClient, string pubSubName) : IOutboxMessagePublisher
+{
+    public async Task PublishAsync(OutboxPublishRequest request, CancellationToken cancellationToken = default)
+    {
+        using var httpRequest = new HttpRequestMessage(
+            HttpMethod.Post,
+            BuildPublishPath(pubSubName, request))
+        {
+            Content = new StringContent(request.Message.PayloadJson, Encoding.UTF8, "application/json")
+        };
+
+        using var response = await httpClient.SendAsync(httpRequest, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        throw new InvalidOperationException(
+            $"Dapr publish failed for outbox message '{request.Message.MessageId}' to topic " +
+            $"'{request.Message.Destination}' with status {(int)response.StatusCode}: {responseBody}");
+    }
+
+    private static string BuildPublishPath(string pubSubName, OutboxPublishRequest request)
+    {
+        var path = $"v1.0/publish/{Uri.EscapeDataString(pubSubName)}/{Uri.EscapeDataString(request.Message.Destination)}";
+
+        if (request.ApplicationProperties.Count == 0)
+        {
+            return path;
+        }
+
+        var metadata = request.ApplicationProperties
+            .OrderBy(property => property.Key, StringComparer.Ordinal)
+            .Select(property =>
+                $"metadata.{Uri.EscapeDataString(property.Key)}={Uri.EscapeDataString(property.Value)}");
+
+        return $"{path}?{string.Join("&", metadata)}";
+    }
+}

--- a/tests/MediaIngest.Worker.Outbox.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Outbox.Tests/Program.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using MediaIngest.Contracts.Commands;
 using MediaIngest.Persistence;
@@ -11,6 +12,9 @@ await DispatchPendingMessagesDoesNothingWhenNoMessagesArePending();
 await DispatchPendingMessagesLeavesTheMessagePendingWhenPublishFails();
 await OverlappingDispatcherRunsDoNotPublishTheSameMessageTwice();
 await ClaimedMessagesCanBeRetriedAfterTheClaimExpires();
+await DaprPublisherPublishesPayloadToTheDestinationTopic();
+await DaprPublisherMapsApplicationPropertiesToDaprMetadata();
+await DaprPublisherSurfacesNonSuccessResponses();
 
 Console.WriteLine("MediaIngest outbox dispatcher smoke tests passed.");
 
@@ -231,6 +235,98 @@ static async Task ClaimedMessagesCanBeRetriedAfterTheClaimExpires()
     AssertEqual(timeProvider.UtcNow, store.OutboxMessages[0].DispatchedAt, "expired claim retry dispatched timestamp");
 }
 
+static async Task DaprPublisherPublishesPayloadToTheDestinationTopic()
+{
+    var handler = new RecordingHttpMessageHandler(HttpStatusCode.NoContent, "");
+    using var httpClient = new HttpClient(handler)
+    {
+        BaseAddress = new Uri("http://127.0.0.1:3500")
+    };
+    var publisher = new DaprOutboxMessagePublisher(httpClient, "commandbus");
+    var request = new OutboxPublishRequest(
+        CreateMessage(
+            messageId: "message-dapr-001",
+            destination: "media.command.create_proxy",
+            messageType: "MediaCommandEnvelope",
+            createdAt: new DateTimeOffset(2026, 5, 3, 12, 40, 0, TimeSpan.Zero),
+            payloadJson: """{"commandId":"command-001","executionClass":"light"}"""),
+        new Dictionary<string, string>(StringComparer.Ordinal));
+
+    await publisher.PublishAsync(request);
+
+    AssertEqual(HttpMethod.Post, handler.Requests[0].Method, "dapr publish method");
+    AssertEqual(
+        "http://127.0.0.1:3500/v1.0/publish/commandbus/media.command.create_proxy",
+        handler.Requests[0].RequestUri?.ToString(),
+        "dapr publish topic URL");
+    AssertEqual(
+        """{"commandId":"command-001","executionClass":"light"}""",
+        handler.RequestBodies[0],
+        "dapr publish payload body");
+    AssertEqual("application/json; charset=utf-8", handler.Requests[0].Content?.Headers.ContentType?.ToString(), "dapr content type");
+}
+
+static async Task DaprPublisherMapsApplicationPropertiesToDaprMetadata()
+{
+    var handler = new RecordingHttpMessageHandler(HttpStatusCode.NoContent, "");
+    using var httpClient = new HttpClient(handler)
+    {
+        BaseAddress = new Uri("http://127.0.0.1:3500")
+    };
+    var publisher = new DaprOutboxMessagePublisher(httpClient, "commandbus");
+    var request = new OutboxPublishRequest(
+        CreateMessage(
+            messageId: "message-dapr-002",
+            destination: "media.command.archive_asset",
+            messageType: "MediaCommandEnvelope",
+            createdAt: new DateTimeOffset(2026, 5, 3, 12, 45, 0, TimeSpan.Zero),
+            payloadJson: """{"commandId":"command-heavy","executionClass":"heavy"}"""),
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [CommandRoute.ExecutionClassPropertyName] = "heavy"
+        });
+
+    await publisher.PublishAsync(request);
+
+    AssertEqual(
+        "http://127.0.0.1:3500/v1.0/publish/commandbus/media.command.archive_asset?metadata.executionClass=heavy",
+        handler.Requests[0].RequestUri?.ToString(),
+        "dapr publish metadata URL");
+}
+
+static async Task DaprPublisherSurfacesNonSuccessResponses()
+{
+    var handler = new RecordingHttpMessageHandler(HttpStatusCode.ServiceUnavailable, "sidecar unavailable");
+    using var httpClient = new HttpClient(handler)
+    {
+        BaseAddress = new Uri("http://127.0.0.1:3500")
+    };
+    var publisher = new DaprOutboxMessagePublisher(httpClient, "commandbus");
+    var request = new OutboxPublishRequest(
+        CreateMessage(
+            messageId: "message-dapr-003",
+            destination: "media.command.verify_checksum",
+            messageType: "MediaCommandEnvelope",
+            createdAt: new DateTimeOffset(2026, 5, 3, 12, 50, 0, TimeSpan.Zero)),
+        new Dictionary<string, string>(StringComparer.Ordinal));
+    var failed = false;
+
+    try
+    {
+        await publisher.PublishAsync(request);
+    }
+    catch (InvalidOperationException ex) when (
+        ex.Message.Contains("Dapr publish failed", StringComparison.Ordinal)
+        && ex.Message.Contains("503", StringComparison.Ordinal)
+        && ex.Message.Contains("message-dapr-003", StringComparison.Ordinal)
+        && ex.Message.Contains("sidecar unavailable", StringComparison.Ordinal))
+    {
+        failed = true;
+    }
+
+    AssertTrue(failed, "dapr non-success response is surfaced");
+}
+
 static OutboxMessage CreateMessage(
     string messageId,
     string destination,
@@ -320,6 +416,27 @@ internal sealed class BlockingOutboxPublisher : IOutboxMessagePublisher
     public Task WaitForFirstPublishAttemptAsync() => firstPublishAttempted.Task;
 
     public void AllowPublishes() => allowPublishes.TrySetResult();
+}
+
+internal sealed class RecordingHttpMessageHandler(HttpStatusCode statusCode, string responseBody) : HttpMessageHandler
+{
+    public List<HttpRequestMessage> Requests { get; } = [];
+    public List<string> RequestBodies { get; } = [];
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        Requests.Add(request);
+        RequestBodies.Add(request.Content is null
+            ? ""
+            : await request.Content.ReadAsStringAsync(cancellationToken));
+
+        return new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(responseBody)
+        };
+    }
 }
 
 internal sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider


### PR DESCRIPTION
## Summary

- Adds an HTTP-based `DaprOutboxMessagePublisher` behind `IOutboxMessagePublisher`.
- Publishes outbox payload JSON to `/v1.0/publish/commandbus/{destination}` using the outbox destination as the Dapr topic.
- Forwards existing outbox application properties, including `executionClass`, as Dapr publish metadata query parameters.
- Documents the local Dapr publisher boundary without Azure provisioning or Azure SDK dependencies.

## Linked Work

Refs #16

## Validation

- `make test-dotnet-outbox` - baseline passed before changes.
- `make test-dotnet-outbox` - RED failed because `DaprOutboxMessagePublisher` did not exist.
- `make test-dotnet-outbox` - GREEN passed after implementation.
- `make validate` - passed.
- `git diff --check` - passed.

## Risk

Low. The change adds a local HTTP adapter and smoke coverage only. It does not create Azure resources, add Azure SDK dependencies, change command-routing contracts, or provision Service Bus topics/subscriptions.

## Follow-ups

- Wire the Dapr publisher into the runnable outbox worker host when that host/configuration slice is active.
- Add runtime sidecar smoke coverage once the local Dapr runtime path is available.