### PR TITLE
USER-STORY-16: Add local compose make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help agent-preflight check-tools install-tools install-optional-tools print-install-tools print-install-optional-tools local-compose-check validate validate-docs validate-automation test-dotnet test-dotnet-foundation test-dotnet-contracts test-dotnet-watcher test-dotnet-api test-dotnet-persistence test-dotnet-outbox test-dotnet-workflow test-dotnet-observability test-dotnet-command-runner docs-check docs-fix scripts-check github-projects-script-test github-project-check github-project-summary github-project-hierarchy github-project-active github-project-audit-fields github-issue-body-lint
+.PHONY: help agent-preflight check-tools install-tools install-optional-tools print-install-tools print-install-optional-tools up down local-compose-check validate validate-docs validate-automation test-dotnet test-dotnet-foundation test-dotnet-contracts test-dotnet-watcher test-dotnet-api test-dotnet-persistence test-dotnet-outbox test-dotnet-workflow test-dotnet-observability test-dotnet-command-runner docs-check docs-fix scripts-check github-projects-script-test github-project-check github-project-summary github-project-hierarchy github-project-active github-project-audit-fields github-issue-body-lint
 
 help:
 	@printf '%s\n' "Available targets:"
@@ -8,6 +8,8 @@ help:
 	@printf '%s\n' "  make install-optional-tools Install optional local runtime/cloud CLIs"
 	@printf '%s\n' "  make print-install-tools Print manual installation commands"
 	@printf '%s\n' "  make print-install-optional-tools Print optional tool install commands"
+	@printf '%s\n' "  make up                  Start local Docker Compose runtime"
+	@printf '%s\n' "  make down                Stop local Docker Compose runtime"
 	@printf '%s\n' "  make local-compose-check Validate local Docker Compose configuration"
 	@printf '%s\n' "  make validate            Run cheap repository validation"
 	@printf '%s\n' "  make validate-docs       Run docs validation only"
@@ -42,6 +44,12 @@ print-install-tools:
 
 print-install-optional-tools:
 	@sh scripts/dev/install-optional-tools.sh --print-only
+
+up:
+	docker compose -f deploy/docker/compose.yaml up --build
+
+down:
+	docker compose -f deploy/docker/compose.yaml down
 
 local-compose-check:
 	@sh scripts/dev/local-compose-check.sh

--- a/README.md
+++ b/README.md
@@ -57,6 +57,32 @@ helper wrappers, and the .NET solution smoke-test targets. Runtime-specific
 checks such as local Compose validation are exposed as focused Make targets and
 can be run when that slice is in scope.
 
+### 4. Start or stop the local Docker runtime
+
+Use Docker Compose for the current runnable local system:
+
+```bash
+make up
+```
+
+That target builds and starts the local API, UI, and PostgreSQL services with:
+
+```bash
+docker compose -f deploy/docker/compose.yaml up --build
+```
+
+Stop the local Docker runtime with:
+
+```bash
+make down
+```
+
+That target runs:
+
+```bash
+docker compose -f deploy/docker/compose.yaml down
+```
+
 ## Local Manifest Ingest Demo
 
 This local workflow exercises the manifest start path through the API, React

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -20,6 +20,22 @@ projects gain executable hosts.
 Docker assets are local/runtime scaffolding. They do not create Azure resources,
 publish images, store credentials, or validate a production deployment.
 
+Start the local API, UI, and PostgreSQL Compose runtime from the repository
+root:
+
+```bash
+make up
+```
+
+The target runs `docker compose -f deploy/docker/compose.yaml up --build`.
+Stop the local Compose runtime with:
+
+```bash
+make down
+```
+
+The target runs `docker compose -f deploy/docker/compose.yaml down`.
+
 Use the static local check from the repository root to validate Compose syntax
 and service resolution without starting containers:
 

--- a/docs/automation/commands.md
+++ b/docs/automation/commands.md
@@ -13,6 +13,8 @@
 | `make install-optional-tools` | Install optional host runtime and cloud CLIs after local confirmation. | moderate | no | no |
 | `make print-install-tools` | Print installation commands without running them. | cheap | no | no |
 | `make print-install-optional-tools` | Print optional host tool installation commands without running them. | cheap | no | no |
+| `make up` | Start the local API, UI, and PostgreSQL Docker Compose runtime with image builds. | moderate | yes | no |
+| `make down` | Stop the local Docker Compose runtime. | cheap | yes | no |
 | `make local-compose-check` | Validate `deploy/docker/compose.yaml` with `docker compose config` without starting containers. | cheap | yes | no |
 | `make validate` | Run cheap repository validation. | cheap | no | no |
 | `make validate-docs` | Run documentation validation only. | cheap | no | no |

--- a/docs/automation/local-smoke-tests.md
+++ b/docs/automation/local-smoke-tests.md
@@ -65,6 +65,31 @@ Optional overrides:
 
 ## Local Compose Config
 
+Use `make up` to start the local API, UI, and PostgreSQL Compose runtime from
+the repository root:
+
+```bash
+make up
+```
+
+The target runs:
+
+```bash
+docker compose -f deploy/docker/compose.yaml up --build
+```
+
+Use `make down` to stop the local Compose runtime:
+
+```bash
+make down
+```
+
+The target runs:
+
+```bash
+docker compose -f deploy/docker/compose.yaml down
+```
+
 Use `scripts/dev/local-compose-check.sh` to validate the local API, UI, and
 PostgreSQL Compose configuration without starting containers:
 


### PR DESCRIPTION
## Summary

- Adds `make up` and `make down` wrappers for the current Docker Compose local runtime.
- Updates `make help`, README quickstart, automation command docs, local smoke docs, and Docker runtime docs.
- Keeps Kubernetes start/apply commands out of scope; Docker Compose remains the runnable local lane.

Refs #26

## Validation

- `make -n up` -> prints `docker compose -f deploy/docker/compose.yaml up --build`
- `make -n down` -> prints `docker compose -f deploy/docker/compose.yaml down`
- `make help` -> lists `make up` and `make down`
- `make local-compose-check` -> resolved `postgres`, `api`, and `ui`
- `make validate-automation` -> passed
- `make validate` -> passed docs, shell automation, helper tests, build, and .NET smoke tests
- `git diff --check` -> passed

## Risk

Low. This only adds Make wrappers around existing Docker Compose commands and updates local docs.

## Follow-up

Future Kubernetes local-cluster commands remain out of scope until that lane is explicitly adopted.