### PR TITLE
USER-STORY-10: Add nested workflow contract foundation

### DIFF
--- a/src/MediaIngest.Workflow/PackageWorkflowChildWorkPlan.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowChildWorkPlan.cs
@@ -1,0 +1,58 @@
+using MediaIngest.Contracts.Workflow;
+
+namespace MediaIngest.Workflow;
+
+internal static class PackageWorkflowChildWorkPlan
+{
+    public static readonly PreparedChildWork ScanPackage = new(
+        NodeId: "scan-package",
+        DisplayName: "Package scan",
+        WorkflowName: WorkflowContractNames.PackageScanWorkflow);
+
+    public static readonly PreparedChildWork ClassifyFiles = new(
+        NodeId: "classify-files",
+        DisplayName: "Classify discovered files",
+        WorkflowName: WorkflowContractNames.FileClassificationWorkflow);
+
+    public static readonly PreparedChildWork EssenceGroupProcessing = new(
+        NodeId: "essence-group-processing",
+        DisplayName: "Essence group processing",
+        WorkflowName: WorkflowContractNames.EssenceGroupProcessingWorkflow);
+
+    public static readonly PreparedChildWork ProxyCreation = new(
+        NodeId: "proxy-creation",
+        DisplayName: "Proxy creation",
+        WorkflowName: WorkflowContractNames.ProxyCreationWorkflow);
+
+    public static readonly PreparedChildWork ReconcilePackage = new(
+        NodeId: "reconcile-package",
+        DisplayName: "Reconcile package",
+        WorkflowName: WorkflowContractNames.ReconciliationWorkflow);
+
+    public static readonly PreparedChildWork FinalizePackage = new(
+        NodeId: "finalize-package",
+        DisplayName: "Finalize package",
+        WorkflowName: WorkflowContractNames.FinalizationWorkflow);
+
+    public static readonly PreparedChildWork[] FullLifecycle =
+    [
+        ScanPackage,
+        ClassifyFiles,
+        EssenceGroupProcessing,
+        ProxyCreation,
+        ReconcilePackage,
+        FinalizePackage
+    ];
+
+    public static readonly PreparedChildWork[] BusinessStatus =
+    [
+        ScanPackage,
+        ClassifyFiles,
+        EssenceGroupProcessing
+    ];
+
+    public static PreparedChildWork? FindByNodeId(string nodeId)
+    {
+        return FullLifecycle.FirstOrDefault(work => work.NodeId == nodeId);
+    }
+}

--- a/src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs
@@ -4,22 +4,6 @@ namespace MediaIngest.Workflow;
 
 public static class PackageWorkflowGraphProjection
 {
-    private static readonly PreparedChildWork[] PackageLifecyclePlan =
-    [
-        new("scan-package", "Package scan"),
-        new("classify-files", "Classify discovered files"),
-        new("dispatch-processing", "Dispatch processing work"),
-        new("reconcile-package", "Reconcile package"),
-        new("finalize-package", "Finalize package")
-    ];
-
-    private static readonly PreparedChildWork[] PackageBusinessStatusPlan =
-    [
-        new("scan-package", "Package scan"),
-        new("classify-files", "Classify discovered files"),
-        new("dispatch-processing", "Dispatch processing work")
-    ];
-
     public static WorkflowGraphDto FromLifecycle(PackageWorkflowLifecycle lifecycle)
     {
         ArgumentNullException.ThrowIfNull(lifecycle);
@@ -39,7 +23,7 @@ public static class PackageWorkflowGraphProjection
             snapshot.PackageId,
             workflowInstanceId,
             MapLifecycleState(snapshot.State),
-            PackageLifecyclePlan);
+            PackageWorkflowChildWorkPlan.FullLifecycle);
     }
 
     public static WorkflowGraphDto FromPackageStatus(
@@ -66,7 +50,46 @@ public static class PackageWorkflowGraphProjection
             packageId,
             workflowInstanceId,
             MapPackageStatus(status),
-            PackageBusinessStatusPlan);
+            PackageWorkflowChildWorkPlan.BusinessStatus);
+    }
+
+    public static WorkflowGraphDto FromChildWorkflowNode(
+        WorkflowGraphDto parentGraph,
+        WorkflowNodeDto childWorkflowNode)
+    {
+        ArgumentNullException.ThrowIfNull(parentGraph);
+        ArgumentNullException.ThrowIfNull(childWorkflowNode);
+
+        if (childWorkflowNode.Kind != WorkflowNodeKind.ChildWorkflow)
+        {
+            throw new ArgumentException("Node must be a child workflow node.", nameof(childWorkflowNode));
+        }
+
+        if (string.IsNullOrWhiteSpace(childWorkflowNode.ChildWorkflowInstanceId))
+        {
+            throw new ArgumentException("Child workflow instance id is required.", nameof(childWorkflowNode));
+        }
+
+        var childWork = PackageWorkflowChildWorkPlan.FindByNodeId(childWorkflowNode.NodeId)
+            ?? throw new ArgumentException("Unknown child workflow node id.", nameof(childWorkflowNode));
+
+        var childRootNode = new WorkflowNodeDto(
+            NodeId: $"{childWorkflowNode.NodeId}-root",
+            DisplayName: childWorkflowNode.DisplayName,
+            Kind: WorkflowNodeKind.WorkflowStep,
+            Status: childWorkflowNode.Status,
+            WorkflowInstanceId: childWorkflowNode.ChildWorkflowInstanceId,
+            PackageId: parentGraph.PackageId,
+            WorkItemId: childWorkflowNode.WorkItemId,
+            ChildWorkflowInstanceId: null);
+
+        return new WorkflowGraphDto(
+            WorkflowInstanceId: childWorkflowNode.ChildWorkflowInstanceId,
+            WorkflowName: childWork.WorkflowName,
+            PackageId: parentGraph.PackageId,
+            ParentWorkflowInstanceId: parentGraph.WorkflowInstanceId,
+            Nodes: [childRootNode],
+            Edges: []);
     }
 
     private static WorkflowGraphDto CreateGraph(
@@ -92,12 +115,12 @@ public static class PackageWorkflowGraphProjection
         nodes.AddRange(workflowPlan.Select((work, index) => new WorkflowNodeDto(
             NodeId: work.NodeId,
             DisplayName: work.DisplayName,
-            Kind: WorkflowNodeKind.Activity,
+            Kind: WorkflowNodeKind.ChildWorkflow,
             Status: childStatuses[index],
             WorkflowInstanceId: workflowInstanceId,
             PackageId: packageId,
             WorkItemId: work.NodeId,
-            ChildWorkflowInstanceId: null)));
+            ChildWorkflowInstanceId: CreateChildWorkflowInstanceId(workflowInstanceId, work.NodeId))));
 
         var edges = CreateEdges(workflowPlan);
 
@@ -149,6 +172,11 @@ public static class PackageWorkflowGraphProjection
         }
 
         return [.. edges];
+    }
+
+    private static string CreateChildWorkflowInstanceId(string parentWorkflowInstanceId, string nodeId)
+    {
+        return $"{parentWorkflowInstanceId}/{nodeId}";
     }
 
     private static WorkflowNodeStatus[] MapChildStatuses(WorkflowNodeStatus packageStatus, int childCount)

--- a/src/MediaIngest.Workflow/PackageWorkflowStarter.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowStarter.cs
@@ -4,15 +4,6 @@ namespace MediaIngest.Workflow;
 
 public sealed class PackageWorkflowStarter
 {
-    private static readonly PreparedChildWork[] PackageStartPlan =
-    [
-        new("scan-package", "Package scan"),
-        new("classify-files", "Classify discovered files"),
-        new("dispatch-processing", "Dispatch processing work"),
-        new("reconcile-package", "Reconcile package"),
-        new("finalize-package", "Finalize package")
-    ];
-
     public PackageWorkflowStart Start(PackageIngestRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -34,6 +25,6 @@ public sealed class PackageWorkflowStarter
             WorkflowInstanceId: $"package-{request.PackageId}",
             CorrelationId: request.CorrelationId,
             AcceptedAt: request.AcceptedAt,
-            PreparedChildWork: PackageStartPlan);
+            PreparedChildWork: PackageWorkflowChildWorkPlan.FullLifecycle);
     }
 }

--- a/src/MediaIngest.Workflow/PreparedChildWork.cs
+++ b/src/MediaIngest.Workflow/PreparedChildWork.cs
@@ -2,4 +2,5 @@ namespace MediaIngest.Workflow;
 
 public sealed record PreparedChildWork(
     string NodeId,
-    string DisplayName);
+    string DisplayName,
+    string WorkflowName);

--- a/tests/MediaIngest.Contracts.Tests/Program.cs
+++ b/tests/MediaIngest.Contracts.Tests/Program.cs
@@ -37,10 +37,39 @@ var graph = new WorkflowGraphDto(
     ]);
 
 AssertEqual("PackageIngestWorkflow", WorkflowContractNames.PackageIngestWorkflow, "root workflow name");
+AssertSequenceEqual(
+    [
+        "PackageScanWorkflow",
+        "FileClassificationWorkflow",
+        "EssenceGroupProcessingWorkflow",
+        "ProxyCreationWorkflow",
+        "ReconciliationWorkflow",
+        "FinalizationWorkflow"
+    ],
+    [
+        WorkflowContractNames.PackageScanWorkflow,
+        WorkflowContractNames.FileClassificationWorkflow,
+        WorkflowContractNames.EssenceGroupProcessingWorkflow,
+        WorkflowContractNames.ProxyCreationWorkflow,
+        WorkflowContractNames.ReconciliationWorkflow,
+        WorkflowContractNames.FinalizationWorkflow
+    ],
+    "child workflow names");
 AssertEqual(WorkflowNodeStatus.Running, graph.Nodes[1].Status, "node status");
 AssertEqual("workflow-proxy-001", graph.Nodes[1].ChildWorkflowInstanceId, "child workflow drilldown link");
 AssertEqual("scan", graph.Edges[0].SourceNodeId, "edge source");
 AssertJsonRoundTrip(graph);
+
+var childGraph = graph with
+{
+    WorkflowInstanceId = "workflow-proxy-001",
+    WorkflowName = WorkflowContractNames.ProxyCreationWorkflow,
+    ParentWorkflowInstanceId = "workflow-package-001",
+    Nodes = [],
+    Edges = []
+};
+AssertEqual("workflow-package-001", childGraph.ParentWorkflowInstanceId, "child graph parent workflow reference");
+AssertJsonRoundTrip(childGraph);
 
 var details = new WorkflowNodeDetailsDto(
     WorkflowInstanceId: graph.WorkflowInstanceId,

--- a/tests/MediaIngest.Workflow.Tests/Program.cs
+++ b/tests/MediaIngest.Workflow.Tests/Program.cs
@@ -14,12 +14,19 @@ AssertEqual("package-001", start.PackageId, "package id");
 AssertEqual("PackageIngestWorkflow", start.WorkflowName, "workflow name");
 AssertEqual("package-package-001", start.WorkflowInstanceId, "workflow instance id");
 AssertEqual("correlation-001", start.CorrelationId, "correlation id");
-AssertEqual(5, start.PreparedChildWork.Count, "prepared child work count");
+AssertEqual(6, start.PreparedChildWork.Count, "prepared child work count");
 AssertEqual("scan-package", start.PreparedChildWork[0].NodeId, "scan node id");
 AssertEqual("classify-files", start.PreparedChildWork[1].NodeId, "classify node id");
-AssertEqual("dispatch-processing", start.PreparedChildWork[2].NodeId, "dispatch node id");
-AssertEqual("reconcile-package", start.PreparedChildWork[3].NodeId, "reconcile node id");
-AssertEqual("finalize-package", start.PreparedChildWork[4].NodeId, "finalize node id");
+AssertEqual("essence-group-processing", start.PreparedChildWork[2].NodeId, "essence group node id");
+AssertEqual("proxy-creation", start.PreparedChildWork[3].NodeId, "proxy node id");
+AssertEqual("reconcile-package", start.PreparedChildWork[4].NodeId, "reconcile node id");
+AssertEqual("finalize-package", start.PreparedChildWork[5].NodeId, "finalize node id");
+AssertEqual(WorkflowContractNames.PackageScanWorkflow, start.PreparedChildWork[0].WorkflowName, "scan workflow name");
+AssertEqual(WorkflowContractNames.FileClassificationWorkflow, start.PreparedChildWork[1].WorkflowName, "classification workflow name");
+AssertEqual(WorkflowContractNames.EssenceGroupProcessingWorkflow, start.PreparedChildWork[2].WorkflowName, "essence group workflow name");
+AssertEqual(WorkflowContractNames.ProxyCreationWorkflow, start.PreparedChildWork[3].WorkflowName, "proxy workflow name");
+AssertEqual(WorkflowContractNames.ReconciliationWorkflow, start.PreparedChildWork[4].WorkflowName, "reconciliation workflow name");
+AssertEqual(WorkflowContractNames.FinalizationWorkflow, start.PreparedChildWork[5].WorkflowName, "finalization workflow name");
 
 var lifecycle = PackageWorkflowLifecycle.Observe(request);
 AssertEqual(PackageWorkflowLifecycleState.Observed, lifecycle.Current.State, "observed lifecycle state");
@@ -45,16 +52,28 @@ var succeededGraph = PackageWorkflowGraphProjection.FromLifecycle(lifecycle);
 AssertEqual("package-package-001", succeededGraph.WorkflowInstanceId, "succeeded graph workflow instance id");
 AssertEqual("PackageIngestWorkflow", succeededGraph.WorkflowName, "succeeded graph workflow name");
 AssertEqual("package-001", succeededGraph.PackageId, "succeeded graph package id");
-AssertEqual(6, succeededGraph.Nodes.Count, "succeeded graph node count");
-AssertEqual(5, succeededGraph.Edges.Count, "succeeded graph edge count");
+AssertEqual(7, succeededGraph.Nodes.Count, "succeeded graph node count");
+AssertEqual(6, succeededGraph.Edges.Count, "succeeded graph edge count");
 AssertEqual("package-start", succeededGraph.Nodes[0].NodeId, "succeeded graph start node id");
 AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[0].Status, "succeeded graph start status");
 AssertEqual("scan-package", succeededGraph.Nodes[1].NodeId, "succeeded graph scan node id");
+AssertEqual(WorkflowNodeKind.ChildWorkflow, succeededGraph.Nodes[1].Kind, "succeeded graph scan node kind");
 AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[1].Status, "succeeded graph scan status");
-AssertEqual("reconcile-package", succeededGraph.Nodes[4].NodeId, "succeeded graph reconcile node id");
-AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[4].Status, "succeeded graph reconcile status");
-AssertEqual("finalize-package", succeededGraph.Nodes[5].NodeId, "succeeded graph finalization node id");
-AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[5].Status, "succeeded graph finalization status");
+AssertEqual("package-package-001/scan-package", succeededGraph.Nodes[1].ChildWorkflowInstanceId, "succeeded graph scan child workflow instance");
+AssertEqual("reconcile-package", succeededGraph.Nodes[5].NodeId, "succeeded graph reconcile node id");
+AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[5].Status, "succeeded graph reconcile status");
+AssertEqual("package-package-001/reconcile-package", succeededGraph.Nodes[5].ChildWorkflowInstanceId, "succeeded graph reconcile child workflow instance");
+AssertEqual("finalize-package", succeededGraph.Nodes[6].NodeId, "succeeded graph finalization node id");
+AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[6].Status, "succeeded graph finalization status");
+AssertEqual("package-package-001/finalize-package", succeededGraph.Nodes[6].ChildWorkflowInstanceId, "succeeded graph finalization child workflow instance");
+
+var scanChildGraph = PackageWorkflowGraphProjection.FromChildWorkflowNode(succeededGraph, succeededGraph.Nodes[1]);
+AssertEqual("package-package-001/scan-package", scanChildGraph.WorkflowInstanceId, "scan child graph workflow instance id");
+AssertEqual(WorkflowContractNames.PackageScanWorkflow, scanChildGraph.WorkflowName, "scan child graph workflow name");
+AssertEqual("package-package-001", scanChildGraph.ParentWorkflowInstanceId, "scan child graph parent workflow instance id");
+AssertEqual("package-001", scanChildGraph.PackageId, "scan child graph package id");
+AssertEqual(1, scanChildGraph.Nodes.Count, "scan child graph node count");
+AssertEqual("scan-package-root", scanChildGraph.Nodes[0].NodeId, "scan child graph root node id");
 
 var failingLifecycle = PackageWorkflowLifecycle.Observe(request);
 failingLifecycle.MarkReady(new DateTimeOffset(2026, 5, 3, 12, 4, 0, TimeSpan.Zero));
@@ -80,7 +99,7 @@ var businessStatusGraph = PackageWorkflowGraphProjection.FromPackageStatus(
     workflowInstanceId: "package-package-001",
     status: "Succeeded");
 AssertEqual(4, businessStatusGraph.Nodes.Count, "business status graph node count");
-AssertEqual("dispatch-processing", businessStatusGraph.Nodes[3].NodeId, "business status graph final visible node");
+AssertEqual("essence-group-processing", businessStatusGraph.Nodes[3].NodeId, "business status graph final visible node");
 
 AssertThrows<InvalidOperationException>(
     () => PackageWorkflowLifecycle.Observe(request).Start(new DateTimeOffset(2026, 5, 3, 12, 7, 0, TimeSpan.Zero)),


### PR DESCRIPTION
Refs #20

## Summary
- Adds a shared in-process child workflow plan for package scan, file classification, essence group processing, proxy creation, reconciliation, and finalization.
- Projects package lifecycle nodes as `ChildWorkflow` nodes with deterministic child workflow instance IDs.
- Adds a child graph projection helper that preserves the parent workflow instance reference for later drilldown/back traversal.

## Validation
- `make test-dotnet-contracts` passed.
- `make test-dotnet-workflow` passed.
- `make validate` passed.
- `git diff --check` passed.

## Risk
- Contract/projection-only change; no Dapr package dependency, runtime wiring, API integration, persistence changes, or UI changes.
- Existing graph consumers may now see lifecycle work as `ChildWorkflow` nodes instead of `Activity` nodes once this branch is integrated.

## Follow-ups
- Wire runtime child workflow starts when Dapr orchestration is implemented.
- Add API/UI drilldown endpoints and Canvas navigation in the later UI stories.