### PR TITLE
TASK-4-4: Define command bus adapter boundary

### DIFF
--- a/deploy/dapr/README.md
+++ b/deploy/dapr/README.md
@@ -59,6 +59,14 @@ destination. Existing outbox application properties, including
 as `metadata.executionClass=heavy`. This keeps the local publisher independent
 of Azure SDKs and Azure resource provisioning.
 
+TASK-4-4 adds a code-level Service Bus command-bus adapter boundary before the
+local publisher. The adapter validates that each `MediaCommandEnvelope` targets
+one of the static command topics, preserves the raw command JSON body, copies
+application properties, and maps `executionClass` to the `light`, `medium`, or
+`heavy` subscription name defined by the topology. Local runs still publish via
+the configured local `IOutboxMessagePublisher`, such as the Dapr sidecar
+publisher above, after that broker mapping succeeds.
+
 All credentials are Kubernetes Secret references. Real secret values,
 kubeconfigs, Azure subscription details, and Terraform state are intentionally
 absent from this repository.

--- a/docs/architecture/003-messaging-and-outbox.md
+++ b/docs/architecture/003-messaging-and-outbox.md
@@ -48,6 +48,23 @@ already computed for the outbox request are forwarded as Dapr metadata query
 parameters, so command metadata such as `executionClass=heavy` reaches the
 broker boundary without the dispatcher making routing decisions.
 
+The Azure Service Bus adapter boundary is represented by the outbox worker's
+command-bus adapter. It maps an `OutboxPublishRequest` for a
+`MediaCommandEnvelope` into a broker-oriented message shape with:
+
+- the semantic Service Bus topic from the outbox destination;
+- the raw JSON command envelope body;
+- application properties copied from the outbox publish request; and
+- the routed subscription name selected from the static `executionClass`
+  topology.
+
+Local development keeps the same dispatcher behavior by validating that
+Service Bus mapping first, then delegating publication to the existing local
+publisher strategy. Today that local strategy is the Dapr sidecar publisher,
+but tests may also use in-memory publishers behind the same
+`IOutboxMessagePublisher` boundary. This keeps command topic and application
+property rules exercised locally without adding an Azure SDK dependency.
+
 This boundary is local runtime plumbing only. It does not provision Azure
 Service Bus topics, create subscriptions, run paid cloud validation, or add Azure
 SDK dependencies.

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -34,6 +34,9 @@ epic/story granularity; detailed implementation tasks belong in plans.
 - MILESTONE-4 / USER-STORY-6 / USER-STORY-8: define static command-bus topology
   readiness for semantic Azure Service Bus command topics and light, medium,
   and heavy subscriptions.
+- MILESTONE-4 / USER-STORY-6 / USER-STORY-8: define the Service Bus
+  command-bus adapter boundary and preserve local Dapr or in-memory publisher
+  behavior through the outbox publisher strategy.
 - MILESTONE-6 / USER-STORY-7: add the first local generic command runner
   foundation for light, medium, and heavy execution classes without Azure
   Service Bus consumption or real media command execution.
@@ -57,8 +60,6 @@ epic/story granularity; detailed implementation tasks belong in plans.
 
 - MILESTONE-2 / USER-STORY-16: plan the next Docker-first local runtime
   validation slice beyond static Compose checks.
-- MILESTONE-4 / USER-STORY-6: define Azure Service Bus topic/subscription
-  adapters and local development strategy.
 ## Later
 
 - MILESTONE-6 / USER-STORY-7: connect generic command runners to Azure Service

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -132,6 +132,11 @@
   now carries stable child workflow instance IDs and parent workflow references,
   and workflow graph projection can render queued child workflow nodes directly
   from a package workflow start.
+- TASK-4-4 defined the Service Bus command-bus adapter boundary in the outbox
+  worker. Command publish requests now map to a broker-oriented message shape
+  with semantic topic, raw command body, application properties, and routed
+  light/medium/heavy subscription name before local Dapr or in-memory publisher
+  delegation.
 
 ## Next
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -5,6 +5,10 @@ messages or paste command output unless it explains a decision.
 
 ## 2026-05-04
 
+- Added TASK-4-4 Service Bus command-bus adapter boundary for outbox command
+  publishes: routed command requests now validate semantic topics and
+  `executionClass` subscription mapping before delegating to the existing local
+  publisher strategy, without Azure SDK dependencies or cloud provisioning.
 - Added the TASK-2-3 Docker-first local runtime smoke slice: `make
   local-runtime-smoke` starts the Compose API, UI, and PostgreSQL stack, waits
   for local API/UI HTTP responses, runs the existing manifest ingest smoke

--- a/src/MediaIngest.Worker.Outbox/CommandBusOutboxMessagePublisher.cs
+++ b/src/MediaIngest.Worker.Outbox/CommandBusOutboxMessagePublisher.cs
@@ -1,0 +1,14 @@
+namespace MediaIngest.Worker.Outbox;
+
+public sealed class CommandBusOutboxMessagePublisher(
+    ServiceBusCommandBusAdapter serviceBusAdapter,
+    IOutboxMessagePublisher localPublisher)
+    : IOutboxMessagePublisher
+{
+    public async Task PublishAsync(OutboxPublishRequest request, CancellationToken cancellationToken = default)
+    {
+        _ = serviceBusAdapter.CreateMessage(request);
+
+        await localPublisher.PublishAsync(request, cancellationToken);
+    }
+}

--- a/src/MediaIngest.Worker.Outbox/ServiceBusCommandBusAdapter.cs
+++ b/src/MediaIngest.Worker.Outbox/ServiceBusCommandBusAdapter.cs
@@ -1,0 +1,64 @@
+using MediaIngest.Contracts.Commands;
+
+namespace MediaIngest.Worker.Outbox;
+
+public sealed record ServiceBusCommandBusMessage(
+    string TopicName,
+    string RoutedSubscriptionName,
+    string BodyJson,
+    IReadOnlyDictionary<string, string> ApplicationProperties);
+
+public sealed class ServiceBusCommandBusAdapter
+{
+    public ServiceBusCommandBusMessage CreateMessage(OutboxPublishRequest request)
+    {
+        if (!string.Equals(request.Message.MessageType, nameof(MediaCommandEnvelope), StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Outbox message '{request.Message.MessageId}' must be a {nameof(MediaCommandEnvelope)} command.");
+        }
+
+        if (!CommandBusTopology.CommandTopics.Contains(request.Message.Destination, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Command outbox message '{request.Message.MessageId}' targets unknown command topic " +
+                $"'{request.Message.Destination}'.");
+        }
+
+        if (!request.ApplicationProperties.TryGetValue(
+                CommandRoute.ExecutionClassPropertyName,
+                out var executionClass))
+        {
+            throw new InvalidOperationException(
+                $"Command outbox message '{request.Message.MessageId}' must include an " +
+                $"{CommandRoute.ExecutionClassPropertyName} application property.");
+        }
+
+        var normalizedExecutionClass = ExecutionClassProperties
+            .FromPropertyValue(executionClass)
+            .ToPropertyValue();
+        var subscription = CommandBusTopology.Subscriptions.SingleOrDefault(candidate =>
+            string.Equals(candidate.FilterPropertyName, CommandRoute.ExecutionClassPropertyName, StringComparison.Ordinal)
+            && string.Equals(candidate.FilterPropertyValue, normalizedExecutionClass, StringComparison.Ordinal));
+
+        if (subscription is null)
+        {
+            throw new InvalidOperationException(
+                $"Command outbox message '{request.Message.MessageId}' execution class " +
+                $"'{normalizedExecutionClass}' does not map to a command-bus subscription.");
+        }
+
+        var applicationProperties = new Dictionary<string, string>(
+            request.ApplicationProperties,
+            StringComparer.Ordinal)
+        {
+            [CommandRoute.ExecutionClassPropertyName] = normalizedExecutionClass
+        };
+
+        return new ServiceBusCommandBusMessage(
+            TopicName: request.Message.Destination,
+            RoutedSubscriptionName: subscription.SubscriptionName,
+            BodyJson: request.Message.PayloadJson,
+            ApplicationProperties: applicationProperties);
+    }
+}

--- a/tests/MediaIngest.Worker.Outbox.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.Outbox.Tests/Program.cs
@@ -17,6 +17,8 @@ await DaprPublisherPublishesPayloadToTheDestinationTopic();
 await DaprPublisherRequestsRawPayloadToPreserveBrokerMessageBody();
 await DaprPublisherMapsApplicationPropertiesToDaprMetadata();
 await DaprPublisherSurfacesNonSuccessResponses();
+await ServiceBusAdapterMapsCommandRequestsToBrokerTopology();
+await CommandBusPublisherValidatesServiceBusMappingThenUsesLocalPublisher();
 
 Console.WriteLine("MediaIngest outbox dispatcher smoke tests passed.");
 
@@ -392,6 +394,60 @@ static async Task DaprPublisherSurfacesNonSuccessResponses()
     }
 
     AssertTrue(failed, "dapr non-success response is surfaced");
+}
+
+static Task ServiceBusAdapterMapsCommandRequestsToBrokerTopology()
+{
+    var request = new OutboxPublishRequest(
+        CreateMessage(
+            messageId: "message-servicebus-heavy",
+            destination: CommandNames.ArchiveAsset,
+            messageType: "MediaCommandEnvelope",
+            createdAt: new DateTimeOffset(2026, 5, 4, 9, 0, 0, TimeSpan.Zero),
+            payloadJson: """{"commandId":"command-heavy","executionClass":"heavy"}"""),
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [CommandRoute.ExecutionClassPropertyName] = "heavy"
+        });
+
+    var adapter = new ServiceBusCommandBusAdapter();
+    var brokerMessage = adapter.CreateMessage(request);
+
+    AssertEqual(CommandNames.ArchiveAsset, brokerMessage.TopicName, "service bus topic");
+    AssertEqual(CommandBusTopology.HeavySubscriptionName, brokerMessage.RoutedSubscriptionName, "service bus subscription");
+    AssertEqual(
+        """{"commandId":"command-heavy","executionClass":"heavy"}""",
+        brokerMessage.BodyJson,
+        "service bus message body");
+    AssertEqual(
+        "heavy",
+        brokerMessage.ApplicationProperties[CommandRoute.ExecutionClassPropertyName],
+        "service bus executionClass application property");
+
+    return Task.CompletedTask;
+}
+
+static async Task CommandBusPublisherValidatesServiceBusMappingThenUsesLocalPublisher()
+{
+    var localPublisher = new RecordingOutboxPublisher();
+    var publisher = new CommandBusOutboxMessagePublisher(new ServiceBusCommandBusAdapter(), localPublisher);
+    var request = new OutboxPublishRequest(
+        CreateMessage(
+            messageId: "message-local-strategy",
+            destination: CommandNames.CreateProxy,
+            messageType: "MediaCommandEnvelope",
+            createdAt: new DateTimeOffset(2026, 5, 4, 9, 5, 0, TimeSpan.Zero),
+            payloadJson: """{"commandId":"command-local","executionClass":"light"}"""),
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [CommandRoute.ExecutionClassPropertyName] = "light"
+        });
+
+    await publisher.PublishAsync(request);
+
+    AssertEqual(1, localPublisher.Published.Count, "local fallback publish count");
+    AssertEqual("message-local-strategy", localPublisher.Published[0].Message.MessageId, "local fallback message id");
+    AssertEqual("light", localPublisher.Published[0].ApplicationProperties[CommandRoute.ExecutionClassPropertyName], "local fallback executionClass");
 }
 
 static OutboxMessage CreateMessage(


### PR DESCRIPTION
## Summary
- Adds a Service Bus command-bus adapter boundary in the outbox worker that maps routed `MediaCommandEnvelope` publish requests to broker-oriented topic, raw body, application properties, and light/medium/heavy subscription data.
- Adds a local command-bus publisher strategy that validates the Service Bus mapping before delegating to the configured local `IOutboxMessagePublisher`.
- Updates messaging/outbox and Dapr docs plus status/backlog/work-log notes for TASK-4-4.

## Linked Issues
Closes #96
Refs #16
Refs #18

## Validation
- `make test-dotnet-outbox` passed: outbox dispatcher smoke tests passed.
- RED evidence: `make test-dotnet-outbox` failed before implementation with missing `ServiceBusCommandBusAdapter` and `CommandBusOutboxMessagePublisher` types.
- `make validate` passed: documentation checks, GitHub Projects helper tests, .NET build, and smoke tests passed.
- `git diff --check` passed.

## Risk
- No Azure resources, secrets, paid cloud actions, Azure SDK dependencies, or provisioning are introduced.
- The adapter validates broker topology mapping but does not consume from or publish directly to Azure Service Bus yet.

## Follow-up Notes
- Azure Service Bus SDK integration and runner subscription consumption remain deferred to a later runtime slice.
