### PR TITLE
USER-STORY-16: Add summary validation mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help agent-preflight pr-readiness-check check-tools install-tools install-optional-tools print-install-tools print-install-optional-tools up down local-compose-check local-runtime-smoke validate validate-docs validate-automation test-dotnet test-dotnet-foundation test-dotnet-contracts test-dotnet-watcher test-dotnet-api test-dotnet-persistence test-dotnet-outbox test-dotnet-workflow test-dotnet-observability test-dotnet-command-runner test-ui docs-check docs-fix scripts-check github-projects-script-test github-project-check github-project-summary github-project-hierarchy github-project-active github-project-audit-fields github-issue-body-lint
+.PHONY: help agent-preflight pr-readiness-check check-tools install-tools install-optional-tools print-install-tools print-install-optional-tools up down local-compose-check local-runtime-smoke validate validate-summary validate-docs validate-docs-summary validate-automation validate-automation-summary test-dotnet test-dotnet-summary test-dotnet-foundation test-dotnet-contracts test-dotnet-watcher test-dotnet-api test-dotnet-persistence test-dotnet-outbox test-dotnet-workflow test-dotnet-observability test-dotnet-command-runner test-ui test-ui-summary docs-check docs-check-summary docs-fix scripts-check github-projects-script-test github-project-check github-project-summary github-project-hierarchy github-project-active github-project-audit-fields github-issue-body-lint summary-validation-script-test
 
 help:
 	@printf '%s\n' "Available targets:"
@@ -14,11 +14,16 @@ help:
 	@printf '%s\n' "  make local-compose-check Validate local Docker Compose configuration"
 	@printf '%s\n' "  make local-runtime-smoke Start Compose and run local ingest smoke"
 	@printf '%s\n' "  make validate            Run cheap repository validation"
+	@printf '%s\n' "  make validate-summary    Run cheap validation with compact output and /tmp log"
 	@printf '%s\n' "  make validate-docs       Run docs validation only"
+	@printf '%s\n' "  make validate-docs-summary Run docs validation with compact output"
 	@printf '%s\n' "  make validate-automation Run automation script validation only"
+	@printf '%s\n' "  make validate-automation-summary Run automation validation with compact output"
 	@printf '%s\n' "  make test-dotnet         Build and smoke-test the .NET solution"
+	@printf '%s\n' "  make test-dotnet-summary Build and smoke-test .NET with compact output"
 	@printf '%s\n' "  make test-dotnet-*       Run a focused .NET smoke target"
 	@printf '%s\n' "  make test-ui             Run React control-plane Vitest tests"
+	@printf '%s\n' "  make test-ui-summary     Run UI tests with compact output"
 	@printf '%s\n' "  make docs-check          Check docs for unfinished placeholders"
 	@printf '%s\n' "  make docs-fix            Apply safe docs formatting fixes"
 	@printf '%s\n' "  make scripts-check       Syntax-check shell scripts"
@@ -63,14 +68,26 @@ local-compose-check:
 local-runtime-smoke:
 	@sh scripts/dev/local-compose-check.sh --runtime-smoke
 
-validate: docs-check scripts-check github-projects-script-test test-dotnet
+validate: docs-check scripts-check github-projects-script-test summary-validation-script-test test-dotnet
+
+validate-summary:
+	@sh scripts/dev/validation-summary.sh make validate
 
 validate-docs: docs-check
 
-validate-automation: scripts-check github-projects-script-test
+validate-docs-summary:
+	@sh scripts/dev/validation-summary.sh make validate-docs
+
+validate-automation: scripts-check github-projects-script-test summary-validation-script-test
+
+validate-automation-summary:
+	@sh scripts/dev/validation-summary.sh make validate-automation
 
 test-dotnet:
 	@sh scripts/dev/test-dotnet.sh
+
+test-dotnet-summary:
+	@sh scripts/dev/validation-summary.sh make test-dotnet
 
 test-dotnet-foundation:
 	@sh scripts/dev/test-dotnet.sh foundation
@@ -102,8 +119,14 @@ test-dotnet-command-runner:
 test-ui:
 	@npm run ui:test
 
+test-ui-summary:
+	@sh scripts/dev/validation-summary.sh make test-ui
+
 docs-check:
 	@npm run docs:check
+
+docs-check-summary:
+	@sh scripts/dev/validation-summary.sh make docs-check
 
 docs-fix:
 	@npm run docs:fix
@@ -114,6 +137,8 @@ scripts-check:
 	@sh -n scripts/dev/install-optional-tools.sh
 	@sh -n scripts/dev/agent-preflight.sh
 	@sh -n scripts/dev/pr-readiness-check.sh
+	@sh -n scripts/dev/validation-summary.sh
+	@sh -n scripts/dev/test-summary-validation.sh
 	@sh -n scripts/dev/test-dotnet.sh
 	@sh -n scripts/dev/github-projects.sh
 	@sh -n scripts/dev/test-github-projects.sh
@@ -122,6 +147,9 @@ scripts-check:
 
 github-projects-script-test:
 	@sh scripts/dev/test-github-projects.sh
+
+summary-validation-script-test:
+	@sh scripts/dev/test-summary-validation.sh
 
 github-project-check:
 	@sh scripts/dev/github-projects.sh check-auth

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ The installer does not log in to Azure or create paid cloud resources.
 make validate
 ```
 
+Agent sessions should prefer the summary form for broad validation:
+
+```bash
+make validate-summary
+```
+
+It writes the full log under `/tmp` and prints only the command, exit code, key
+success or failure lines, and log path.
+
 Validation currently checks documentation, shell script syntax, GitHub tracker
 helper wrappers, and the .NET solution smoke-test targets. Runtime-specific
 checks such as local Compose validation are exposed as focused Make targets and

--- a/docs/automation/agent-handoff.md
+++ b/docs/automation/agent-handoff.md
@@ -4,6 +4,10 @@ Every implementation, review, or bug-fix agent should return a concise handoff.
 
 ## Required Handoff Format
 
+Keep handoffs compact. Use at most five finding bullets, summarize validation as
+command plus pass/fail and log path, avoid quoted file contents, and include logs
+only when a failure cannot be understood from the summary.
+
 ```text
 status: completed | blocked | escalation-needed | no-op
 scope:

--- a/docs/automation/commands.md
+++ b/docs/automation/commands.md
@@ -42,8 +42,12 @@ only when the mount behavior requires them:
 | `make local-compose-check` | Validate `deploy/docker/compose.yaml` with `docker compose config` without starting containers. | cheap | yes | no |
 | `make local-runtime-smoke` | Start the local Compose API, UI, and PostgreSQL runtime, wait for API/UI HTTP responses, run the local ingest smoke script, and stop the stack. | moderate | yes | no |
 | `make validate` | Run cheap repository validation. | cheap | no | no |
+| `make validate-summary` | Run `make validate`, capture the full log under `/tmp`, and print only the command, exit code, key success or failure lines, and log path. Prefer this before broad validation in agent sessions. | cheap | no | no |
 | `make validate-docs` | Run documentation validation only. | cheap | no | no |
+| `make validate-docs-summary` | Run docs validation with compact summary output and a full `/tmp` log. | cheap | no | no |
 | `make validate-automation` | Run shell syntax checks and GitHub helper wrapper tests. | cheap | no | no |
+| `make validate-automation-summary` | Run automation validation with compact summary output and a full `/tmp` log. | cheap | no | no |
+| `make summary-validation-script-test` | Test the summary validation wrapper without network or external services. | cheap | no | no |
 | `dotnet run --project src/MediaIngest.Api --urls http://127.0.0.1:5000` | Start the local ingest API on the fixed development port. | cheap | no | no |
 | `cd web/ingest-control-plane && npm run dev` | Start the React control plane with Vite `/api` proxying to the local API. | cheap | no | no |
 | `sh scripts/dev/local-e2e-smoke.sh --dry-run` | Print the local manifest ingest E2E smoke plan without changing files or calling the API. Use `SMOKE_EXPECT_COPIED_FILES=manifest` to plan manifest-only copied output assertions with command-node evidence. | cheap | no | no |
@@ -53,6 +57,7 @@ only when the mount behavior requires them:
 | `sh scripts/dev/local-compose-check.sh --runtime-smoke` | Start the local Compose runtime with project name `media-asset-ingest-local`, wait for API/UI HTTP responses, run `scripts/dev/local-e2e-smoke.sh` with manifest-output assertions and command-node evidence, and stop the stack. Override `LOCAL_COMPOSE_API_PORT`, `LOCAL_COMPOSE_UI_PORT`, or `LOCAL_COMPOSE_POSTGRES_PORT` when default local ports are busy; the script exports the current UID/GID for host-writable smoke output. | moderate | yes | no |
 | `sh scripts/dev/local-compose-check.sh --runtime-smoke --dry-run` | Print the local Compose runtime smoke plan without requiring Docker, changing files, starting containers, or calling local HTTP endpoints. | cheap | no | no |
 | `make test-dotnet` | Build and smoke-test the .NET solution using host `dotnet` or the .NET SDK container. | moderate | yes when host `dotnet` is unavailable | no |
+| `make test-dotnet-summary` | Run .NET solution validation with compact summary output and a full `/tmp` log. | moderate | yes when host `dotnet` is unavailable | no |
 | `make test-dotnet-foundation` | Run the foundation smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
 | `make test-dotnet-contracts` | Run the contracts smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
 | `make test-dotnet-watcher` | Run the ingest watcher smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
@@ -62,6 +67,7 @@ only when the mount behavior requires them:
 | `make test-dotnet-observability` | Run the observability smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
 | `make test-dotnet-command-runner` | Run the generic command runner smoke test project only. | cheap | yes when host `dotnet` is unavailable | no |
 | `make test-ui` | Run the React control-plane Vitest tests. | cheap | no | no |
+| `make test-ui-summary` | Run UI tests with compact summary output and a full `/tmp` log. | cheap | no | no |
 | `make docs-fix` | Apply safe documentation formatting fixes before committing. | cheap | no | no |
 | `make github-projects-script-test` | Test GitHub tracker helper wrappers without network. | cheap | no | no |
 | `make github-project-check` | Verify GitHub CLI auth and project access. | cheap | no | no |
@@ -71,10 +77,14 @@ only when the mount behavior requires them:
 | `make github-project-audit-fields` | Legacy helper for detailed Project fields; not required for lightweight tracking. | cheap | no | no |
 | `make github-issue-body-lint` | Check issue bodies avoid duplicated relationship metadata. | cheap | no | no |
 | `npm run docs:check` | Check docs for unfinished placeholders. | cheap | no | no |
+| `npm run docs:check:summary` | Check docs with compact summary output and a full `/tmp` log. | cheap | no | no |
 | `npm run docs:fix` | Apply safe docs formatting fixes. | cheap | no | no |
 | `npm run dotnet:test` | Build and smoke-test the .NET solution through npm. | moderate | yes when host `dotnet` is unavailable | no |
+| `npm run dotnet:test:summary` | Build and smoke-test the .NET solution through npm with compact summary output and a full `/tmp` log. | moderate | yes when host `dotnet` is unavailable | no |
 | `npm run dotnet:test:<target>` | Run a focused .NET smoke test target. | cheap | yes when host `dotnet` is unavailable | no |
 | `npm run ui:test` | Run the React control-plane Vitest tests from the repo root. | cheap | no | no |
+| `npm run ui:test:summary` | Run UI tests with compact summary output and a full `/tmp` log. | cheap | no | no |
+| `npm run validate:summary` | Run cheap repository validation with compact summary output and a full `/tmp` log. | cheap | no | no |
 | `npm run pr:readiness` | Print the local dry PR readiness checklist through npm. | cheap | no | no |
 | `npm run github-project:check` | Verify GitHub CLI auth and project access through npm. | cheap | no | no |
 | `npm run github-project:summary` | Print GitHub tracker counts through npm. | cheap | no | no |
@@ -83,11 +93,14 @@ only when the mount behavior requires them:
 | `npm run github-project:audit-fields` | Legacy detailed Project field audit through npm; not required for lightweight tracking. | cheap | no | no |
 | `npm run github-project:issue-body-lint` | Check issue body relationship metadata through npm. | cheap | no | no |
 | `npm run github-project:script-test` | Test GitHub tracker helper wrappers through npm. | cheap | no | no |
+| `npm run summary-validation:test` | Test the summary validation wrapper through npm. | cheap | no | no |
 | `npm run tools:check` | Verify required Linux development tools through npm. | cheap | no | no |
 | `npm run tools:print-install:optional` | Print optional host tool installation commands through npm. | cheap | no | no |
 
 Add Makefile targets once the runtime scaffold exists. Prefer the cheapest
-relevant validation command first.
+relevant validation command first. In agent sessions, prefer the `*-summary`
+validation target for broad commands and open the full `/tmp` log only when the
+summary does not explain a failure.
 
 When a task adds a canonical command, update this file and
 `docs/automation/validation.md` when validation behavior changes.

--- a/docs/automation/execution-checklist.md
+++ b/docs/automation/execution-checklist.md
@@ -45,12 +45,15 @@ scope and report staged and unstaged files separately.
 - [ ] Identify validation command.
 - [ ] Check `.worktrees/state/*.md` and `git worktree list` for overlapping work.
 - [ ] Confirm no other parallel task owns the same target files.
+- [ ] Create or update the current task capsule in `.worktrees/state/<worktree-slug>.md` with goal, branch/worktree, changed files, validation status, next action, and blockers.
 
 ## During Work
 
 - [ ] Keep edits inside target files.
 - [ ] Escalate before dependency, cloud, secret, or out-of-scope work.
 - [ ] Write or update a durable checkpoint before long logs, broad diffs, or compaction risk.
+- [ ] Inspect diffs in this order by default: `git diff --name-only`, `git diff --stat`, targeted `git diff -- <file>`, then full diff only when needed.
+- [ ] Before `make validate`, `local-runtime-smoke`, Docker validation, or other long commands, update the state record, then run a summary validation command when available.
 - [ ] Close completed subagents after their findings are integrated.
 - [ ] Follow BDD/TDD for behavior changes.
 - [ ] Update GitHub issue or simple Project status only when tracker state changes.
@@ -60,6 +63,7 @@ scope and report staged and unstaged files separately.
 ## Before Reporting Completion
 
 - [ ] Run the cheapest relevant validation.
+- [ ] Prefer `*-summary` validation targets for broad commands, and report the log path.
 - [ ] Run stronger validation if the change touches runtime, contracts, infra, or tooling.
 - [ ] Run `git diff --check`.
 - [ ] Run lightweight GitHub tracker validation when tracker state changed.

--- a/docs/automation/guardrails.md
+++ b/docs/automation/guardrails.md
@@ -1,6 +1,7 @@
 # Guardrails
 
 - Keep diffs focused; avoid broad rewrites.
+- Inspect diff names and stats before targeted patches; read full diffs only when names, stats, or targeted file diffs are insufficient.
 - Avoid unrelated formatting churn.
 - Do not upgrade or add dependencies without a task-specific reason and approval where needed.
 - Do not generate or commit secrets.
@@ -8,11 +9,13 @@
 - Do not add non-Azure cloud dependencies to the target architecture.
 - Do not add large docs without updating the relevant index or read order.
 - Keep human and agent documentation lanes separate.
+- Keep detailed ephemeral planning in ignored `.worktrees/state/` records. Commit only compact durable plans under `docs/plans`; do not use ignored or generated planning artifacts as durable repo docs.
 - Preserve useful existing docs; move or summarize only when clearly misplaced, stale, duplicate, or unsafe.
 - Prefer durable business state over log scraping for UI behavior.
 - Use `workflowInstanceId`, `packageId`, `fileId`, `workItemId`, and `nodeId`
   consistently when designing logs, traces, and UI projections.
 - Follow BDD/TDD for behavior changes unless the user approves an exception.
+- Read each relevant workflow skill once at the start of a workflow, then rely on the compact automation docs unless switching workflow type or the skill details are unclear.
 - Keep domain behavior independent of Dapr, Azure Service Bus, PostgreSQL, and
   UI infrastructure details.
 - Update status, backlog, milestone, standards, tooling, and automation docs

--- a/docs/automation/parallelization.md
+++ b/docs/automation/parallelization.md
@@ -36,6 +36,10 @@ Common default subagent lanes:
 - focused test or CI failure investigation
 - isolated implementation tasks with disjoint file ownership
 
+For small doc-only or tooling-documentation changes, prefer one implementer and
+one final read-only reviewer. Skip multi-reviewer loops unless the change
+touches code behavior, contracts, runtime validation, or architecture decisions.
+
 Do not wait for a reminder when these conditions are met. If authorization is
 missing, ask once near the start instead of doing all work inline.
 
@@ -128,9 +132,9 @@ short handoffs only.
 
 Subagent output should include:
 
-- finding or change summary
+- finding or change summary, capped at five bullets
 - files inspected or changed
-- validation command and outcome
+- validation command and outcome, plus a log path when available
 - blockers or conflicts
 
 Subagents should not paste full logs, full diffs, or broad repo scans unless the

--- a/docs/automation/state-record-template.md
+++ b/docs/automation/state-record-template.md
@@ -14,6 +14,7 @@ State records are local coordination checkpoints. Do not commit them.
 - Linked issue or PR: `<URL or not-applicable>`
 - Story/task: `<USER-STORY/TASK/BUG or not-applicable>`
 - Ownership lane: `<lane>`
+- Goal: `<one sentence>`
 - Target files:
   - `<path>`
 - Forbidden files:
@@ -25,7 +26,11 @@ State records are local coordination checkpoints. Do not commit them.
 - Status: In Progress | Ready For Review | Ready For PR | PR Open | Merged | Blocked
 - Validation:
   - `<command>`: passed | failed | not-run
+- Changed files:
+  - `<path or none>`
 - Next resume point: `<single sentence>`
+- Blockers:
+  - `<none or details>`
 - Cleanup:
   - Worktree removed: yes | no | not-applicable
   - Local branch deleted: yes | no | not-applicable

--- a/docs/automation/validation.md
+++ b/docs/automation/validation.md
@@ -7,7 +7,7 @@
 | Automation-doc change | `make validate-automation` and `make docs-check` | `make validate`, then read `AGENTS.md`, task workflow, and automation docs for consistency | no | no | cheap |
 | Automation process docs only | `make docs-check` and `git diff --check` | `make validate` before PR when command docs, scripts, or Makefile targets also changed | no | no | cheap |
 | Standards change | `make docs-check` and the relevant focused validation target | `make validate` and review affected automation docs and task workflow | no | no | cheap |
-| Tooling change | `make validate` and `make check-tools` when host tools are expected | `make print-install-tools` review | no | no | cheap |
+| Tooling change | `make validate-summary` and `make check-tools` when host tools are expected | `make validate`, then `make print-install-tools` review | no | no | cheap |
 | GitHub tracker change | GitHub plugin inspection, `make github-project-summary`, and `make github-project-active` | targeted GitHub plugin issue/PR inspection, `make github-project-hierarchy` only when parent/child navigation changed | no | no | cheap |
 | .NET code change | focused `make test-dotnet-*` target for the touched component | `make test-dotnet`, then `make validate` before PR | yes when host `dotnet` is unavailable | no | moderate |
 | Generic command runner change | `make test-dotnet-command-runner` | `make test-dotnet`, then `make validate` before PR | yes when host `dotnet` is unavailable | no | moderate |
@@ -26,7 +26,7 @@ Agents must report validation commands and outcomes before claiming completion.
 
 Use changed paths to pick the cheapest sufficient validation:
 
-- `Makefile`, `package.json`, or `scripts/dev/*`: run `make validate`.
+- `Makefile`, `package.json`, or `scripts/dev/*`: run `make validate-summary`.
 - `web/*`: run `make test-ui`.
 - `docs/automation/*`: run `make docs-check` and `git diff --check`.
 - `src/MediaIngest.Worker.CommandRunner/*` or
@@ -36,6 +36,11 @@ Use changed paths to pick the cheapest sufficient validation:
   the component, then `make validate` before PR.
 - Docker or Kubernetes files: use the Docker/Kubernetes rows above and avoid
   cloud validation unless explicitly approved.
+
+For broad commands such as `make validate`, `make test-dotnet`, and
+`make test-ui`, prefer the matching `*-summary` target during agent sessions.
+The summary wrapper writes the full log to `/tmp` and prints the command, exit
+code, key success or failure lines, and log path.
 
 Run `make pr-readiness-check` before reporting PR readiness to print the local
 changed-path summary, state-record status, and validation reminders.

--- a/docs/standards/tooling.md
+++ b/docs/standards/tooling.md
@@ -18,9 +18,15 @@ Use:
 - `make print-install-optional-tools` to inspect optional install commands
   without running them.
 - `make test-dotnet` to build and smoke-test the .NET solution.
+- `make test-dotnet-summary` to build and smoke-test the .NET solution with
+  compact output and a full `/tmp` log during agent sessions.
 - `make test-dotnet-*` for focused .NET smoke tests during inner-loop work.
 - `make validate` for cheap repository validation.
+- `make validate-summary` for cheap repository validation with compact output
+  and a full `/tmp` log during agent sessions.
 - `make validate-docs` and `make validate-automation` for focused validation.
+- `make validate-docs-summary` and `make validate-automation-summary` for
+  focused validation with compact output and a full `/tmp` log.
 - `make docs-fix` to apply safe docs formatting fixes before committing.
 - `make github-projects-script-test` to test legacy GitHub tracker helper
   wrappers without network access.
@@ -30,12 +36,17 @@ Use:
   needed.
 - `make github-project-active` to list active tracker items.
 - `npm run docs:check` for docs placeholder checks.
+- `npm run docs:check:summary` for docs placeholder checks with compact output.
 - `npm run docs:fix` for safe docs formatting fixes.
 - `npm run dotnet:test` for .NET solution validation through npm.
+- `npm run dotnet:test:summary` for .NET solution validation through npm with
+  compact output and a full `/tmp` log.
 - `npm run dotnet:test:<target>` for focused .NET smoke tests.
 - `npm run github-project:script-test` for legacy tracker helper wrapper tests.
 - `npm run tools:check` for host tool checks through npm.
 - `npm run tools:print-install:optional` for optional install command review.
+- `npm run validate:summary` for repo validation through npm with compact
+  output and a full `/tmp` log.
 
 ## Tooling Strategy
 

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -144,6 +144,10 @@
   with semantic topic, raw command body, application properties, and routed
   light/medium/heavy subscription name before local Dapr or in-memory publisher
   delegation.
+- Agent validation now has summary-only entrypoints that keep full logs under
+  `/tmp` while printing command, exit code, key success or failure lines, and
+  log path. Current task capsules live in ignored `.worktrees/state/` records
+  for compact resume context.
 
 ## Next
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -11,6 +11,10 @@ messages or paste command output unless it explains a decision.
   metadata before reaching the generic runner, then map handling outcomes to
   complete, abandon, or dead-letter decisions without Azure SDK dependencies or
   cloud validation.
+- Added summary-only validation mode for broad agent checks, including
+  `make validate-summary`, focused summary targets, a tested
+  `scripts/dev/validation-summary.sh` wrapper, and compact state/handoff
+  guidance for checkpoints, diff inspection, and subagent outputs.
 
 ## 2026-05-04
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Cloud-native media asset ingest backend planning and repository tooling.",
   "scripts": {
     "docs:check": "node scripts/dev/check-docs.mjs",
+    "docs:check:summary": "sh scripts/dev/validation-summary.sh npm run docs:check",
     "docs:fix": "node scripts/dev/check-docs.mjs --fix",
     "dotnet:test:contracts": "sh scripts/dev/test-dotnet.sh contracts",
     "dotnet:test:foundation": "sh scripts/dev/test-dotnet.sh foundation",
@@ -16,6 +17,7 @@
     "dotnet:test:watcher": "sh scripts/dev/test-dotnet.sh watcher",
     "dotnet:test:workflow": "sh scripts/dev/test-dotnet.sh workflow",
     "dotnet:test": "sh scripts/dev/test-dotnet.sh",
+    "dotnet:test:summary": "sh scripts/dev/validation-summary.sh npm run dotnet:test",
     "github-project:active": "sh scripts/dev/github-projects.sh active",
     "github-project:audit-fields": "sh scripts/dev/github-projects.sh audit-fields",
     "github-project:check": "sh scripts/dev/github-projects.sh check-auth",
@@ -23,11 +25,14 @@
     "github-project:issue-body-lint": "sh scripts/dev/github-projects.sh lint-issue-bodies",
     "github-project:script-test": "sh scripts/dev/test-github-projects.sh",
     "github-project:summary": "sh scripts/dev/github-projects.sh summary",
+    "summary-validation:test": "sh scripts/dev/test-summary-validation.sh",
     "pr:readiness": "sh scripts/dev/pr-readiness-check.sh",
     "tools:install:optional": "sh scripts/dev/install-optional-tools.sh",
     "tools:print-install:optional": "sh scripts/dev/install-optional-tools.sh --print-only",
     "tools:check": "sh scripts/dev/check-tools.sh",
-    "ui:test": "node web/ingest-control-plane/node_modules/vitest/vitest.mjs run --root web/ingest-control-plane"
+    "ui:test": "node web/ingest-control-plane/node_modules/vitest/vitest.mjs run --root web/ingest-control-plane",
+    "ui:test:summary": "sh scripts/dev/validation-summary.sh npm run ui:test",
+    "validate:summary": "sh scripts/dev/validation-summary.sh make validate"
   },
   "devDependencies": {}
 }

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -75,6 +75,7 @@ printf '%s\n' "- make scripts-check"
 printf '%s\n' "- make test-dotnet"
 printf '%s\n' "- make test-ui"
 printf '%s\n' "- make validate"
+printf '%s\n' "- make validate-summary"
 printf '%s\n' "- make pr-readiness-check"
 
 printf '\n%s\n' "Focused .NET validation:"

--- a/scripts/dev/pr-readiness-check.sh
+++ b/scripts/dev/pr-readiness-check.sh
@@ -77,7 +77,7 @@ else
   printf '%s\n' "$paths" | while IFS= read -r path; do
     case "$path" in
       Makefile|package.json|scripts/dev/*)
-        printf '%s\n' "- $path: make validate"
+        printf '%s\n' "- $path: make validate-summary"
         ;;
       web/*)
         printf '%s\n' "- $path: make test-ui"
@@ -102,7 +102,7 @@ printf '\n%s\n' "Required before PR:"
 printf '%s\n' "- explicit authorization to push and open PR"
 printf '%s\n' "- local commits are allowed after validation; prefer small scoped commits"
 printf '%s\n' "- intended staged scope only"
-printf '%s\n' "- make validate when command docs, scripts, Makefile targets, contracts, or tooling changed"
+printf '%s\n' "- make validate-summary when command docs, scripts, Makefile targets, contracts, or tooling changed"
 printf '%s\n' "- git diff --check and git diff --cached --check"
 printf '%s\n' "- updated .worktrees/state/<worktree-slug>.md"
 printf '%s\n' "- handoff from docs/automation/agent-handoff.md"

--- a/scripts/dev/test-summary-validation.sh
+++ b/scripts/dev/test-summary-validation.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -eu
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fake_bin="$tmp_dir/bin"
+mkdir -p "$fake_bin"
+
+cat >"$fake_bin/fake-validation" <<'FAKE_VALIDATION'
+#!/bin/sh
+set -eu
+
+printf '%s\n' "Starting validation"
+printf '%s\n' "PASS FoundationSmoke"
+printf '%s\n' "FAIL MediaIngest.Tests.CommandRunnerRoutesHeavyWork"
+printf '%s\n' "Error Message: expected heavy runner route"
+printf '%s\n' "Failed MediaIngest.Tests.ManifestRequiredBeforePackageStart"
+printf '%s\n' "Final line that should remain in the log only"
+exit 23
+FAKE_VALIDATION
+
+cat >"$fake_bin/fake-success" <<'FAKE_SUCCESS'
+#!/bin/sh
+set -eu
+
+printf '%s\n' "Starting validation"
+printf '%s\n' "GitHub Projects helper tests passed."
+printf '%s\n' "Test Run Successful."
+exit 0
+FAKE_SUCCESS
+
+chmod +x "$fake_bin/fake-validation" "$fake_bin/fake-success"
+
+failure_summary="$tmp_dir/failure-summary.txt"
+if PATH="$fake_bin:$PATH" sh scripts/dev/validation-summary.sh fake-validation >"$failure_summary" 2>&1; then
+  printf '%s\n' "Expected summary wrapper to return the wrapped command exit code." >&2
+  exit 1
+fi
+
+grep -F "command: fake-validation" "$failure_summary" >/dev/null
+grep -F "exit code: 23" "$failure_summary" >/dev/null
+grep -F "failing lines:" "$failure_summary" >/dev/null
+grep -F "FAIL MediaIngest.Tests.CommandRunnerRoutesHeavyWork" "$failure_summary" >/dev/null
+grep -F "Failed MediaIngest.Tests.ManifestRequiredBeforePackageStart" "$failure_summary" >/dev/null
+grep -E "^log: /tmp/media-asset-ingest-validation-[^ ]+\\.log$" "$failure_summary" >/dev/null
+log_path=$(sed -n 's/^log: //p' "$failure_summary")
+test -f "$log_path"
+grep -F "Final line that should remain in the log only" "$log_path" >/dev/null
+
+success_summary="$tmp_dir/success-summary.txt"
+PATH="$fake_bin:$PATH" sh scripts/dev/validation-summary.sh fake-success >"$success_summary" 2>&1
+
+grep -F "command: fake-success" "$success_summary" >/dev/null
+grep -F "exit code: 0" "$success_summary" >/dev/null
+grep -F "success lines:" "$success_summary" >/dev/null
+grep -F "GitHub Projects helper tests passed." "$success_summary" >/dev/null
+grep -F "Test Run Successful." "$success_summary" >/dev/null
+grep -E "^log: /tmp/media-asset-ingest-validation-[^ ]+\\.log$" "$success_summary" >/dev/null
+
+printf '%s\n' "Summary validation wrapper tests passed."

--- a/scripts/dev/validation-summary.sh
+++ b/scripts/dev/validation-summary.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -u
+
+if [ "$#" -eq 0 ]; then
+  printf '%s\n' "Usage: sh scripts/dev/validation-summary.sh <command> [args...]" >&2
+  exit 2
+fi
+
+log_file=$(mktemp "${TMPDIR:-/tmp}/media-asset-ingest-validation-XXXXXX.log")
+command_text=$*
+
+"$@" >"$log_file" 2>&1
+exit_code=$?
+
+printf '%s\n' "command: $command_text"
+printf '%s\n' "exit code: $exit_code"
+
+if [ "$exit_code" -eq 0 ]; then
+  success_lines=$(grep -E \
+    "([Tt]ests? passed|[Tt]est [Rr]un [Ss]uccessful|Build succeeded|Validation passed|passed\\.|checks? passed|successful\\.)" \
+    "$log_file" | tail -n 20 || true)
+  if [ -n "$success_lines" ]; then
+    printf '%s\n' "success lines:"
+    printf '%s\n' "$success_lines"
+  else
+    printf '%s\n' "success lines:"
+    tail -n 5 "$log_file"
+  fi
+else
+  failing_lines=$(grep -E \
+    "(^|[[:space:]])(FAIL|Failed|failed|Error Message:|Assertion|Exception|error:|fatal:)" \
+    "$log_file" | tail -n 40 || true)
+  if [ -n "$failing_lines" ]; then
+    printf '%s\n' "failing lines:"
+    printf '%s\n' "$failing_lines"
+  else
+    printf '%s\n' "failing lines:"
+    tail -n 20 "$log_file"
+  fi
+fi
+
+printf '%s\n' "log: $log_file"
+exit "$exit_code"


### PR DESCRIPTION
## Summary
- Adds `scripts/dev/validation-summary.sh` to capture full validation logs under `/tmp` while printing command, exit code, key success or failure lines, and log path.
- Adds Make/npm summary targets, including `make validate-summary`, and tests the wrapper with `scripts/dev/test-summary-validation.sh`.
- Updates automation, tooling, README, status, and work-log docs for compact state capsules, diff-first inspection, checkpointing before long validation, and capped handoffs.

## Linked Work
Refs USER-STORY-16

## Validation
- `make validate-summary`: passed; full log `/tmp/media-asset-ingest-validation-Nbu8cy.log`
- `git diff --check`: passed
- `git diff --cached --check`: passed

## Risk
- Low. This adds wrapper entrypoints and docs only; existing validation targets remain available.

## Follow-up
- None required.