### PR TITLE
USER-STORY-11: Strengthen observability coverage

### DIFF
--- a/src/MediaIngest.Observability/DiagnosticEventNames.cs
+++ b/src/MediaIngest.Observability/DiagnosticEventNames.cs
@@ -6,6 +6,10 @@ public static class DiagnosticEventNames
     public const string Readiness = "ingest.readiness";
     public const string Copy = "ingest.copy";
     public const string OutboxDispatch = "outbox.dispatch";
+    public const string CommandStarted = "command.started";
+    public const string CommandProgress = "command.progress";
+    public const string CommandSucceeded = "command.succeeded";
+    public const string CommandFailed = "command.failed";
     public const string Success = "ingest.succeeded";
     public const string Failure = "ingest.failed";
 
@@ -15,6 +19,10 @@ public static class DiagnosticEventNames
         Readiness,
         Copy,
         OutboxDispatch,
+        CommandStarted,
+        CommandProgress,
+        CommandSucceeded,
+        CommandFailed,
         Success,
         Failure
     ];

--- a/src/MediaIngest.Observability/ObservabilityCorrelationContext.cs
+++ b/src/MediaIngest.Observability/ObservabilityCorrelationContext.cs
@@ -1,18 +1,72 @@
 namespace MediaIngest.Observability;
 
-public sealed record ObservabilityCorrelationContext(
-    string WorkflowInstanceId,
-    string PackageId,
-    string FileId,
-    string WorkItemId,
-    string NodeId,
-    string AgentType,
-    string QueueName,
-    string CorrelationId,
-    string CausationId,
-    string TraceId,
-    string SpanId)
+public sealed record ObservabilityCorrelationContext
 {
+    public ObservabilityCorrelationContext(
+        string WorkflowInstanceId,
+        string PackageId,
+        string FileId,
+        string WorkItemId,
+        string NodeId,
+        string AgentType,
+        string QueueName,
+        string CorrelationId,
+        string CausationId,
+        string TraceId,
+        string SpanId)
+    {
+        this.WorkflowInstanceId = Require(WorkflowInstanceId, nameof(WorkflowInstanceId));
+        this.PackageId = Require(PackageId, nameof(PackageId));
+        this.FileId = Require(FileId, nameof(FileId));
+        this.WorkItemId = Require(WorkItemId, nameof(WorkItemId));
+        this.NodeId = Require(NodeId, nameof(NodeId));
+        this.AgentType = Require(AgentType, nameof(AgentType));
+        this.QueueName = Require(QueueName, nameof(QueueName));
+        this.CorrelationId = Require(CorrelationId, nameof(CorrelationId));
+        this.CausationId = Require(CausationId, nameof(CausationId));
+        this.TraceId = Require(TraceId, nameof(TraceId));
+        this.SpanId = Require(SpanId, nameof(SpanId));
+    }
+
+    public string WorkflowInstanceId { get; }
+    public string PackageId { get; }
+    public string FileId { get; }
+    public string WorkItemId { get; }
+    public string NodeId { get; }
+    public string AgentType { get; }
+    public string QueueName { get; }
+    public string CorrelationId { get; }
+    public string CausationId { get; }
+    public string TraceId { get; }
+    public string SpanId { get; }
+
+    public static ObservabilityCorrelationContext Create(
+        string workflowInstanceId,
+        string packageId,
+        string fileId,
+        string workItemId,
+        string nodeId,
+        string agentType,
+        string queueName,
+        string correlationId,
+        string causationId,
+        string traceId,
+        string spanId)
+    {
+        return new ObservabilityCorrelationContext(
+            workflowInstanceId,
+            packageId,
+            fileId,
+            workItemId,
+            nodeId,
+            agentType,
+            queueName,
+            correlationId,
+            causationId,
+            traceId,
+            spanId);
+    }
+
     public IReadOnlyDictionary<string, string> ToFields()
     {
         return new Dictionary<string, string>
@@ -29,5 +83,15 @@ public sealed record ObservabilityCorrelationContext(
             [CorrelationFieldNames.TraceId] = TraceId,
             [CorrelationFieldNames.SpanId] = SpanId
         };
+    }
+
+    private static string Require(string value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException($"{name} is required.", name);
+        }
+
+        return value;
     }
 }

--- a/tests/MediaIngest.Observability.Tests/Program.cs
+++ b/tests/MediaIngest.Observability.Tests/Program.cs
@@ -16,6 +16,18 @@ var expectedFields = new[]
 };
 
 AssertSequenceEqual(expectedFields, CorrelationFieldNames.All, "correlation field catalog");
+AssertUnique(CorrelationFieldNames.All, "correlation field catalog");
+AssertEqual("workflowInstanceId", CorrelationFieldNames.WorkflowInstanceId, "workflow instance field");
+AssertEqual("packageId", CorrelationFieldNames.PackageId, "package field");
+AssertEqual("fileId", CorrelationFieldNames.FileId, "file field");
+AssertEqual("workItemId", CorrelationFieldNames.WorkItemId, "work item field");
+AssertEqual("nodeId", CorrelationFieldNames.NodeId, "node field");
+AssertEqual("agentType", CorrelationFieldNames.AgentType, "agent type field");
+AssertEqual("queueName", CorrelationFieldNames.QueueName, "queue field");
+AssertEqual("correlationId", CorrelationFieldNames.CorrelationId, "correlation field");
+AssertEqual("causationId", CorrelationFieldNames.CausationId, "causation field");
+AssertEqual("traceId", CorrelationFieldNames.TraceId, "trace field");
+AssertEqual("spanId", CorrelationFieldNames.SpanId, "span field");
 
 var expectedDiagnosticEvents = new[]
 {
@@ -23,15 +35,24 @@ var expectedDiagnosticEvents = new[]
     "ingest.readiness",
     "ingest.copy",
     "outbox.dispatch",
+    "command.started",
+    "command.progress",
+    "command.succeeded",
+    "command.failed",
     "ingest.succeeded",
     "ingest.failed"
 };
 
 AssertSequenceEqual(expectedDiagnosticEvents, DiagnosticEventNames.All, "diagnostic event catalog");
+AssertUnique(DiagnosticEventNames.All, "diagnostic event catalog");
 AssertEqual("ingest.scan", DiagnosticEventNames.Scan, "scan diagnostic event");
 AssertEqual("ingest.readiness", DiagnosticEventNames.Readiness, "readiness diagnostic event");
 AssertEqual("ingest.copy", DiagnosticEventNames.Copy, "copy diagnostic event");
 AssertEqual("outbox.dispatch", DiagnosticEventNames.OutboxDispatch, "outbox dispatch diagnostic event");
+AssertEqual("command.started", DiagnosticEventNames.CommandStarted, "command started diagnostic event");
+AssertEqual("command.progress", DiagnosticEventNames.CommandProgress, "command progress diagnostic event");
+AssertEqual("command.succeeded", DiagnosticEventNames.CommandSucceeded, "command succeeded diagnostic event");
+AssertEqual("command.failed", DiagnosticEventNames.CommandFailed, "command failed diagnostic event");
 AssertEqual("ingest.succeeded", DiagnosticEventNames.Success, "success diagnostic event");
 AssertEqual("ingest.failed", DiagnosticEventNames.Failure, "failure diagnostic event");
 
@@ -63,6 +84,49 @@ AssertEqual("package-001", fields["packageId"], "package correlation");
 AssertEqual("proxy", fields["agentType"], "agent correlation");
 AssertEqual("work-item-proxy-001", fields["workItemId"], "work item correlation");
 
+var createdContext = ObservabilityCorrelationContext.Create(
+    workflowInstanceId: "workflow-package-002",
+    packageId: "package-002",
+    fileId: "file-source-002",
+    workItemId: "work-item-qc-002",
+    nodeId: "node-qc",
+    agentType: "qc",
+    queueName: "mediaingest.qc",
+    correlationId: "correlation-002",
+    causationId: "command-002",
+    traceId: "trace-002",
+    spanId: "span-002");
+
+var createdFields = createdContext.ToFields();
+
+AssertEqual(CorrelationFieldNames.All.Count, createdFields.Count, "created context field count");
+AssertEqual("workflow-package-002", createdFields[CorrelationFieldNames.WorkflowInstanceId], "created workflow correlation");
+AssertEqual("package-002", createdFields[CorrelationFieldNames.PackageId], "created package correlation");
+AssertEqual("file-source-002", createdFields[CorrelationFieldNames.FileId], "created file correlation");
+AssertEqual("work-item-qc-002", createdFields[CorrelationFieldNames.WorkItemId], "created work item correlation");
+AssertEqual("node-qc", createdFields[CorrelationFieldNames.NodeId], "created node correlation");
+AssertEqual("qc", createdFields[CorrelationFieldNames.AgentType], "created agent correlation");
+AssertEqual("mediaingest.qc", createdFields[CorrelationFieldNames.QueueName], "created queue correlation");
+AssertEqual("correlation-002", createdFields[CorrelationFieldNames.CorrelationId], "created correlation id");
+AssertEqual("command-002", createdFields[CorrelationFieldNames.CausationId], "created causation id");
+AssertEqual("trace-002", createdFields[CorrelationFieldNames.TraceId], "created trace id");
+AssertEqual("span-002", createdFields[CorrelationFieldNames.SpanId], "created span id");
+
+AssertThrows<ArgumentException>(
+    () => ObservabilityCorrelationContext.Create(
+        workflowInstanceId: " ",
+        packageId: "package-002",
+        fileId: "file-source-002",
+        workItemId: "work-item-qc-002",
+        nodeId: "node-qc",
+        agentType: "qc",
+        queueName: "mediaingest.qc",
+        correlationId: "correlation-002",
+        causationId: "command-002",
+        traceId: "trace-002",
+        spanId: "span-002"),
+    "blank workflow correlation");
+
 Console.WriteLine("MediaIngest observability smoke test passed.");
 
 static void AssertSequenceEqual<T>(IReadOnlyList<T> expected, IReadOnlyList<T> actual, string name)
@@ -84,4 +148,32 @@ static void AssertEqual<T>(T expected, T actual, string name)
     {
         throw new InvalidOperationException($"{name}: expected '{expected}', got '{actual}'.");
     }
+}
+
+static void AssertUnique(IReadOnlyList<string> values, string name)
+{
+    var seen = new HashSet<string>(StringComparer.Ordinal);
+
+    foreach (var value in values)
+    {
+        if (!seen.Add(value))
+        {
+            throw new InvalidOperationException($"{name}: duplicate value '{value}'.");
+        }
+    }
+}
+
+static void AssertThrows<TException>(Action action, string name)
+    where TException : Exception
+{
+    try
+    {
+        action();
+    }
+    catch (TException)
+    {
+        return;
+    }
+
+    throw new InvalidOperationException($"{name}: expected {typeof(TException).Name}.");
 }


### PR DESCRIPTION
## Summary

- Adds command-runner diagnostic event names to the shared observability catalog for USER-STORY-11 progress logging.
- Strengthens correlation field/event catalog tests for exact canonical names and duplicate detection.
- Adds validated correlation context creation behavior and full field-map coverage without adding OpenTelemetry packages or runtime exporters.

## Validation

- `make test-dotnet-observability` passed.
- `make validate` passed.
- `git diff --check` passed.

Refs #21
Refs #23
