### PR TITLE
USER-STORY-3: Add manifest discrepancy warnings

### DIFF
--- a/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestMountScanner.cs
@@ -2,6 +2,8 @@ namespace MediaIngest.Worker.Watcher;
 
 public sealed class IngestMountScanner
 {
+    private readonly ManifestReferenceReader manifestReferenceReader = new();
+
     public IReadOnlyList<IngestPackageCandidate> FindPackageCandidates(string ingestMountPath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ingestMountPath);
@@ -27,6 +29,21 @@ public sealed class IngestMountScanner
     {
         ArgumentNullException.ThrowIfNull(candidate);
 
+        return FindPhysicalPackageFiles(candidate);
+    }
+
+    public IngestPackageFileScan ScanPackageFiles(IngestPackageCandidate candidate)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        var files = FindPhysicalPackageFiles(candidate);
+        var warnings = FindManifestWarnings(candidate, files);
+
+        return new IngestPackageFileScan(files, warnings);
+    }
+
+    private static IReadOnlyList<IngestPackageFile> FindPhysicalPackageFiles(IngestPackageCandidate candidate)
+    {
         var packagePath = Path.GetFullPath(candidate.PackagePath);
 
         return Directory.EnumerateFiles(packagePath, "*", SearchOption.AllDirectories)
@@ -36,6 +53,38 @@ public sealed class IngestMountScanner
                 Path.GetRelativePath(packagePath, filePath),
                 new FileInfo(filePath).Length))
             .OrderBy(file => file.PackageRelativePath, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private IReadOnlyList<IngestPackageWarning> FindManifestWarnings(
+        IngestPackageCandidate candidate,
+        IReadOnlyList<IngestPackageFile> files)
+    {
+        var packagePath = Path.GetFullPath(candidate.PackagePath);
+        var manifestPath = Path.Combine(packagePath, "manifest.json");
+
+        if (!File.Exists(manifestPath))
+        {
+            return [];
+        }
+
+        var manifestReferences = manifestReferenceReader.ReadFileReferences(manifestPath);
+
+        if (manifestReferences.MalformedWarning is not null)
+        {
+            return [manifestReferences.MalformedWarning];
+        }
+
+        var physicalRelativePaths = files
+            .Select(file => file.PackageRelativePath)
+            .ToHashSet(StringComparer.Ordinal);
+
+        return manifestReferences.FilePaths
+            .Where(reference => !physicalRelativePaths.Contains(reference))
+            .Select(reference => new IngestPackageWarning(
+                "ManifestFileMissing",
+                reference,
+                $"Manifest references missing file '{reference}'."))
             .ToArray();
     }
 

--- a/src/MediaIngest.Worker.Watcher/IngestPackageFileScan.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestPackageFileScan.cs
@@ -1,0 +1,5 @@
+namespace MediaIngest.Worker.Watcher;
+
+public sealed record IngestPackageFileScan(
+    IReadOnlyList<IngestPackageFile> Files,
+    IReadOnlyList<IngestPackageWarning> Warnings);

--- a/src/MediaIngest.Worker.Watcher/IngestPackageWarning.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestPackageWarning.cs
@@ -1,0 +1,6 @@
+namespace MediaIngest.Worker.Watcher;
+
+public sealed record IngestPackageWarning(
+    string Code,
+    string PackageRelativePath,
+    string Message);

--- a/src/MediaIngest.Worker.Watcher/ManifestReferenceReader.cs
+++ b/src/MediaIngest.Worker.Watcher/ManifestReferenceReader.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+
+namespace MediaIngest.Worker.Watcher;
+
+internal sealed class ManifestReferenceReader
+{
+    public ManifestReferences ReadFileReferences(string manifestPath)
+    {
+        try
+        {
+            using var manifest = File.OpenRead(manifestPath);
+            using var document = JsonDocument.Parse(manifest);
+
+            if (!document.RootElement.TryGetProperty("files", out var filesElement) ||
+                filesElement.ValueKind != JsonValueKind.Array)
+            {
+                return ManifestReferences.Empty;
+            }
+
+            var filePaths = filesElement
+                .EnumerateArray()
+                .Where(fileElement => fileElement.ValueKind == JsonValueKind.String)
+                .Select(fileElement => fileElement.GetString())
+                .Where(filePath => !string.IsNullOrWhiteSpace(filePath))
+                .Select(NormalizeManifestPath)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+
+            return new ManifestReferences(filePaths, MalformedWarning: null);
+        }
+        catch (JsonException exception)
+        {
+            return new ManifestReferences(
+                [],
+                new IngestPackageWarning(
+                    "ManifestMalformed",
+                    "manifest.json",
+                    $"Manifest could not be parsed: {exception.Message}"));
+        }
+    }
+
+    private static string NormalizeManifestPath(string? filePath)
+    {
+        return filePath!
+            .Trim()
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar);
+    }
+}
+
+internal sealed record ManifestReferences(
+    IReadOnlyList<string> FilePaths,
+    IngestPackageWarning? MalformedWarning)
+{
+    public static ManifestReferences Empty { get; } = new([], MalformedWarning: null);
+}

--- a/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Watcher.Tests/Program.cs
@@ -110,6 +110,8 @@ try
     await VerifyObservationLoopScansRepeatedlyUntilCancelled();
     await VerifyObservationLoopDoesNotReportUnchangedPackageTwice();
     await VerifyObservationLoopStopsWhenCancellationIsRequested();
+    VerifyManifestDiscrepancyWarnings();
+    VerifyMalformedManifestWarningDoesNotStopDiskDiscovery();
 }
 finally
 {
@@ -120,6 +122,84 @@ finally
 }
 
 Console.WriteLine("MediaIngest watcher smoke tests passed.");
+
+static void VerifyManifestDiscrepancyWarnings()
+{
+    var packagePath = CreateTestDirectory();
+    var mediaPath = Directory.CreateDirectory(Path.Combine(packagePath, "media")).FullName;
+    var sidecarPath = Directory.CreateDirectory(Path.Combine(packagePath, "sidecars")).FullName;
+
+    try
+    {
+        File.WriteAllText(
+            Path.Combine(packagePath, "manifest.json"),
+            """
+            {
+              "files": [
+                "media/clip.mov",
+                "missing/proxy.mp4"
+              ]
+            }
+            """);
+        File.WriteAllText(Path.Combine(packagePath, "manifest.json.checksum"), "not-a-real-checksum");
+        File.WriteAllText(Path.Combine(mediaPath, "clip.mov"), "not-real-media");
+        File.WriteAllText(Path.Combine(sidecarPath, "clip.en.srt"), "not-real-captions");
+
+        var scan = new IngestMountScanner().ScanPackageFiles(new IngestPackageCandidate(packagePath));
+
+        AssertSequenceEqual(
+            new[]
+            {
+                "manifest.json",
+                "manifest.json.checksum",
+                Path.Combine("media", "clip.mov"),
+                Path.Combine("sidecars", "clip.en.srt"),
+            },
+            scan.Files.Select(file => file.PackageRelativePath).ToArray(),
+            "manifest discrepancy scan discovered relative paths");
+        AssertEqual(1, scan.Warnings.Count, "manifest discrepancy warning count");
+        AssertEqual("ManifestFileMissing", scan.Warnings[0].Code, "manifest discrepancy warning code");
+        AssertEqual(
+            Path.Combine("missing", "proxy.mp4"),
+            scan.Warnings[0].PackageRelativePath,
+            "manifest discrepancy warning relative path");
+    }
+    finally
+    {
+        DeleteTestDirectory(packagePath);
+    }
+}
+
+static void VerifyMalformedManifestWarningDoesNotStopDiskDiscovery()
+{
+    var packagePath = CreateTestDirectory();
+
+    try
+    {
+        File.WriteAllText(Path.Combine(packagePath, "manifest.json"), "{not-json");
+        File.WriteAllText(Path.Combine(packagePath, "manifest.json.checksum"), "not-a-real-checksum");
+        File.WriteAllText(Path.Combine(packagePath, "clip.mov"), "not-real-media");
+
+        var scan = new IngestMountScanner().ScanPackageFiles(new IngestPackageCandidate(packagePath));
+
+        AssertSequenceEqual(
+            new[]
+            {
+                "clip.mov",
+                "manifest.json",
+                "manifest.json.checksum",
+            },
+            scan.Files.Select(file => file.PackageRelativePath).ToArray(),
+            "malformed manifest scan discovered relative paths");
+        AssertEqual(1, scan.Warnings.Count, "malformed manifest warning count");
+        AssertEqual("ManifestMalformed", scan.Warnings[0].Code, "malformed manifest warning code");
+        AssertEqual("manifest.json", scan.Warnings[0].PackageRelativePath, "malformed manifest warning relative path");
+    }
+    finally
+    {
+        DeleteTestDirectory(packagePath);
+    }
+}
 
 static async Task VerifyObservationLoopUsesConfiguredMountPath()
 {


### PR DESCRIPTION
Refs #13

## Summary
- Adds watcher scan results that return discovered physical files plus manifest validation warnings.
- Reads conservative manifest references from a top-level `files` string array with `System.Text.Json`.
- Warns for manifest-listed files missing on disk and malformed manifests without blocking physical file discovery.

## Validation
- `make test-dotnet-watcher` passed.
- `make validate` passed.
- `git diff --check` passed.

## Risk
- Warning records are currently local to watcher scan results and are not yet persisted or surfaced through workflow/API paths.
- Manifest parsing intentionally supports only the initial top-level `files` string array shape.

## Follow-ups
- Wire warnings into durable package state or timeline events when the owning persistence/workflow slice is ready.
- Extend manifest schema support if a richer manifest contract is adopted.