### PR TITLE
USER-STORY-16: Harden agent process tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .worktrees/
 .cache/
 .terminals/
+.idea/
+docs/superpowers/
 /input/
 /output/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,9 @@ direction.
   is only a simple status board when remote tracker access is available.
 - Start branch names, commit subjects, and PR titles with the lowest-level
   available work identifier: task ID, bug ID, then story ID.
-- Commits, pushes, and PR creation happen only when the user asks or when a task
-  explicitly grants automatic PR creation after validation.
+- Local commits are allowed after relevant validation and should be small,
+  scoped checkpoints. Pushes and PR creation happen only when the user asks or
+  when a task explicitly grants automatic PR creation after validation.
 
 ## Architecture Principles
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: help agent-preflight check-tools install-tools install-optional-tools print-install-tools print-install-optional-tools up down local-compose-check local-runtime-smoke validate validate-docs validate-automation test-dotnet test-dotnet-foundation test-dotnet-contracts test-dotnet-watcher test-dotnet-api test-dotnet-persistence test-dotnet-outbox test-dotnet-workflow test-dotnet-observability test-dotnet-command-runner docs-check docs-fix scripts-check github-projects-script-test github-project-check github-project-summary github-project-hierarchy github-project-active github-project-audit-fields github-issue-body-lint
+.PHONY: help agent-preflight pr-readiness-check check-tools install-tools install-optional-tools print-install-tools print-install-optional-tools up down local-compose-check local-runtime-smoke validate validate-docs validate-automation test-dotnet test-dotnet-foundation test-dotnet-contracts test-dotnet-watcher test-dotnet-api test-dotnet-persistence test-dotnet-outbox test-dotnet-workflow test-dotnet-observability test-dotnet-command-runner test-ui docs-check docs-fix scripts-check github-projects-script-test github-project-check github-project-summary github-project-hierarchy github-project-active github-project-audit-fields github-issue-body-lint
 
 help:
 	@printf '%s\n' "Available targets:"
 	@printf '%s\n' "  make agent-preflight     Print local agent startup context"
+	@printf '%s\n' "  make pr-readiness-check  Print dry PR readiness checklist"
 	@printf '%s\n' "  make check-tools         Verify required Linux development tools"
 	@printf '%s\n' "  make install-tools       Install supported Linux development tools"
 	@printf '%s\n' "  make install-optional-tools Install optional local runtime/cloud CLIs"
@@ -17,6 +18,7 @@ help:
 	@printf '%s\n' "  make validate-automation Run automation script validation only"
 	@printf '%s\n' "  make test-dotnet         Build and smoke-test the .NET solution"
 	@printf '%s\n' "  make test-dotnet-*       Run a focused .NET smoke target"
+	@printf '%s\n' "  make test-ui             Run React control-plane Vitest tests"
 	@printf '%s\n' "  make docs-check          Check docs for unfinished placeholders"
 	@printf '%s\n' "  make docs-fix            Apply safe docs formatting fixes"
 	@printf '%s\n' "  make scripts-check       Syntax-check shell scripts"
@@ -30,6 +32,9 @@ help:
 
 agent-preflight:
 	@sh scripts/dev/agent-preflight.sh
+
+pr-readiness-check:
+	@sh scripts/dev/pr-readiness-check.sh
 
 check-tools:
 	@sh scripts/dev/check-tools.sh
@@ -94,6 +99,9 @@ test-dotnet-observability:
 test-dotnet-command-runner:
 	@sh scripts/dev/test-dotnet.sh command-runner
 
+test-ui:
+	@npm run ui:test
+
 docs-check:
 	@npm run docs:check
 
@@ -105,6 +113,7 @@ scripts-check:
 	@sh -n scripts/dev/install-tools.sh
 	@sh -n scripts/dev/install-optional-tools.sh
 	@sh -n scripts/dev/agent-preflight.sh
+	@sh -n scripts/dev/pr-readiness-check.sh
 	@sh -n scripts/dev/test-dotnet.sh
 	@sh -n scripts/dev/github-projects.sh
 	@sh -n scripts/dev/test-github-projects.sh

--- a/docs/automation/README.md
+++ b/docs/automation/README.md
@@ -16,7 +16,10 @@ Low-token operating entrypoint for AI coding agents and local automation.
 10. [agent-handoff.md](agent-handoff.md) before reporting task results
 11. [github-projects.md](github-projects.md) when work changes issues, PRs, milestones, or project state
 12. [git-conventions.md](git-conventions.md) before creating branches, commits, or PRs
-13. [terminal-scripts.md](terminal-scripts.md) when using local `.terminals/`
+13. [state-record-template.md](state-record-template.md) when creating or updating
+    local worktree state records
+14. [subagent-prompts.md](subagent-prompts.md) when dispatching review or worker subagents
+15. [terminal-scripts.md](terminal-scripts.md) when using local `.terminals/`
     helpers for parallel worktree launches
 
 ## Durable References
@@ -35,6 +38,8 @@ Low-token operating entrypoint for AI coding agents and local automation.
 - [pr-checklist.md](pr-checklist.md) - pull request creation and merge checklist.
 - [github-projects.md](github-projects.md) - GitHub tracking model, plugin preference, and CLI fallback commands.
 - [git-conventions.md](git-conventions.md) - branch, commit, and PR naming conventions.
+- [state-record-template.md](state-record-template.md) - local worktree checkpoint template.
+- [subagent-prompts.md](subagent-prompts.md) - compact subagent prompt templates.
 - [local-smoke-tests.md](local-smoke-tests.md) - local smoke test commands and manual runtime checks.
 - [terminal-scripts.md](terminal-scripts.md) - local-only helper script guidance for
   launching parallel worktree tasks.

--- a/docs/automation/agent-handoff.md
+++ b/docs/automation/agent-handoff.md
@@ -16,6 +16,15 @@ ownership:
   primaryLane: <lane>
   supportingLanes:
     - <lane>
+workflow:
+  superpowers:
+    skillsUsed:
+      - <skill name or none>
+    subagentsUsed: yes | no
+    reason: <why subagents were used or skipped>
+  context:
+    checkpointWritten: yes | no
+    nextResumePoint: <short summary or not-applicable>
 filesChanged:
   - <path>
 docsUpdated:
@@ -41,6 +50,14 @@ pr:
   authorized: yes | no
   url: <url or none>
   state: not-created | open | merged | blocked
+cleanup:
+  worktreePath: <path or not-applicable>
+  stateRecord: <path or not-applicable>
+  targetBranchFastForwarded: yes | no | not-applicable
+  worktreeRemoved: yes | no | not-applicable
+  localBranchDeleted: yes | no | not-applicable
+  remoteBranchDeleted: yes | no | not-applicable
+  notes: <short notes>
 ```
 
 ## Escalation Reasons
@@ -54,6 +71,9 @@ Use `status: escalation-needed` when:
 - architecture or contract decisions conflict
 - validation fails for an unclear reason
 - another agent is working in the same file scope
+- context is approaching the agreed budget and no durable checkpoint exists
+- compaction risk is high and the next safe action is to write a handoff
+- subagent authorization is missing for clearly independent work
 
 ## PR Handoff
 

--- a/docs/automation/commands.md
+++ b/docs/automation/commands.md
@@ -1,5 +1,28 @@
 # Commands
 
+## Output Discipline
+
+Prefer narrow commands and summarized evidence. Use `git diff --name-only`,
+`git diff --stat`, targeted `sed`, and focused `rg` before full diffs or broad
+logs.
+
+When reporting results, include command names, pass/fail outcome, and the small
+piece of output that proves the claim. Avoid pasting full logs unless a failure
+requires it.
+
+## Shared Mount Notes
+
+This local repository is often used from a shared mount. Use these workarounds
+only when the mount behavior requires them:
+
+- Add `-c core.filemode=false` to Git inspection commands when executable-bit
+  noise hides the real content diff.
+- Add a command-local `-c safe.directory=<absolute-worktree-path>` when Git
+  rejects a worktree with dubious ownership. Prefer command-local overrides over
+  changing global Git config.
+- Use `npm ci --no-bin-links --prefix web/ingest-control-plane` when installing
+  UI dependencies on mounts that do not support npm `.bin` symlink creation.
+
 | Command | Purpose | Cost | Docker | Cloud |
 | --- | --- | --- | --- | --- |
 | `git status --short` | Check working tree state. | cheap | no | no |
@@ -8,6 +31,7 @@
 | `find docs -maxdepth 3 -type f -print` | List documentation files. | cheap | no | no |
 | `make help` | List canonical project commands. | cheap | no | no |
 | `make agent-preflight` | Print local startup context, worktrees, tool status, and validation targets. | cheap | no | no |
+| `make pr-readiness-check` | Print a local dry PR readiness checklist, staged/unstaged paths, state records, and suggested validation. | cheap | no | no |
 | `make check-tools` | Verify required Linux development tools and report optional tools. | cheap | no | no |
 | `make install-tools` | Install supported Linux host tools after local confirmation. | moderate | no | no |
 | `make install-optional-tools` | Install optional host runtime and cloud CLIs after local confirmation. | moderate | no | no |
@@ -37,6 +61,7 @@
 | `make test-dotnet-workflow` | Run the workflow smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
 | `make test-dotnet-observability` | Run the observability smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
 | `make test-dotnet-command-runner` | Run the generic command runner smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
+| `make test-ui` | Run the React control-plane Vitest tests. | cheap | no | no |
 | `make docs-fix` | Apply safe documentation formatting fixes before committing. | cheap | no | no |
 | `make github-projects-script-test` | Test GitHub tracker helper wrappers without network. | cheap | no | no |
 | `make github-project-check` | Verify GitHub CLI auth and project access. | cheap | no | no |
@@ -49,6 +74,8 @@
 | `npm run docs:fix` | Apply safe docs formatting fixes. | cheap | no | no |
 | `npm run dotnet:test` | Build and smoke-test the .NET solution through npm. | moderate | yes when host `dotnet` is unavailable | no |
 | `npm run dotnet:test:<target>` | Run a focused .NET smoke test target. | cheap | yes when host `dotnet` is unavailable | no |
+| `npm run ui:test` | Run the React control-plane Vitest tests from the repo root. | cheap | no | no |
+| `npm run pr:readiness` | Print the local dry PR readiness checklist through npm. | cheap | no | no |
 | `npm run github-project:check` | Verify GitHub CLI auth and project access through npm. | cheap | no | no |
 | `npm run github-project:summary` | Print GitHub tracker counts through npm. | cheap | no | no |
 | `npm run github-project:hierarchy` | Print GitHub tracker hierarchy through npm. | cheap | no | no |

--- a/docs/automation/execution-checklist.md
+++ b/docs/automation/execution-checklist.md
@@ -2,10 +2,41 @@
 
 Use this checklist before an agent starts and before it reports completion.
 
+## Change Mode Matrix
+
+Use the lightest mode that preserves traceability and isolation.
+
+| Mode | Worktree | Issue ID | Branch | Staging | Commit/Push/PR |
+| --- | --- | --- | --- | --- | --- |
+| Answer or review only | no | no | no | no | no |
+| Tiny doc hygiene | optional when checkout is clean | optional | optional | when making a local commit | local commit allowed; push/PR only when explicitly asked |
+| Tooling or docs behavior | yes for PR-bound work | story/task preferred | yes for PR-bound work | before each local commit | local commits allowed; push/PR only when explicitly asked |
+| Feature or bug implementation | yes | lowest available task, bug, or story | yes | before each local commit | local commits allowed; push/PR only when explicitly asked |
+| Parallel or subagent implementation | yes | required when available | yes | coordinator decides before integration | local commits allowed; push/PR only when explicitly asked |
+| Post-merge cleanup | existing checkout is acceptable | PR reference | no new branch | no | no new PR unless explicitly asked |
+
+Local commits are allowed after relevant validation and should be small enough
+to review or revert independently. Prefer committing each completed task or
+coherent checkpoint instead of accumulating one large final commit.
+
+Push and PR creation require explicit user authorization or explicit task/plan
+authorization after validation. Completing implementation, staging a diff, or
+making a local commit does not imply permission to push or open a PR.
+
+Staging is optional until local commit or PR readiness unless the user asks for
+staged changes. When staging is used, keep staged paths limited to the intended
+scope and report staged and unstaged files separately.
+
 ## Before Starting
 
 - [ ] Read `AGENTS.md`.
 - [ ] Read `docs/automation/README.md`.
+- [ ] Select the change mode from the matrix above.
+- [ ] Decide whether worktree, branch, and GitHub issue linkage are required for that mode.
+- [ ] Identify applicable Superpowers skills or explicitly state none apply.
+- [ ] Decide whether the task has 2+ independent lanes suitable for subagents.
+- [ ] If subagents are suitable and authorized, dispatch them before deep local work.
+- [ ] Set a context budget: plan a handoff/checkpoint before long logs, broad diffs, or compaction risk.
 - [ ] Read `docs/automation/github-projects.md`.
 - [ ] Identify ownership lane from `docs/automation/roles.md`.
 - [ ] Identify linked GitHub issue, user stories, and milestone.
@@ -19,6 +50,8 @@ Use this checklist before an agent starts and before it reports completion.
 
 - [ ] Keep edits inside target files.
 - [ ] Escalate before dependency, cloud, secret, or out-of-scope work.
+- [ ] Write or update a durable checkpoint before long logs, broad diffs, or compaction risk.
+- [ ] Close completed subagents after their findings are integrated.
 - [ ] Follow BDD/TDD for behavior changes.
 - [ ] Update GitHub issue or simple Project status only when tracker state changes.
 - [ ] Update task, story, milestone, status, and bug docs when durable repo context changes.
@@ -31,6 +64,14 @@ Use this checklist before an agent starts and before it reports completion.
 - [ ] Run `git diff --check`.
 - [ ] Run lightweight GitHub tracker validation when tracker state changed.
 - [ ] Update required docs.
+- [ ] Review staged and unstaged paths separately.
+- [ ] Prefer small local commits after validation when the change is ready.
+- [ ] Confirm push and PR creation are authorized before running them.
+- [ ] If reporting PR readiness, confirm `docs/automation/pr-checklist.md` is satisfied.
+- [ ] If a PR was merged, fast-forward the target branch locally when safe.
+- [ ] If a PR was merged, remove completed local worktrees after confirming no uncommitted work remains.
+- [ ] If a PR was merged, delete completed local feature branches when no longer needed.
+- [ ] If a PR was merged, delete completed `.worktrees/state/<worktree-slug>.md` records.
 - [ ] Prepare handoff using `docs/automation/agent-handoff.md`.
 - [ ] If PR creation is authorized, complete `docs/automation/pr-checklist.md`.
 - [ ] Report any validation not run and why.

--- a/docs/automation/git-conventions.md
+++ b/docs/automation/git-conventions.md
@@ -19,6 +19,20 @@ BUG-1-fix-manifest-watch-race
 USER-STORY-16-link-and-commit-standards
 ```
 
+## When An Identifier Is Required
+
+Use the lowest available task, bug, or story identifier for substantial
+implementation, bug fixing, tooling behavior, or PR-bound documentation work.
+
+Tiny local-only hygiene can proceed without creating a GitHub issue when it is
+not being committed or opened as a PR. If the change becomes PR-bound, use the
+lowest available identifier in the branch, commit subject, and PR title.
+
+Story-level branch names are acceptable for standards, planning, automation, or
+tooling work when no lower-level task or bug issue exists yet. Do not invent a
+task ID locally; create or identify one first when task-level tracking is
+needed.
+
 ## Commit Messages
 
 Start commit subjects with the same lowest-level identifier used by the branch.
@@ -54,6 +68,9 @@ Reference parent stories or epics with `Refs` unless they are truly completed by
 the PR.
 
 ## Before Committing
+
+Local commits are allowed for agent work and should be small, coherent
+checkpoints. Push and PR creation still require explicit authorization.
 
 Run safe docs fixes and validation before committing documentation changes:
 

--- a/docs/automation/parallelization.md
+++ b/docs/automation/parallelization.md
@@ -12,6 +12,33 @@ processes.
 committed. Git history, GitHub issues, and PR links are the durable record after
 work completes.
 
+## Subagent Trigger Gate
+
+At task start, the coordinator must decide whether independent subagent work is
+available.
+
+Use `docs/automation/subagent-prompts.md` for compact review, implementation,
+PR-readiness, and failure-investigation prompts.
+
+Use subagents when all of these are true:
+
+- there are 2+ independent review, verification, investigation, or implementation lanes
+- target files are disjoint or the subagents are read-only
+- the parent agent can continue useful coordination work while subagents run
+- the user has explicitly authorized subagents for the task or the task is covered
+  by standing authorization in the current session
+
+Common default subagent lanes:
+
+- tooling or Makefile review
+- documentation consistency review
+- git/worktree cleanup review
+- focused test or CI failure investigation
+- isolated implementation tasks with disjoint file ownership
+
+Do not wait for a reminder when these conditions are met. If authorization is
+missing, ask once near the start instead of doing all work inline.
+
 ## Safe Parallel Patterns
 
 | Lane | Usually safe with | Avoid parallel edits with |
@@ -47,6 +74,8 @@ Each parallel agent must receive:
 
 Create one ignored local state file per active worktree:
 `.worktrees/state/<worktree-slug>.md`.
+
+Use `docs/automation/state-record-template.md` for the required shape.
 
 Required fields:
 
@@ -90,6 +119,49 @@ Do not merge competing edits manually without a new plan.
 Parallel agents normally run in separate terminals with separate worktrees. Each
 agent owns cleanup for the worktree it created; do not leave merged worktrees
 behind unless cleanup is blocked, and report the blocker in the handoff.
+
+## Context-Saving Pattern
+
+The parent agent owns coordination, final integration, tracker writes, and final
+handoff. Subagents own bounded investigation or implementation lanes and return
+short handoffs only.
+
+Subagent output should include:
+
+- finding or change summary
+- files inspected or changed
+- validation command and outcome
+- blockers or conflicts
+
+Subagents should not paste full logs, full diffs, or broad repo scans unless the
+parent explicitly asks for that evidence.
+
+## Subagent Closeout
+
+After a subagent result is integrated:
+
+1. Record the relevant finding, changed files, validation, or blocker in the
+   coordinator notes or handoff.
+2. Close the completed subagent so stale threads do not consume tool slots or
+   distract later coordination.
+3. Reuse the result summary instead of re-reading the full subagent transcript.
+
+Do not leave completed subagents open after their results are accepted, rejected,
+or superseded.
+
+## Token Budget Rules
+
+Treat context as a finite execution resource.
+
+- Prefer narrow prompts and bounded file ownership for each subagent.
+- Ask subagents for short structured handoffs, not full logs.
+- Use `git diff --name-only`, `git diff --stat`, focused `rg`, and targeted
+  file reads before full diffs or broad scans.
+- Summarize validation with command, outcome, and the smallest proof output.
+- Write a checkpoint to `.worktrees/state/<worktree-slug>.md`, an issue, a PR,
+  or a handoff before compaction risk becomes likely.
+- Stop and hand off before forced compaction when the next safe action is
+  resumable from durable state.
 
 ## Tracker Coordination
 

--- a/docs/automation/pr-checklist.md
+++ b/docs/automation/pr-checklist.md
@@ -45,8 +45,53 @@ The PR body must include:
 After creating the PR, update the issue or simple Project status only when that
 status is meaningful for visibility.
 
+## PR Readiness Gate
+
+Implementation complete does not automatically mean push or PR creation is
+authorized. Local commits are allowed after validation and should be small,
+coherent checkpoints.
+
+Before committing, pushing, or opening a PR:
+
+- Confirm the user, task, or plan explicitly authorizes push and PR creation.
+- Confirm the branch is up to date with the target branch or conflict-free.
+- Review staged and unstaged paths separately and keep the staged set limited to
+  the intended local commit or PR scope.
+- Run `make validate` when command docs, scripts, Makefile targets, runtime
+  contracts, or tooling behavior changed.
+- Run `git diff --check` and `git diff --cached --check` when staged changes
+  exist.
+- Update `.worktrees/state/<worktree-slug>.md` with branch status, validation
+  evidence, and whether the PR is not created, open, or merged.
+- Run `make pr-readiness-check` and resolve any unexpected staged paths,
+  missing state records, or validation reminders.
+- Prepare the handoff from `docs/automation/agent-handoff.md`.
+
+Prefer multiple small local commits over one large commit when a branch contains
+separable process, tooling, documentation, or implementation checkpoints.
+
 ## Merge Notes
 
 - CI may be disabled for this repository.
 - Cloud validation requires explicit approval.
 - Squash merge is preferred for documentation and planning branches.
+
+## Post-Merge Agent Cleanup
+
+After a PR is merged and the target branch is fast-forwarded locally:
+
+- Remove the completed local worktree with `git worktree remove <path>` once no
+  uncommitted work remains there.
+- Delete the merged local feature branch after removing its worktree when it is
+  no longer needed.
+- Delete the ignored `.worktrees/state/<worktree-slug>.md` record for completed
+  work so future agents do not treat it as active.
+- Prune stale worktree metadata with `git worktree prune` if `git worktree list`
+  shows missing or stale entries.
+- Leave remote branch deletion to the repository owner or the GitHub PR merge
+  settings unless the user explicitly asks for remote branch cleanup.
+
+Report the cleanup result in the `cleanup` block from
+`docs/automation/agent-handoff.md`. If cleanup is skipped or blocked, state the
+reason and leave the `.worktrees/state/<worktree-slug>.md` record updated rather
+than stale.

--- a/docs/automation/state-record-template.md
+++ b/docs/automation/state-record-template.md
@@ -1,0 +1,34 @@
+# Worktree State Record Template
+
+Use one ignored local state record per active worktree:
+`.worktrees/state/<worktree-slug>.md`.
+
+State records are local coordination checkpoints. Do not commit them.
+
+```markdown
+# <worktree-slug>
+
+- Mode: answer-review | tiny-doc-hygiene | tooling-docs-behavior | feature-bug-implementation | parallel-subagent-implementation | post-merge-cleanup
+- Worktree: `.worktrees/<worktree-slug>`
+- Branch: `<branch-name>`
+- Linked issue or PR: `<URL or not-applicable>`
+- Story/task: `<USER-STORY/TASK/BUG or not-applicable>`
+- Ownership lane: `<lane>`
+- Target files:
+  - `<path>`
+- Forbidden files:
+  - `<path or none>`
+- Subagents:
+  - Used: yes | no
+  - Open: `<agent ids or none>`
+  - Closed: `<agent ids or none>`
+- Status: In Progress | Ready For Review | Ready For PR | PR Open | Merged | Blocked
+- Validation:
+  - `<command>`: passed | failed | not-run
+- Next resume point: `<single sentence>`
+- Cleanup:
+  - Worktree removed: yes | no | not-applicable
+  - Local branch deleted: yes | no | not-applicable
+  - Remote branch deleted: yes | no | not-applicable
+- Notes: `<short notes>`
+```

--- a/docs/automation/subagent-prompts.md
+++ b/docs/automation/subagent-prompts.md
@@ -1,0 +1,97 @@
+# Subagent Prompt Templates
+
+Use these compact prompts to keep subagent context bounded. Replace bracketed
+values before dispatching.
+
+## Read-Only Review
+
+```text
+Review only. Do not edit files.
+
+Worktree: [absolute worktree path]
+Scope:
+- Files to inspect: [paths]
+- Files not to inspect unless necessary: [paths or none]
+
+Check:
+- [specific requirements]
+- no unrelated changes
+- validation evidence is sufficient
+
+Return:
+status: APPROVED | CHANGES_REQUESTED
+findings:
+residualRisks:
+notes:
+```
+
+## Implementation Worker
+
+```text
+You are not alone in the codebase. Do not revert or modify work outside your
+ownership.
+
+Worktree: [absolute worktree path]
+Ownership:
+- Modify only: [paths]
+- Do not edit: [paths]
+
+Task:
+- [specific steps]
+
+Validation:
+- [commands]
+
+Return:
+status: DONE | BLOCKED
+filesChanged:
+validation:
+notes:
+Local commits are allowed after validation when they are small, scoped, and
+use the branch identifier. Do not push or open a PR.
+```
+
+## PR Readiness Reviewer
+
+```text
+Read-only PR readiness review. Do not edit files.
+
+Worktree: [absolute worktree path]
+
+Check:
+- branch follows docs/automation/git-conventions.md
+- staged and unstaged paths are intentional
+- required validation from docs/automation/validation.md has passed
+- .worktrees/state/<worktree-slug>.md is current
+- no secrets or generated local files are staged
+- push/PR authorization is explicit
+
+Return:
+status: READY | NOT_READY
+findings:
+requiredBeforePR:
+notes:
+```
+
+## CI Or Failure Investigator
+
+```text
+Investigate only. Do not edit files unless explicitly asked in a follow-up.
+
+Worktree: [absolute worktree path]
+Failure:
+- Command/check: [name]
+- Key output: [short excerpt]
+
+Find:
+- likely root cause
+- minimal files involved
+- recommended validation command
+
+Return:
+status: ROOT_CAUSE_FOUND | NEEDS_MORE_CONTEXT
+rootCause:
+evidence:
+recommendedFix:
+validation:
+```

--- a/docs/automation/validation.md
+++ b/docs/automation/validation.md
@@ -5,11 +5,13 @@
 | Docs-only change | `make docs-check` | `make docs-fix` before committing when formatting/link checks fail | no | no | cheap |
 | Architecture/ADR change | targeted term search for contradictory decisions | review affected ADRs and architecture docs together | no | no | cheap |
 | Automation-doc change | `make validate-automation` and `make docs-check` | `make validate`, then read `AGENTS.md`, task workflow, and automation docs for consistency | no | no | cheap |
+| Automation process docs only | `make docs-check` and `git diff --check` | `make validate` before PR when command docs, scripts, or Makefile targets also changed | no | no | cheap |
 | Standards change | `make docs-check` and the relevant focused validation target | `make validate` and review affected automation docs and task workflow | no | no | cheap |
 | Tooling change | `make validate` and `make check-tools` when host tools are expected | `make print-install-tools` review | no | no | cheap |
 | GitHub tracker change | GitHub plugin inspection, `make github-project-summary`, and `make github-project-active` | targeted GitHub plugin issue/PR inspection, `make github-project-hierarchy` only when parent/child navigation changed | no | no | cheap |
 | .NET code change | focused `make test-dotnet-*` target for the touched component | `make test-dotnet`, then `make validate` before PR | yes when host `dotnet` is unavailable | no | moderate |
 | Generic command runner change | `make test-dotnet-command-runner` | `make test-dotnet`, then `make validate` before PR | yes when host `dotnet` is unavailable | no | moderate |
+| React control-plane change | `make test-ui` | `make test-ui` plus `make validate` before PR when backend contracts also changed | no | no | cheap |
 | Local ingest smoke script change | `sh -n scripts/dev/local-e2e-smoke.sh` and `sh scripts/dev/local-e2e-smoke.sh --dry-run` | Run `dotnet run --project src/MediaIngest.Api --urls http://127.0.0.1:5000`, then `sh scripts/dev/local-e2e-smoke.sh` from another terminal to verify output files plus workflow command nodes | no | no | cheap |
 | Local Compose validation script change | `sh -n scripts/dev/local-compose-check.sh`, `sh scripts/dev/local-compose-check.sh --dry-run`, `sh scripts/dev/local-compose-check.sh --runtime-smoke --dry-run`, and `sh scripts/dev/local-compose-check.sh` | `make local-compose-check`, `make local-runtime-smoke` when Docker is available, then `make validate` before PR creation | yes for default and runtime validation only | no | cheap to moderate |
 | Docker/Kubernetes static asset change | `make docs-check`, `kubectl kustomize deploy/k8s`, `kubectl kustomize deploy/dapr/k8s`, and `git diff --check` | `kubectl apply --dry-run=client -k deploy/k8s` only when kubectl has an approved reachable local context | optional | no | cheap |
@@ -19,3 +21,21 @@
 Do not run expensive Docker or cloud validation for docs-only edits.
 
 Agents must report validation commands and outcomes before claiming completion.
+
+## Validation Selection
+
+Use changed paths to pick the cheapest sufficient validation:
+
+- `Makefile`, `package.json`, or `scripts/dev/*`: run `make validate`.
+- `web/*`: run `make test-ui`.
+- `docs/automation/*`: run `make docs-check` and `git diff --check`.
+- `src/MediaIngest.Worker.CommandRunner/*` or
+  `tests/MediaIngest.Worker.CommandRunner.Tests/*`: run
+  `make test-dotnet-command-runner`.
+- Other `src/*` or `tests/*`: run the focused `make test-dotnet-*` target for
+  the component, then `make validate` before PR.
+- Docker or Kubernetes files: use the Docker/Kubernetes rows above and avoid
+  cloud validation unless explicitly approved.
+
+Run `make pr-readiness-check` before reporting PR readiness to print the local
+changed-path summary, state-record status, and validation reminders.

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "github-project:issue-body-lint": "sh scripts/dev/github-projects.sh lint-issue-bodies",
     "github-project:script-test": "sh scripts/dev/test-github-projects.sh",
     "github-project:summary": "sh scripts/dev/github-projects.sh summary",
+    "pr:readiness": "sh scripts/dev/pr-readiness-check.sh",
     "tools:install:optional": "sh scripts/dev/install-optional-tools.sh",
     "tools:print-install:optional": "sh scripts/dev/install-optional-tools.sh --print-only",
-    "tools:check": "sh scripts/dev/check-tools.sh"
+    "tools:check": "sh scripts/dev/check-tools.sh",
+    "ui:test": "node web/ingest-control-plane/node_modules/vitest/vitest.mjs run --root web/ingest-control-plane"
   },
   "devDependencies": {}
 }

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -1,11 +1,70 @@
 #!/usr/bin/env bash
 set -u
 
+repo_path=$(pwd)
+git_cmd() {
+  git -c "safe.directory=$repo_path" -c core.filemode=false "$@"
+}
+common_git_dir=$(git_cmd rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+if [ -n "$common_git_dir" ]; then
+  state_dir="$(dirname "$common_git_dir")/.worktrees/state"
+else
+  state_dir=".worktrees/state"
+fi
+
 printf '%s\n' "Repository:"
-git status --short --branch
+git_cmd status --short --branch
+
+printf '\n%s\n' "Branch:"
+branch=$(git_cmd branch --show-current 2>/dev/null || true)
+if [ -n "$branch" ]; then
+  printf '%s\n' "$branch"
+else
+  printf '%s\n' "(detached or unavailable)"
+fi
+
+printf '\n%s\n' "Staged paths:"
+staged=$(git_cmd diff --cached --name-only 2>/dev/null || true)
+if [ -n "$staged" ]; then
+  printf '%s\n' "$staged"
+else
+  printf '%s\n' "(none)"
+fi
+
+printf '\n%s\n' "Unstaged tracked paths:"
+unstaged=$(git_cmd diff --name-only 2>/dev/null || true)
+if [ -n "$unstaged" ]; then
+  printf '%s\n' "$unstaged"
+else
+  printf '%s\n' "(none)"
+fi
+
+printf '\n%s\n' "Changed paths with filemode ignored:"
+changed=$(git_cmd diff --name-only HEAD 2>/dev/null || true)
+if [ -n "$changed" ]; then
+  printf '%s\n' "$changed"
+else
+  printf '%s\n' "(none)"
+fi
 
 printf '\n%s\n' "Worktrees:"
-git worktree list
+git_cmd worktree list
+
+printf '\n%s\n' "Active worktree state records:"
+state_records=$(find "$state_dir" -maxdepth 1 -type f -name '*.md' -print 2>/dev/null | sort || true)
+if [ -n "$state_records" ]; then
+  printf '%s\n' "$state_records"
+else
+  printf '%s\n' "(none)"
+fi
+
+printf '\n%s\n' "Process reminders:"
+printf '%s\n' "- Select a change mode from docs/automation/execution-checklist.md."
+printf '%s\n' "- Local commits are allowed after validation; keep them small and scoped."
+printf '%s\n' "- Push and PR creation require explicit authorization."
+printf '%s\n' "- Stage only intended PR scope; report staged and unstaged paths separately."
+printf '%s\n' "- Use subagents for authorized independent lanes and close them after integration."
+printf '%s\n' "- Checkpoint before long logs, broad diffs, or compaction risk."
 
 printf '\n%s\n' "Required tools:"
 sh scripts/dev/check-tools.sh
@@ -14,7 +73,9 @@ printf '\n%s\n' "Canonical validation:"
 printf '%s\n' "- make docs-check"
 printf '%s\n' "- make scripts-check"
 printf '%s\n' "- make test-dotnet"
+printf '%s\n' "- make test-ui"
 printf '%s\n' "- make validate"
+printf '%s\n' "- make pr-readiness-check"
 
 printf '\n%s\n' "Focused .NET validation:"
 printf '%s\n' "- make test-dotnet-foundation"
@@ -24,3 +85,4 @@ printf '%s\n' "- make test-dotnet-persistence"
 printf '%s\n' "- make test-dotnet-outbox"
 printf '%s\n' "- make test-dotnet-workflow"
 printf '%s\n' "- make test-dotnet-observability"
+printf '%s\n' "- make test-dotnet-command-runner"

--- a/scripts/dev/pr-readiness-check.sh
+++ b/scripts/dev/pr-readiness-check.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -u
+
+repo_path=$(pwd)
+git_cmd() {
+  git -c "safe.directory=$repo_path" -c core.filemode=false "$@"
+}
+common_git_dir=$(git_cmd rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+if [ -n "$common_git_dir" ]; then
+  state_dir="$(dirname "$common_git_dir")/.worktrees/state"
+else
+  state_dir=".worktrees/state"
+fi
+
+printf '%s\n' "PR readiness dry check"
+
+printf '\n%s\n' "Branch:"
+branch=$(git_cmd branch --show-current 2>/dev/null || true)
+if [ -n "$branch" ]; then
+  printf '%s\n' "$branch"
+else
+  printf '%s\n' "(detached or unavailable)"
+fi
+
+printf '\n%s\n' "Status:"
+git_cmd status --short --branch
+
+printf '\n%s\n' "Staged paths:"
+staged=$(git_cmd diff --cached --name-only 2>/dev/null || true)
+if [ -n "$staged" ]; then
+  printf '%s\n' "$staged"
+else
+  printf '%s\n' "(none)"
+fi
+
+printf '\n%s\n' "Unstaged tracked paths:"
+unstaged=$(git_cmd diff --name-only 2>/dev/null || true)
+if [ -n "$unstaged" ]; then
+  printf '%s\n' "$unstaged"
+else
+  printf '%s\n' "(none)"
+fi
+
+printf '\n%s\n' "Untracked paths:"
+untracked=$(git_cmd ls-files --others --exclude-standard 2>/dev/null || true)
+if [ -n "$untracked" ]; then
+  printf '%s\n' "$untracked"
+else
+  printf '%s\n' "(none)"
+fi
+
+printf '\n%s\n' "Change summary:"
+git_cmd diff --cached --stat
+git_cmd diff --stat
+
+printf '\n%s\n' "File mode summary:"
+summary=$(git_cmd diff --cached --summary; git_cmd diff --summary)
+if [ -n "$summary" ]; then
+  printf '%s\n' "$summary"
+else
+  printf '%s\n' "(none)"
+fi
+
+printf '\n%s\n' "State records:"
+state_records=$(find "$state_dir" -maxdepth 1 -type f -name '*.md' -print 2>/dev/null | sort || true)
+if [ -n "$state_records" ]; then
+  printf '%s\n' "$state_records"
+else
+  printf '%s\n' "(none)"
+fi
+
+printf '\n%s\n' "Suggested validation by changed path:"
+paths=$(printf '%s\n%s\n%s\n' "$staged" "$unstaged" "$untracked" | sort -u | sed '/^$/d')
+if [ -z "$paths" ]; then
+  printf '%s\n' "- No tracked content changes detected."
+else
+  printf '%s\n' "$paths" | while IFS= read -r path; do
+    case "$path" in
+      Makefile|package.json|scripts/dev/*)
+        printf '%s\n' "- $path: make validate"
+        ;;
+      web/*)
+        printf '%s\n' "- $path: make test-ui"
+        ;;
+      docs/automation/*)
+        printf '%s\n' "- $path: make docs-check && git diff --check"
+        ;;
+      src/MediaIngest.Worker.CommandRunner/*|tests/MediaIngest.Worker.CommandRunner.Tests/*)
+        printf '%s\n' "- $path: make test-dotnet-command-runner"
+        ;;
+      src/*|tests/*)
+        printf '%s\n' "- $path: focused make test-dotnet-* target, then make validate before PR"
+        ;;
+      *)
+        printf '%s\n' "- $path: choose validation from docs/automation/validation.md"
+        ;;
+    esac
+  done | sort -u
+fi
+
+printf '\n%s\n' "Required before PR:"
+printf '%s\n' "- explicit authorization to push and open PR"
+printf '%s\n' "- local commits are allowed after validation; prefer small scoped commits"
+printf '%s\n' "- intended staged scope only"
+printf '%s\n' "- make validate when command docs, scripts, Makefile targets, contracts, or tooling changed"
+printf '%s\n' "- git diff --check and git diff --cached --check"
+printf '%s\n' "- updated .worktrees/state/<worktree-slug>.md"
+printf '%s\n' "- handoff from docs/automation/agent-handoff.md"


### PR DESCRIPTION
## Summary
- Clarifies agent workflow policy for change modes, local commits, push/PR authorization, subagents, worktree cleanup, and context budgeting.
- Adds local process helpers for agent preflight and dry PR readiness checks.
- Documents state-record and subagent prompt templates, plus deterministic validation selection.

Refs #26

## Validation
- `make agent-preflight`
- `make pr-readiness-check`
- `make scripts-check`
- `make docs-check`
- `make test-ui` (17 tests passed)
- `make validate`
- `git diff --check`
- `git diff --cached --check`

## Risk
- Documentation/tooling-only change. No runtime behavior, dependencies, secrets, cloud resources, or production deployment changes.

## Follow-up
- After merge, fast-forward local `main`, remove the completed worktree/local branch, and delete the ignored state record.