### PR TITLE
USER-STORY-10: Improve nested workflow projection

### DIFF
--- a/src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs
@@ -73,6 +73,16 @@ public static class PackageWorkflowGraphProjection
         var childWork = PackageWorkflowChildWorkPlan.FindByNodeId(childWorkflowNode.NodeId)
             ?? throw new ArgumentException("Unknown child workflow node id.", nameof(childWorkflowNode));
 
+        var parentNavigationNode = new WorkflowNodeDto(
+            NodeId: $"{childWorkflowNode.NodeId}-parent",
+            DisplayName: "Parent workflow",
+            Kind: WorkflowNodeKind.ChildWorkflow,
+            Status: childWorkflowNode.Status,
+            WorkflowInstanceId: childWorkflowNode.ChildWorkflowInstanceId,
+            PackageId: parentGraph.PackageId,
+            WorkItemId: null,
+            ChildWorkflowInstanceId: parentGraph.WorkflowInstanceId);
+
         var childRootNode = new WorkflowNodeDto(
             NodeId: $"{childWorkflowNode.NodeId}-root",
             DisplayName: childWorkflowNode.DisplayName,
@@ -88,8 +98,14 @@ public static class PackageWorkflowGraphProjection
             WorkflowName: childWork.WorkflowName,
             PackageId: parentGraph.PackageId,
             ParentWorkflowInstanceId: parentGraph.WorkflowInstanceId,
-            Nodes: [childRootNode],
-            Edges: []);
+            Nodes: [parentNavigationNode, childRootNode],
+            Edges:
+            [
+                new WorkflowEdgeDto(
+                    EdgeId: $"{parentNavigationNode.NodeId}-{childRootNode.NodeId}",
+                    SourceNodeId: parentNavigationNode.NodeId,
+                    TargetNodeId: childRootNode.NodeId)
+            ]);
     }
 
     private static WorkflowGraphDto CreateGraph(

--- a/tests/MediaIngest.Workflow.Tests/Program.cs
+++ b/tests/MediaIngest.Workflow.Tests/Program.cs
@@ -67,13 +67,57 @@ AssertEqual("finalize-package", succeededGraph.Nodes[6].NodeId, "succeeded graph
 AssertEqual(WorkflowNodeStatus.Succeeded, succeededGraph.Nodes[6].Status, "succeeded graph finalization status");
 AssertEqual("package-package-001/finalize-package", succeededGraph.Nodes[6].ChildWorkflowInstanceId, "succeeded graph finalization child workflow instance");
 
+var childWorkflowNodes = succeededGraph.Nodes
+    .Where(node => node.Kind == WorkflowNodeKind.ChildWorkflow)
+    .ToArray();
+AssertEqual(6, childWorkflowNodes.Length, "parent graph child workflow node count");
+AssertAll(
+    childWorkflowNodes,
+    node => node.WorkflowInstanceId == succeededGraph.WorkflowInstanceId,
+    "parent child workflow node belongs to parent workflow");
+AssertAll(
+    childWorkflowNodes,
+    node => node.PackageId == succeededGraph.PackageId,
+    "parent child workflow node preserves package id");
+AssertAll(
+    childWorkflowNodes,
+    node => node.WorkItemId == node.NodeId,
+    "parent child workflow node exposes work item drilldown metadata");
+AssertAll(
+    childWorkflowNodes,
+    node => node.ChildWorkflowInstanceId == $"{succeededGraph.WorkflowInstanceId}/{node.NodeId}",
+    "parent child workflow node exposes child workflow drilldown metadata");
+
 var scanChildGraph = PackageWorkflowGraphProjection.FromChildWorkflowNode(succeededGraph, succeededGraph.Nodes[1]);
 AssertEqual("package-package-001/scan-package", scanChildGraph.WorkflowInstanceId, "scan child graph workflow instance id");
 AssertEqual(WorkflowContractNames.PackageScanWorkflow, scanChildGraph.WorkflowName, "scan child graph workflow name");
 AssertEqual("package-package-001", scanChildGraph.ParentWorkflowInstanceId, "scan child graph parent workflow instance id");
 AssertEqual("package-001", scanChildGraph.PackageId, "scan child graph package id");
-AssertEqual(1, scanChildGraph.Nodes.Count, "scan child graph node count");
-AssertEqual("scan-package-root", scanChildGraph.Nodes[0].NodeId, "scan child graph root node id");
+AssertEqual(2, scanChildGraph.Nodes.Count, "scan child graph node count");
+AssertEqual(1, scanChildGraph.Edges.Count, "scan child graph edge count");
+AssertEqual("scan-package-parent", scanChildGraph.Nodes[0].NodeId, "scan child graph parent navigation node id");
+AssertEqual(WorkflowNodeKind.ChildWorkflow, scanChildGraph.Nodes[0].Kind, "scan child graph parent navigation node kind");
+AssertEqual("package-package-001/scan-package", scanChildGraph.Nodes[0].WorkflowInstanceId, "scan child graph parent navigation workflow instance id");
+AssertEqual("package-package-001", scanChildGraph.Nodes[0].ChildWorkflowInstanceId, "scan child graph parent navigation target");
+AssertEqual("scan-package-root", scanChildGraph.Nodes[1].NodeId, "scan child graph root node id");
+AssertEqual("scan-package", scanChildGraph.Nodes[1].WorkItemId, "scan child graph root work item metadata");
+AssertEqual("scan-package-parent-scan-package-root", scanChildGraph.Edges[0].EdgeId, "scan child graph parent edge id");
+AssertEqual("scan-package-parent", scanChildGraph.Edges[0].SourceNodeId, "scan child graph parent edge source");
+AssertEqual("scan-package-root", scanChildGraph.Edges[0].TargetNodeId, "scan child graph parent edge target");
+
+var childWorkflowNamesByNodeId = start.PreparedChildWork.ToDictionary(work => work.NodeId, work => work.WorkflowName);
+foreach (var childWorkflowNode in childWorkflowNodes)
+{
+    var childGraph = PackageWorkflowGraphProjection.FromChildWorkflowNode(succeededGraph, childWorkflowNode);
+
+    AssertEqual(childWorkflowNode.ChildWorkflowInstanceId, childGraph.WorkflowInstanceId, $"{childWorkflowNode.NodeId} child graph workflow instance id");
+    AssertEqual(childWorkflowNamesByNodeId[childWorkflowNode.NodeId], childGraph.WorkflowName, $"{childWorkflowNode.NodeId} child graph workflow name");
+    AssertEqual(succeededGraph.WorkflowInstanceId, childGraph.ParentWorkflowInstanceId, $"{childWorkflowNode.NodeId} child graph parent workflow instance id");
+    AssertEqual(succeededGraph.PackageId, childGraph.PackageId, $"{childWorkflowNode.NodeId} child graph package id");
+    AssertEqual(childWorkflowNode.Status, childGraph.Nodes[1].Status, $"{childWorkflowNode.NodeId} child graph root status");
+    AssertEqual(childWorkflowNode.WorkItemId, childGraph.Nodes[1].WorkItemId, $"{childWorkflowNode.NodeId} child graph root work item id");
+    AssertEqual(succeededGraph.WorkflowInstanceId, childGraph.Nodes[0].ChildWorkflowInstanceId, $"{childWorkflowNode.NodeId} child graph parent navigation target");
+}
 
 var failingLifecycle = PackageWorkflowLifecycle.Observe(request);
 failingLifecycle.MarkReady(new DateTimeOffset(2026, 5, 3, 12, 4, 0, TimeSpan.Zero));
@@ -128,4 +172,18 @@ static void AssertThrows<TException>(Action action, string name)
     }
 
     throw new InvalidOperationException($"{name}: expected {typeof(TException).Name}.");
+}
+
+static void AssertAll<T>(IEnumerable<T> values, Func<T, bool> predicate, string name)
+{
+    var index = 0;
+    foreach (var value in values)
+    {
+        if (!predicate(value))
+        {
+            throw new InvalidOperationException($"{name}: item {index} failed.");
+        }
+
+        index++;
+    }
 }


### PR DESCRIPTION
## Summary
- Adds focused workflow smoke-test coverage for parent child-workflow drilldown metadata across all planned child workflow nodes.
- Projects child workflow graphs with explicit parent graph relationship metadata plus an in-graph parent navigation node and edge using existing workflow DTO fields.
- Keeps the slice within `src/MediaIngest.Workflow/**` and `tests/MediaIngest.Workflow.Tests/**`; no Dapr runtime wiring or contract changes.

## Linked Stories
Refs #20
Refs #24
Refs #25

## Validation
- `make test-dotnet-workflow` passed after RED failure confirmation.
- `make validate` passed.
- `git diff --check` passed.

## TDD Evidence
- RED: `make test-dotnet-workflow` failed with `scan child graph node count: expected '2', got '1'`.
- GREEN: `make test-dotnet-workflow` passed after implementation.

## Risk
Low. The change only enriches workflow graph projection data inside the workflow slice and reuses existing DTO fields.

## Follow-up
- API/UI runtime sources can consume this projected parent navigation metadata in later Canvas/API slices.