### PR TITLE
USER-STORY-16: Add Azure-shaped runner consumption

### DIFF
--- a/docs/architecture/003-messaging-and-outbox.md
+++ b/docs/architecture/003-messaging-and-outbox.md
@@ -69,6 +69,19 @@ This boundary is local runtime plumbing only. It does not provision Azure
 Service Bus topics, create subscriptions, run paid cloud validation, or add Azure
 SDK dependencies.
 
+On the runner side, command consumption is represented by a local Azure-shaped
+consumer boundary before live Azure SDK receiving exists. The command-runner
+consumer accepts a broker-shaped message containing the semantic topic,
+subscription name, raw command body, message id, and application properties. It
+validates that topic and `executionClass` metadata match the static
+`CommandBusTopology`, verifies the `MediaCommandEnvelope` shape and route match
+the broker metadata, and maps runner outcomes to complete, abandon, or
+dead-letter decisions that a future Service Bus host can apply.
+
+This keeps runner consumption semantics covered locally without provisioning
+Azure Service Bus, handling secrets, adding Azure SDK dependencies, or running
+paid cloud validation.
+
 ## Responsibility Split
 
 - Domain/application logic decides which command should be sent and which

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -281,8 +281,9 @@ Acceptance themes:
 - Runners can emit downstream work when allowed by workflow design.
 - Current foundation is local only: runners accept command envelopes by
   configured execution class, record in-memory progress with canonical
-  correlation fields, and keep execution behind a stub abstraction.
-- Azure Service Bus consumption, Kubernetes scaling, downstream command
+  correlation fields, keep execution behind a stub abstraction, and consume
+  Azure-shaped command-bus messages through a local broker-neutral boundary.
+- Live Azure Service Bus SDK receiving, Kubernetes scaling, downstream command
   emission, and real media command execution are deferred.
 
 Dependencies:

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -112,6 +112,13 @@
   duplicate `CommandId` handling, and records in-memory business progress with
   canonical correlation fields. Azure Service Bus consumption, Kubernetes
   scaling, and real media command execution remain deferred.
+- USER-STORY-7 and USER-STORY-16 now have a local Azure-shaped command-runner
+  consumption boundary. Broker-shaped command messages are validated against
+  semantic topic and execution-class subscription metadata, deserialized into
+  `MediaCommandEnvelope` values, checked for required envelope shape and route,
+  handled by the generic runner, and mapped to complete, abandon, or
+  dead-letter decisions without Azure SDK dependencies, secrets, or cloud
+  validation.
 - TASK-8-2 added multi-package workflow selection in the React control plane,
   preserving node detail during same-workflow refreshes and clearing detail when
   the operator switches workflows.
@@ -140,7 +147,7 @@
 
 ## Next
 
-- Plan the next runtime slice: Azure Service Bus runner consumption, richer
+- Plan the next runtime slice: live Azure Service Bus SDK receiving, richer
   node log/timeline data sources, or deeper local container runtime validation.
 
 ## Update Rule

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -3,6 +3,15 @@
 Use this log for concise human-readable progress notes. Do not duplicate commit
 messages or paste command output unless it explains a decision.
 
+## 2026-05-06
+
+- Added a local Azure-shaped command-runner consumption boundary for
+  USER-STORY-7 and USER-STORY-16: broker-shaped command messages now validate
+  semantic topic, subscription, `executionClass`, and required envelope-shape
+  metadata before reaching the generic runner, then map handling outcomes to
+  complete, abandon, or dead-letter decisions without Azure SDK dependencies or
+  cloud validation.
+
 ## 2026-05-04
 
 - Added TASK-4-4 Service Bus command-bus adapter boundary for outbox command

--- a/src/MediaIngest.Worker.CommandRunner/CommandBusMessageConsumer.cs
+++ b/src/MediaIngest.Worker.CommandRunner/CommandBusMessageConsumer.cs
@@ -1,0 +1,342 @@
+using System.Text.Json;
+using MediaIngest.Contracts.Commands;
+using MediaIngest.Observability;
+
+namespace MediaIngest.Worker.CommandRunner;
+
+public sealed class CommandBusMessageConsumer
+{
+    private readonly GenericCommandRunner runner;
+
+    public CommandBusMessageConsumer(GenericCommandRunner runner)
+    {
+        this.runner = runner ?? throw new ArgumentNullException(nameof(runner));
+    }
+
+    public async Task<CommandBusMessageHandlingResult> HandleAsync(
+        CommandBusReceivedMessage message,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        string? commandId = null;
+        try
+        {
+            var routeValidation = ValidateBrokerRoute(message);
+            if (routeValidation is not null)
+            {
+                return routeValidation;
+            }
+
+            var envelopeResult = DeserializeEnvelope(message);
+            if (envelopeResult.Result is not null)
+            {
+                return envelopeResult.Result;
+            }
+
+            var envelope = envelopeResult.Envelope;
+            if (envelope is null)
+            {
+                return CommandBusMessageHandlingResult.DeadLetter(
+                    message.MessageId,
+                    null,
+                    "Command message body is empty.");
+            }
+
+            var envelopeShapeValidation = ValidateEnvelopeShape(
+                message,
+                envelope,
+                envelopeResult.HasExecutionClassProperty);
+            if (envelopeShapeValidation is not null)
+            {
+                return envelopeShapeValidation;
+            }
+
+            commandId = envelope.CommandId;
+
+            var envelopeValidation = ValidateEnvelopeRoute(message, envelope);
+            if (envelopeValidation is not null)
+            {
+                return envelopeValidation;
+            }
+
+            var correlation = CreateCorrelation(message, envelope);
+            var handling = await runner.HandleAsync(envelope, correlation, cancellationToken).ConfigureAwait(false);
+            var reason = handling.Message ?? $"Command handling finished with {handling.Status}.";
+            return handling.Status switch
+            {
+                CommandHandlingStatus.Succeeded => CommandBusMessageHandlingResult.Complete(
+                    message.MessageId,
+                    envelope.CommandId,
+                    reason),
+                CommandHandlingStatus.Duplicate => CommandBusMessageHandlingResult.Complete(
+                    message.MessageId,
+                    envelope.CommandId,
+                    reason),
+                CommandHandlingStatus.Failed => CommandBusMessageHandlingResult.Abandon(
+                    message.MessageId,
+                    envelope.CommandId,
+                    reason),
+                CommandHandlingStatus.RejectedExecutionClass => CommandBusMessageHandlingResult.DeadLetter(
+                    message.MessageId,
+                    envelope.CommandId,
+                    reason),
+                _ => CommandBusMessageHandlingResult.Abandon(
+                    message.MessageId,
+                    envelope.CommandId,
+                    $"Unhandled command status {handling.Status}.")
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return CommandBusMessageHandlingResult.Abandon(message.MessageId, commandId, ex.Message);
+        }
+    }
+
+    private static CommandBusMessageHandlingResult? ValidateBrokerRoute(CommandBusReceivedMessage message)
+    {
+        if (string.IsNullOrWhiteSpace(message.MessageId))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(string.Empty, null, "MessageId is required.");
+        }
+
+        if (!CommandBusTopology.CommandTopics.Contains(message.TopicName, StringComparer.Ordinal))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                null,
+                $"Unknown command topic '{message.TopicName}'.");
+        }
+
+        var subscription = CommandBusTopology.Subscriptions.SingleOrDefault(candidate =>
+            string.Equals(candidate.SubscriptionName, message.SubscriptionName, StringComparison.Ordinal));
+        if (subscription is null)
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                null,
+                $"Unknown command subscription '{message.SubscriptionName}'.");
+        }
+
+        if (!message.ApplicationProperties.TryGetValue(
+                CommandRoute.ExecutionClassPropertyName,
+                out var executionClassProperty))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                null,
+                $"Missing {CommandRoute.ExecutionClassPropertyName} application property.");
+        }
+
+        ExecutionClass executionClass;
+        try
+        {
+            executionClass = ExecutionClassProperties.FromPropertyValue(executionClassProperty);
+        }
+        catch (ArgumentException ex)
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(message.MessageId, null, ex.Message);
+        }
+
+        var normalizedExecutionClass = executionClass.ToPropertyValue();
+        if (!string.Equals(subscription.FilterPropertyValue, normalizedExecutionClass, StringComparison.Ordinal))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                null,
+                $"Subscription '{message.SubscriptionName}' does not match execution class '{normalizedExecutionClass}'.");
+        }
+
+        return null;
+    }
+
+    private static EnvelopeReadResult DeserializeEnvelope(CommandBusReceivedMessage message)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(message.BodyJson);
+            var hasExecutionClassProperty = HasProperty(
+                document.RootElement,
+                nameof(MediaCommandEnvelope.ExecutionClass));
+            var envelope = document.RootElement.Deserialize<MediaCommandEnvelope>();
+            return envelope is null
+                ? new EnvelopeReadResult(
+                    null,
+                    hasExecutionClassProperty,
+                    CommandBusMessageHandlingResult.DeadLetter(
+                        message.MessageId,
+                        null,
+                        "Command message body is empty."))
+                : new EnvelopeReadResult(envelope, hasExecutionClassProperty, null);
+        }
+        catch (JsonException ex)
+        {
+            return new EnvelopeReadResult(
+                null,
+                HasExecutionClassProperty: false,
+                CommandBusMessageHandlingResult.DeadLetter(
+                    message.MessageId,
+                    null,
+                    $"Command message body is not valid JSON: {ex.Message}"));
+        }
+    }
+
+    private static CommandBusMessageHandlingResult? ValidateEnvelopeShape(
+        CommandBusReceivedMessage message,
+        MediaCommandEnvelope envelope,
+        bool hasExecutionClassProperty)
+    {
+        if (string.IsNullOrWhiteSpace(envelope.CommandId))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                "Envelope CommandId is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(envelope.CommandName))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                "Envelope CommandName is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(envelope.TopicName))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                "Envelope TopicName is required.");
+        }
+
+        if (!hasExecutionClassProperty)
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                "Envelope ExecutionClass is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(envelope.CommandLine))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                "Envelope CommandLine is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(envelope.WorkingDirectory))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                "Envelope WorkingDirectory is required.");
+        }
+
+        if (envelope.InputPaths is null)
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                "Envelope InputPaths is required.");
+        }
+
+        if (envelope.OutputPaths is null)
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                "Envelope OutputPaths is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(envelope.CorrelationId))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                "Envelope CorrelationId is required.");
+        }
+
+        return null;
+    }
+
+    private CommandBusMessageHandlingResult? ValidateEnvelopeRoute(
+        CommandBusReceivedMessage message,
+        MediaCommandEnvelope envelope)
+    {
+        if (!string.Equals(envelope.TopicName, message.TopicName, StringComparison.Ordinal))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                $"Envelope topic '{envelope.TopicName}' does not match broker topic '{message.TopicName}'.");
+        }
+
+        if (!string.Equals(envelope.CommandName, envelope.TopicName, StringComparison.Ordinal))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                $"Envelope command name '{envelope.CommandName}' does not match envelope topic '{envelope.TopicName}'.");
+        }
+
+        var envelopeExecutionClass = envelope.ExecutionClass.ToPropertyValue();
+        var propertyExecutionClass = ExecutionClassProperties
+            .FromPropertyValue(message.ApplicationProperties[CommandRoute.ExecutionClassPropertyName])
+            .ToPropertyValue();
+        if (!string.Equals(envelopeExecutionClass, propertyExecutionClass, StringComparison.Ordinal))
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                $"Envelope execution class '{envelopeExecutionClass}' does not match broker execution class '{propertyExecutionClass}'.");
+        }
+
+        if (envelope.ExecutionClass != runner.ConfiguredExecutionClass)
+        {
+            return CommandBusMessageHandlingResult.DeadLetter(
+                message.MessageId,
+                envelope.CommandId,
+                $"Runner configured for {runner.ConfiguredExecutionClass.ToPropertyValue()} cannot consume {envelopeExecutionClass} subscription messages.");
+        }
+
+        return null;
+    }
+
+    private static ObservabilityCorrelationContext CreateCorrelation(
+        CommandBusReceivedMessage message,
+        MediaCommandEnvelope envelope)
+    {
+        var executionClass = envelope.ExecutionClass.ToPropertyValue();
+        return new ObservabilityCorrelationContext(
+            WorkflowInstanceId: envelope.CorrelationId,
+            PackageId: envelope.WorkingDirectory,
+            FileId: envelope.InputPaths.FirstOrDefault() ?? envelope.CommandId,
+            WorkItemId: envelope.CommandId,
+            NodeId: envelope.CommandName,
+            AgentType: $"command-runner-{executionClass}",
+            QueueName: $"{message.TopicName}/{message.SubscriptionName}",
+            CorrelationId: envelope.CorrelationId,
+            CausationId: message.MessageId,
+            TraceId: envelope.CorrelationId,
+            SpanId: envelope.CommandId);
+    }
+
+    private static bool HasProperty(JsonElement element, string propertyName)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        return element
+            .EnumerateObject()
+            .Any(property => string.Equals(property.Name, propertyName, StringComparison.Ordinal));
+    }
+
+    private sealed record EnvelopeReadResult(
+        MediaCommandEnvelope? Envelope,
+        bool HasExecutionClassProperty,
+        CommandBusMessageHandlingResult? Result);
+}

--- a/src/MediaIngest.Worker.CommandRunner/CommandBusMessageDisposition.cs
+++ b/src/MediaIngest.Worker.CommandRunner/CommandBusMessageDisposition.cs
@@ -1,0 +1,8 @@
+namespace MediaIngest.Worker.CommandRunner;
+
+public enum CommandBusMessageDisposition
+{
+    Complete,
+    Abandon,
+    DeadLetter
+}

--- a/src/MediaIngest.Worker.CommandRunner/CommandBusMessageHandlingResult.cs
+++ b/src/MediaIngest.Worker.CommandRunner/CommandBusMessageHandlingResult.cs
@@ -1,0 +1,35 @@
+namespace MediaIngest.Worker.CommandRunner;
+
+public sealed record CommandBusMessageHandlingResult(
+    CommandBusMessageDisposition Disposition,
+    string MessageId,
+    string? CommandId,
+    string Reason)
+{
+    public static CommandBusMessageHandlingResult Complete(string messageId, string commandId, string reason)
+    {
+        return new CommandBusMessageHandlingResult(
+            CommandBusMessageDisposition.Complete,
+            messageId,
+            commandId,
+            reason);
+    }
+
+    public static CommandBusMessageHandlingResult Abandon(string messageId, string? commandId, string reason)
+    {
+        return new CommandBusMessageHandlingResult(
+            CommandBusMessageDisposition.Abandon,
+            messageId,
+            commandId,
+            reason);
+    }
+
+    public static CommandBusMessageHandlingResult DeadLetter(string messageId, string? commandId, string reason)
+    {
+        return new CommandBusMessageHandlingResult(
+            CommandBusMessageDisposition.DeadLetter,
+            messageId,
+            commandId,
+            reason);
+    }
+}

--- a/src/MediaIngest.Worker.CommandRunner/CommandBusReceivedMessage.cs
+++ b/src/MediaIngest.Worker.CommandRunner/CommandBusReceivedMessage.cs
@@ -1,0 +1,8 @@
+namespace MediaIngest.Worker.CommandRunner;
+
+public sealed record CommandBusReceivedMessage(
+    string MessageId,
+    string TopicName,
+    string SubscriptionName,
+    string BodyJson,
+    IReadOnlyDictionary<string, string> ApplicationProperties);

--- a/tests/MediaIngest.Worker.CommandRunner.Tests/Program.cs
+++ b/tests/MediaIngest.Worker.CommandRunner.Tests/Program.cs
@@ -160,7 +160,348 @@ finally
     processWorkDirectory.Delete(recursive: true);
 }
 
+await CommandBusConsumerCompletesValidMessagesForAllExecutionClasses();
+await CommandBusConsumerCompletesDuplicateMessagesWithoutReexecution();
+await CommandBusConsumerAbandonsRunnerExecutionFailures();
+await CommandBusConsumerDeadLettersInvalidJson();
+await CommandBusConsumerDeadLettersMissingExecutionClass();
+await CommandBusConsumerDeadLettersUnknownTopic();
+await CommandBusConsumerDeadLettersUnknownSubscription();
+await CommandBusConsumerDeadLettersSubscriptionExecutionClassMismatch();
+await CommandBusConsumerDeadLettersEnvelopeRouteMismatch();
+await CommandBusConsumerDeadLettersEnvelopeCommandNameTopicMismatch();
+await CommandBusConsumerDeadLettersBrokerEnvelopeExecutionClassMismatch();
+await CommandBusConsumerDeadLettersRunnerClassMismatch();
+await CommandBusConsumerDeadLettersMissingEnvelopeExecutionClass();
+await CommandBusConsumerDeadLettersMisCasedEnvelopeExecutionClass();
+await CommandBusConsumerDeadLettersMissingEnvelopeCommandId();
+await CommandBusConsumerDeadLettersBlankEnvelopeCommandId();
+await CommandBusConsumerAbandonsUnexpectedBoundaryExceptions();
+
 Console.WriteLine("MediaIngest command runner tests passed.");
+
+static async Task CommandBusConsumerCompletesValidMessagesForAllExecutionClasses()
+{
+    foreach (var executionClass in new[] { ExecutionClass.Light, ExecutionClass.Medium, ExecutionClass.Heavy })
+    {
+        var executor = new RecordingCommandExecutor();
+        var progress = new InMemoryCommandProgressSink();
+        var runner = new GenericCommandRunner(executionClass, executor, progress);
+        var consumer = new CommandBusMessageConsumer(runner);
+        var envelope = CreateEnvelope(executionClass, $"consumer-valid-{executionClass.ToPropertyValue()}");
+
+        CommandBusMessageHandlingResult result = await consumer.HandleAsync(CreateReceivedMessage(envelope));
+
+        AssertEqual(CommandBusMessageDisposition.Complete, result.Disposition, $"{executionClass} consumer disposition");
+        AssertEqual(envelope.CommandId, result.CommandId, $"{executionClass} consumer command id");
+        AssertEqual(1, executor.ExecutionCount, $"{executionClass} consumer executes command");
+        AssertEqual(CommandProgressStatus.Succeeded, progress.Records.Last().Status, $"{executionClass} consumer progress");
+    }
+}
+
+static async Task CommandBusConsumerCompletesDuplicateMessagesWithoutReexecution()
+{
+    var executor = new RecordingCommandExecutor();
+    var progress = new InMemoryCommandProgressSink();
+    var runner = new GenericCommandRunner(ExecutionClass.Medium, executor, progress);
+    var consumer = new CommandBusMessageConsumer(runner);
+    var envelope = CreateEnvelope(ExecutionClass.Medium, "consumer-duplicate");
+    var message = CreateReceivedMessage(envelope);
+
+    CommandBusMessageHandlingResult first = await consumer.HandleAsync(message);
+    CommandBusMessageHandlingResult second = await consumer.HandleAsync(message);
+
+    AssertEqual(CommandBusMessageDisposition.Complete, first.Disposition, "first duplicate consumer disposition");
+    AssertEqual(CommandBusMessageDisposition.Complete, second.Disposition, "second duplicate consumer disposition");
+    AssertEqual(1, executor.ExecutionCount, "duplicate consumer executes once");
+    AssertEqual(CommandProgressStatus.DuplicateSkipped, progress.Records.Last().Status, "duplicate consumer progress");
+}
+
+static async Task CommandBusConsumerAbandonsRunnerExecutionFailures()
+{
+    var executor = new RecordingCommandExecutor { NextResult = CommandExecutionResult.Failed("exit-code-1") };
+    var runner = new GenericCommandRunner(ExecutionClass.Heavy, executor, new InMemoryCommandProgressSink());
+    var consumer = new CommandBusMessageConsumer(runner);
+    var envelope = CreateEnvelope(ExecutionClass.Heavy, "consumer-failed");
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(CreateReceivedMessage(envelope));
+
+    AssertEqual(CommandBusMessageDisposition.Abandon, result.Disposition, "failed consumer disposition");
+    AssertEqual(envelope.CommandId, result.CommandId, "failed consumer command id");
+    AssertEqual("exit-code-1", result.Reason, "failed consumer reason");
+}
+
+static async Task CommandBusConsumerDeadLettersInvalidJson()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(new CommandBusReceivedMessage(
+        MessageId: "message-invalid-json",
+        TopicName: CommandNames.CreateProxy,
+        SubscriptionName: CommandBusTopology.LightSubscriptionName,
+        BodyJson: "{not-json",
+        ApplicationProperties: new Dictionary<string, string>
+        {
+            [CommandRoute.ExecutionClassPropertyName] = ExecutionClass.Light.ToPropertyValue()
+        }));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "invalid json disposition");
+    AssertEqual(0, executor.ExecutionCount, "invalid json does not execute command");
+}
+
+static async Task CommandBusConsumerDeadLettersMissingExecutionClass()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Light, "consumer-missing-execution-class");
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(CreateReceivedMessage(
+        envelope,
+        applicationProperties: new Dictionary<string, string>()));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "missing execution class disposition");
+    AssertEqual(0, executor.ExecutionCount, "missing execution class does not execute command");
+}
+
+static async Task CommandBusConsumerDeadLettersUnknownTopic()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Light, "consumer-unknown-topic") with
+    {
+        TopicName = "media.command.unknown"
+    };
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(CreateReceivedMessage(envelope));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "unknown topic disposition");
+    AssertEqual(0, executor.ExecutionCount, "unknown topic does not execute command");
+}
+
+static async Task CommandBusConsumerDeadLettersUnknownSubscription()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Light, "consumer-unknown-subscription");
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(CreateReceivedMessage(
+        envelope,
+        subscriptionName: "unknown-subscription"));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "unknown subscription disposition");
+    AssertEqual(0, executor.ExecutionCount, "unknown subscription does not execute command");
+}
+
+static async Task CommandBusConsumerDeadLettersSubscriptionExecutionClassMismatch()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Light, "consumer-subscription-mismatch");
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(CreateReceivedMessage(
+        envelope,
+        subscriptionName: CommandBusTopology.HeavySubscriptionName));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "subscription mismatch disposition");
+    AssertEqual(0, executor.ExecutionCount, "subscription mismatch does not execute command");
+}
+
+static async Task CommandBusConsumerDeadLettersEnvelopeRouteMismatch()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Light, "consumer-envelope-mismatch") with
+    {
+        TopicName = CommandNames.ArchiveAsset
+    };
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(CreateReceivedMessage(
+        envelope,
+        topicName: CommandNames.CreateProxy));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "envelope route mismatch disposition");
+    AssertEqual(0, executor.ExecutionCount, "envelope route mismatch does not execute command");
+}
+
+static async Task CommandBusConsumerDeadLettersEnvelopeCommandNameTopicMismatch()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Light, "consumer-envelope-command-topic-mismatch") with
+    {
+        CommandName = CommandNames.ArchiveAsset,
+        TopicName = CommandNames.CreateProxy
+    };
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(CreateReceivedMessage(
+        envelope,
+        topicName: CommandNames.CreateProxy));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "envelope command route mismatch disposition");
+    AssertEqual(0, executor.ExecutionCount, "envelope command route mismatch does not execute command");
+}
+
+static async Task CommandBusConsumerDeadLettersBrokerEnvelopeExecutionClassMismatch()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Light, "consumer-broker-envelope-class-mismatch");
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(CreateReceivedMessage(
+        envelope,
+        subscriptionName: CommandBusTopology.HeavySubscriptionName,
+        applicationProperties: new Dictionary<string, string>
+        {
+            [CommandRoute.ExecutionClassPropertyName] = ExecutionClass.Heavy.ToPropertyValue()
+        }));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "broker envelope class mismatch disposition");
+    AssertEqual(0, executor.ExecutionCount, "broker envelope class mismatch does not execute command");
+}
+
+static async Task CommandBusConsumerDeadLettersRunnerClassMismatch()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Heavy, "consumer-runner-class-mismatch");
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(CreateReceivedMessage(envelope));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "runner class mismatch disposition");
+    AssertEqual(0, executor.ExecutionCount, "runner class mismatch does not execute command");
+}
+
+static async Task CommandBusConsumerDeadLettersMissingEnvelopeExecutionClass()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Light, "consumer-missing-envelope-execution-class");
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(new CommandBusReceivedMessage(
+        MessageId: $"message-{envelope.CommandId}",
+        TopicName: envelope.TopicName,
+        SubscriptionName: envelope.ExecutionClass.ToPropertyValue(),
+        BodyJson: CreateEnvelopeJsonWithoutExecutionClass(envelope),
+        ApplicationProperties: new Dictionary<string, string>
+        {
+            [CommandRoute.ExecutionClassPropertyName] = envelope.ExecutionClass.ToPropertyValue()
+        }));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "missing envelope execution class disposition");
+    AssertEqual(0, executor.ExecutionCount, "missing envelope execution class does not execute command");
+}
+
+static async Task CommandBusConsumerDeadLettersMisCasedEnvelopeExecutionClass()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Light, "consumer-miscased-envelope-execution-class");
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(new CommandBusReceivedMessage(
+        MessageId: $"message-{envelope.CommandId}",
+        TopicName: envelope.TopicName,
+        SubscriptionName: envelope.ExecutionClass.ToPropertyValue(),
+        BodyJson: CreateEnvelopeJsonWithMisCasedExecutionClass(envelope),
+        ApplicationProperties: new Dictionary<string, string>
+        {
+            [CommandRoute.ExecutionClassPropertyName] = envelope.ExecutionClass.ToPropertyValue()
+        }));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "miscased envelope execution class disposition");
+    AssertEqual(0, executor.ExecutionCount, "miscased envelope execution class does not execute command");
+}
+
+static async Task CommandBusConsumerDeadLettersMissingEnvelopeCommandId()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Light, "consumer-missing-envelope-command-id");
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(new CommandBusReceivedMessage(
+        MessageId: $"message-{envelope.CommandId}",
+        TopicName: envelope.TopicName,
+        SubscriptionName: envelope.ExecutionClass.ToPropertyValue(),
+        BodyJson: CreateEnvelopeJsonWithoutCommandId(envelope),
+        ApplicationProperties: new Dictionary<string, string>
+        {
+            [CommandRoute.ExecutionClassPropertyName] = envelope.ExecutionClass.ToPropertyValue()
+        }));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "missing envelope command id disposition");
+    AssertEqual(0, executor.ExecutionCount, "missing envelope command id does not execute command");
+}
+
+static async Task CommandBusConsumerDeadLettersBlankEnvelopeCommandId()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Light, string.Empty);
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(CreateReceivedMessage(envelope));
+
+    AssertEqual(CommandBusMessageDisposition.DeadLetter, result.Disposition, "blank envelope command id disposition");
+    AssertEqual(0, executor.ExecutionCount, "blank envelope command id does not execute command");
+}
+
+static async Task CommandBusConsumerAbandonsUnexpectedBoundaryExceptions()
+{
+    var executor = new RecordingCommandExecutor();
+    var consumer = new CommandBusMessageConsumer(new GenericCommandRunner(
+        ExecutionClass.Light,
+        executor,
+        new InMemoryCommandProgressSink()));
+    var envelope = CreateEnvelope(ExecutionClass.Light, "consumer-boundary-exception");
+
+    CommandBusMessageHandlingResult result = await consumer.HandleAsync(new CommandBusReceivedMessage(
+        MessageId: $"message-{envelope.CommandId}",
+        TopicName: envelope.TopicName,
+        SubscriptionName: envelope.ExecutionClass.ToPropertyValue(),
+        BodyJson: System.Text.Json.JsonSerializer.Serialize(envelope),
+        ApplicationProperties: null!));
+
+    AssertEqual(CommandBusMessageDisposition.Abandon, result.Disposition, "boundary exception disposition");
+    AssertEqual(0, executor.ExecutionCount, "boundary exception does not execute command");
+}
 
 static MediaCommandEnvelope CreateEnvelope(ExecutionClass executionClass, string commandId)
 {
@@ -174,6 +515,72 @@ static MediaCommandEnvelope CreateEnvelope(ExecutionClass executionClass, string
         InputPaths: ["/mnt/ingest/package-001/source.mov"],
         OutputPaths: ["/mnt/work/package-001/proxy.mp4"],
         CorrelationId: $"correlation-{commandId}");
+}
+
+static string CreateEnvelopeJsonWithoutExecutionClass(MediaCommandEnvelope envelope)
+{
+    return $$"""
+        {
+          "CommandId": "{{envelope.CommandId}}",
+          "CommandName": "{{envelope.CommandName}}",
+          "TopicName": "{{envelope.TopicName}}",
+          "CommandLine": "{{envelope.CommandLine}}",
+          "WorkingDirectory": "{{envelope.WorkingDirectory}}",
+          "InputPaths": ["{{envelope.InputPaths.Single()}}"],
+          "OutputPaths": ["{{envelope.OutputPaths.Single()}}"],
+          "CorrelationId": "{{envelope.CorrelationId}}"
+        }
+        """;
+}
+
+static string CreateEnvelopeJsonWithMisCasedExecutionClass(MediaCommandEnvelope envelope)
+{
+    return $$"""
+        {
+          "CommandId": "{{envelope.CommandId}}",
+          "CommandName": "{{envelope.CommandName}}",
+          "TopicName": "{{envelope.TopicName}}",
+          "executionClass": "{{envelope.ExecutionClass.ToPropertyValue()}}",
+          "CommandLine": "{{envelope.CommandLine}}",
+          "WorkingDirectory": "{{envelope.WorkingDirectory}}",
+          "InputPaths": ["{{envelope.InputPaths.Single()}}"],
+          "OutputPaths": ["{{envelope.OutputPaths.Single()}}"],
+          "CorrelationId": "{{envelope.CorrelationId}}"
+        }
+        """;
+}
+
+static string CreateEnvelopeJsonWithoutCommandId(MediaCommandEnvelope envelope)
+{
+    return $$"""
+        {
+          "CommandName": "{{envelope.CommandName}}",
+          "TopicName": "{{envelope.TopicName}}",
+          "ExecutionClass": "{{envelope.ExecutionClass.ToPropertyValue()}}",
+          "CommandLine": "{{envelope.CommandLine}}",
+          "WorkingDirectory": "{{envelope.WorkingDirectory}}",
+          "InputPaths": ["{{envelope.InputPaths.Single()}}"],
+          "OutputPaths": ["{{envelope.OutputPaths.Single()}}"],
+          "CorrelationId": "{{envelope.CorrelationId}}"
+        }
+        """;
+}
+
+static CommandBusReceivedMessage CreateReceivedMessage(
+    MediaCommandEnvelope envelope,
+    string? topicName = null,
+    string? subscriptionName = null,
+    IReadOnlyDictionary<string, string>? applicationProperties = null)
+{
+    return new CommandBusReceivedMessage(
+        MessageId: $"message-{envelope.CommandId}",
+        TopicName: topicName ?? envelope.TopicName,
+        SubscriptionName: subscriptionName ?? envelope.ExecutionClass.ToPropertyValue(),
+        BodyJson: System.Text.Json.JsonSerializer.Serialize(envelope),
+        ApplicationProperties: applicationProperties ?? new Dictionary<string, string>
+        {
+            [CommandRoute.ExecutionClassPropertyName] = envelope.ExecutionClass.ToPropertyValue()
+        });
 }
 
 static ObservabilityCorrelationContext CreateCorrelation(MediaCommandEnvelope envelope)


### PR DESCRIPTION
## Summary

- Adds a local Azure-shaped command-bus consumer boundary for command runners without Azure SDK dependencies.
- Validates broker topic, subscription, execution class, command envelope shape, and route before invoking the generic runner.
- Maps runner outcomes to complete, abandon, or dead-letter decisions and documents the local-only boundary.

Refs #26

## Validation

- `make test-dotnet-command-runner`
- `make validate`
- `git diff --check`

## Notes

- No Azure resources, secrets, cloud validation, or SDK packages were added.
- Live Azure Service Bus SDK receiving remains deferred.