### PR TITLE
TASK-5-2: Expand nested workflow contracts

### DIFF
--- a/docs/architecture/002-workflow-orchestration.md
+++ b/docs/architecture/002-workflow-orchestration.md
@@ -43,6 +43,12 @@ Child workflows are allowed for meaningful lifecycle chunks:
 Do not make every tiny operation its own workflow. Use child workflows when the
 boundary improves clarity, retry behavior, or UI drilldown.
 
+Prepared child workflow work includes the child workflow name, stable child
+workflow instance ID, and parent workflow instance ID before runtime execution.
+The stable child ID format is `<parent-workflow-instance-id>/<child-node-id>`.
+Graph projections must use these prepared references when they are available so
+operator drilldown matches the identifiers used to start child workflows.
+
 ## Parallelism
 
 Dapr Workflow supports fan-out/fan-in. A package workflow may start multiple

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -49,6 +49,9 @@ epic/story granularity; detailed implementation tasks belong in plans.
 - MILESTONE-8 / USER-STORY-13: add persisted local business timeline and node
   diagnostic log backing for workflow node details, covering package start,
   command dispatch, done-marker reconciliation, success, and failure details.
+- MILESTONE-5 / USER-STORY-10: expand nested workflow behavior contracts so
+  prepared child workflow work has stable child identifiers, parent workflow
+  references, and graph projection from package workflow start state.
 
 ## Ready For Planning
 
@@ -56,8 +59,6 @@ epic/story granularity; detailed implementation tasks belong in plans.
   validation slice beyond static Compose checks.
 - MILESTONE-4 / USER-STORY-6: define Azure Service Bus topic/subscription
   adapters and local development strategy.
-- MILESTONE-5 / USER-STORY-10: expand nested workflow contracts and behavior.
-
 ## Later
 
 - MILESTONE-6 / USER-STORY-7: connect generic command runners to Azure Service

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -123,6 +123,10 @@
   reads stored package start, command dispatch, done-marker reconciliation,
   success, and failure records instead of synthetic package-state text. This
   does not complete production log aggregation or OpenTelemetry trace linkage.
+- TASK-5-2 expanded nested workflow behavior contracts so prepared child work
+  now carries stable child workflow instance IDs and parent workflow references,
+  and workflow graph projection can render queued child workflow nodes directly
+  from a package workflow start.
 
 ## Next
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -164,6 +164,10 @@ messages or paste command output unless it explains a decision.
   batches now carry business timeline and node diagnostic log records, and the
   existing workflow node details API reads stored local ingest messages instead
   of synthetic package-state details.
+- Added TASK-5-2 nested workflow behavior contracts: prepared child workflow
+  work now carries stable child workflow instance IDs plus parent workflow
+  references, and workflow graph projection can render queued child workflow
+  nodes from package workflow start state.
 
 ## Update Rule
 

--- a/src/MediaIngest.Workflow/PackageWorkflowChildWorkPlan.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowChildWorkPlan.cs
@@ -55,4 +55,25 @@ internal static class PackageWorkflowChildWorkPlan
     {
         return FullLifecycle.FirstOrDefault(work => work.NodeId == nodeId);
     }
+
+    public static PreparedChildWork[] PrepareForParent(string parentWorkflowInstanceId)
+    {
+        if (string.IsNullOrWhiteSpace(parentWorkflowInstanceId))
+        {
+            throw new ArgumentException("Parent workflow instance id is required.", nameof(parentWorkflowInstanceId));
+        }
+
+        return FullLifecycle
+            .Select(work => work with
+            {
+                WorkflowInstanceId = CreateChildWorkflowInstanceId(parentWorkflowInstanceId, work.NodeId),
+                ParentWorkflowInstanceId = parentWorkflowInstanceId
+            })
+            .ToArray();
+    }
+
+    private static string CreateChildWorkflowInstanceId(string parentWorkflowInstanceId, string nodeId)
+    {
+        return $"{parentWorkflowInstanceId}/{nodeId}";
+    }
 }

--- a/src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs
@@ -26,6 +26,17 @@ public static class PackageWorkflowGraphProjection
             PackageWorkflowChildWorkPlan.FullLifecycle);
     }
 
+    public static WorkflowGraphDto FromWorkflowStart(PackageWorkflowStart start)
+    {
+        ArgumentNullException.ThrowIfNull(start);
+
+        return CreateGraph(
+            start.PackageId,
+            start.WorkflowInstanceId,
+            WorkflowNodeStatus.Queued,
+            start.PreparedChildWork);
+    }
+
     public static WorkflowGraphDto FromPackageStatus(
         string packageId,
         string workflowInstanceId,
@@ -136,7 +147,9 @@ public static class PackageWorkflowGraphProjection
             WorkflowInstanceId: workflowInstanceId,
             PackageId: packageId,
             WorkItemId: work.NodeId,
-            ChildWorkflowInstanceId: CreateChildWorkflowInstanceId(workflowInstanceId, work.NodeId))));
+            ChildWorkflowInstanceId: string.IsNullOrWhiteSpace(work.WorkflowInstanceId)
+                ? CreateChildWorkflowInstanceId(workflowInstanceId, work.NodeId)
+                : work.WorkflowInstanceId)));
 
         var edges = CreateEdges(workflowPlan);
 

--- a/src/MediaIngest.Workflow/PackageWorkflowStarter.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowStarter.cs
@@ -18,13 +18,15 @@ public sealed class PackageWorkflowStarter
             throw new ArgumentException("Package path is required.", nameof(request));
         }
 
+        var workflowInstanceId = $"package-{request.PackageId}";
+
         return new PackageWorkflowStart(
             PackageId: request.PackageId,
             PackagePath: request.PackagePath,
             WorkflowName: WorkflowContractNames.PackageIngestWorkflow,
-            WorkflowInstanceId: $"package-{request.PackageId}",
+            WorkflowInstanceId: workflowInstanceId,
             CorrelationId: request.CorrelationId,
             AcceptedAt: request.AcceptedAt,
-            PreparedChildWork: PackageWorkflowChildWorkPlan.FullLifecycle);
+            PreparedChildWork: PackageWorkflowChildWorkPlan.PrepareForParent(workflowInstanceId));
     }
 }

--- a/src/MediaIngest.Workflow/PreparedChildWork.cs
+++ b/src/MediaIngest.Workflow/PreparedChildWork.cs
@@ -3,4 +3,6 @@ namespace MediaIngest.Workflow;
 public sealed record PreparedChildWork(
     string NodeId,
     string DisplayName,
-    string WorkflowName);
+    string WorkflowName,
+    string? WorkflowInstanceId = null,
+    string? ParentWorkflowInstanceId = null);

--- a/tests/MediaIngest.Workflow.Tests/Program.cs
+++ b/tests/MediaIngest.Workflow.Tests/Program.cs
@@ -27,6 +27,19 @@ AssertEqual(WorkflowContractNames.EssenceGroupProcessingWorkflow, start.Prepared
 AssertEqual(WorkflowContractNames.ProxyCreationWorkflow, start.PreparedChildWork[3].WorkflowName, "proxy workflow name");
 AssertEqual(WorkflowContractNames.ReconciliationWorkflow, start.PreparedChildWork[4].WorkflowName, "reconciliation workflow name");
 AssertEqual(WorkflowContractNames.FinalizationWorkflow, start.PreparedChildWork[5].WorkflowName, "finalization workflow name");
+AssertAll(
+    start.PreparedChildWork,
+    work => work.ParentWorkflowInstanceId == start.WorkflowInstanceId,
+    "prepared child work carries parent workflow instance id");
+AssertAll(
+    start.PreparedChildWork,
+    work => work.WorkflowInstanceId == $"{start.WorkflowInstanceId}/{work.NodeId}",
+    "prepared child work carries stable child workflow instance id");
+
+var startGraph = PackageWorkflowGraphProjection.FromWorkflowStart(start);
+AssertEqual("package-package-001", startGraph.WorkflowInstanceId, "start graph workflow instance id");
+AssertEqual(WorkflowNodeStatus.Queued, startGraph.Nodes[0].Status, "start graph package status");
+AssertEqual("package-package-001/scan-package", startGraph.Nodes[1].ChildWorkflowInstanceId, "start graph scan child workflow instance id");
 
 var lifecycle = PackageWorkflowLifecycle.Observe(request);
 AssertEqual(PackageWorkflowLifecycleState.Observed, lifecycle.Current.State, "observed lifecycle state");


### PR DESCRIPTION
## Summary
- Materializes prepared child workflow work with stable child workflow instance IDs and parent workflow instance references.
- Adds workflow graph projection from `PackageWorkflowStart` so queued child workflow nodes use the prepared runtime identifiers.
- Documents the nested workflow identifier contract and records TASK-5-2 progress in status/product docs.

## Linked Issues
Closes #97
Refs #19
Refs #20
Refs #6

## Validation
- `make test-dotnet-workflow` - passed
- `make validate` - passed
- `git diff --check` - passed

## TDD Evidence
- RED: `make test-dotnet-workflow` failed with missing `PreparedChildWork.ParentWorkflowInstanceId`, missing `PreparedChildWork.WorkflowInstanceId`, and missing `PackageWorkflowGraphProjection.FromWorkflowStart`.
- GREEN: `make test-dotnet-workflow` passed after adding the prepared child workflow references and start graph projection.

## Risk
- Low. This is an in-process workflow contract/projection slice and does not change persistence schema, command/outbox contracts, Dapr provisioning, or cloud resources.

## Follow-up Notes
- Actual Dapr child workflow runtime execution remains deferred to a later runtime integration slice.
- Production persistence of business workflow state remains separate from Dapr runtime state as documented.