### PR TITLE
TASK-5-3: Add orchestrator graph planning docs

### DIFF
--- a/docs/plans/task-index.md
+++ b/docs/plans/task-index.md
@@ -31,6 +31,10 @@ coordination trail unless a local task file was created or renamed.
 | TASK-6-1 | #34 | Add command execution foundation | Essence | `docs/plans/tasks/TASK-6-1-specialized-agent-skeletons.md` | Completed |
 | TASK-7-1 | #37 | Add observability correlation foundation | Beacon | `docs/plans/tasks/TASK-7-1-observability-correlation.md` | Completed |
 | TASK-8-1 | #33 | Scaffold React workflow control plane | Canvas | `docs/plans/tasks/TASK-8-1-react-control-plane.md` | Completed |
+| TASK-5-3 | #107 | Add workflow orchestrator service | Pulse | `docs/plans/tasks/TASK-5-3-workflow-orchestrator-service.md` | Planned |
+| TASK-5-4 | #108 | Add attribute-discovered workflow definition catalog | Pulse | `docs/plans/tasks/TASK-5-4-workflow-definition-catalog.md` | Planned |
+| TASK-8-5 | #109 | Generate workflow graph DTOs from orchestrator definitions | Canvas | `docs/plans/tasks/TASK-8-5-orchestrator-workflow-graph-projection.md` | Planned |
+| TASK-8-6 | #110 | Show orchestrator wait states and command dependencies in UI | Canvas | `docs/plans/tasks/TASK-8-6-orchestrator-wait-command-ui.md` | Planned |
 
 ## Update Rule
 

--- a/docs/plans/tasks/TASK-5-3-workflow-orchestrator-service.md
+++ b/docs/plans/tasks/TASK-5-3-workflow-orchestrator-service.md
@@ -1,0 +1,164 @@
+# TASK-5-3: Add Workflow Orchestrator Service
+
+## Status
+
+Planned
+
+## Linked Work
+
+- GitHub issue: #107
+- Milestone: MILESTONE-5
+- User stories:
+  - USER-STORY-9
+  - USER-STORY-10
+- Bugs:
+  - None
+
+Native GitHub relationships:
+
+- Parent issue: #19
+- Blocked by: none
+- Blocks: #108, #109
+
+## Ownership
+
+Primary lane: Pulse
+
+Supporting lanes:
+
+- Forge
+- Gauge
+
+## Target Files
+
+Agents may edit only these files unless they escalate:
+
+- `src/MediaIngest.Workflow.Orchestrator`
+- `src/MediaIngest.Workflow`
+- `tests/MediaIngest.Workflow.Tests`
+- `MediaIngest.sln`
+- `deploy/dapr`
+- `deploy/k8s`
+- `docker-compose.yml`
+- `docs/architecture/002-workflow-orchestration.md`
+- `docs/status/work-log.md`
+
+## Investigation Targets
+
+Read before editing:
+
+- `docs/architecture/000-system-overview.md` - confirms Dapr Workflow, Azure Service Bus, PostgreSQL, and workflow UI boundaries.
+- `docs/architecture/002-workflow-orchestration.md` - defines package workflow, child workflow, and Dapr/business state separation.
+- `docs/adr/ADR-0003-use-dapr-workflow.md` - records the accepted code-first Dapr Workflow decision.
+- `src/MediaIngest.Workflow` - current in-process workflow lifecycle and graph projection foundation.
+- `src/MediaIngest.Api/IngestRuntimeService.cs` - current API-local runtime facade that later tasks will call through or replace.
+- Dapr workflow architecture and .NET workflow docs - confirm workflow app registration and runtime-state responsibilities.
+
+## BDD Scenario
+
+```gherkin
+Scenario: Orchestrator hosts package workflow registrations
+  Given the workflow orchestrator service starts
+  When it configures workflow hosting
+  Then the package ingest workflow and activities are registered in the orchestrator boundary
+  And Dapr workflow runtime state remains separate from business PostgreSQL state
+```
+
+## TDD Expectations
+
+RED:
+
+```bash
+make test-dotnet-workflow-summary
+```
+
+Expected before implementation: workflow tests fail because no orchestrator service registration boundary exists.
+
+GREEN:
+
+```bash
+make test-dotnet-workflow-summary
+```
+
+Expected after implementation: workflow tests pass with orchestrator service registration coverage.
+
+REFACTOR:
+
+- Keep `make test-dotnet-workflow-summary` passing after cleanup.
+- Run broader validation before PR readiness because this task changes service/runtime shape.
+
+## Implementation Notes
+
+- Create `MediaIngest.Workflow.Orchestrator` as a standalone bounded-context service for workflow hosting.
+- The service owns workflow definitions, instance orchestration entrypoints, and graph-projection endpoints or application services.
+- Dapr provides durable workflow execution, state, timers, external events, and lifecycle management.
+- Keep PostgreSQL business status, timeline, and audit state separate from Dapr runtime state.
+- Start with package ingest, but keep naming and service boundaries generic enough for multiple workflow definitions.
+- Stop and ask before adding or upgrading Dapr Workflow SDK dependencies.
+- Do not provision Azure resources, create paid cloud assets, or introduce secrets.
+
+## Validation
+
+Minimal validation:
+
+```bash
+make test-dotnet-workflow-summary
+git diff --check
+```
+
+Stronger validation before PR readiness:
+
+```bash
+make validate-summary
+```
+
+## Required Documentation Updates
+
+- `docs/architecture/002-workflow-orchestration.md`
+- `docs/status/work-log.md`
+- `docs/status/current-status.md` when focus or next action changes
+- `docs/product/backlog.md` when task status changes
+- `docs/plans/task-index.md` only if this local task file is renamed or deleted
+
+## Completion Checklist
+
+- [ ] Scope and ownership lane confirmed.
+- [ ] Investigation targets reviewed.
+- [ ] Dependency changes approved before implementation.
+- [ ] BDD scenario confirmed or updated.
+- [ ] Failing test observed before production code, unless exception documented.
+- [ ] Orchestrator service added within target files.
+- [ ] Workflow hosting registration boundary covered by tests.
+- [ ] Dapr runtime state and PostgreSQL business state boundaries documented.
+- [ ] Validation command run and evidence recorded.
+- [ ] Required docs updated.
+- [ ] Handoff result prepared.
+
+## Handoff Result
+
+```text
+status: completed | blocked | escalation-needed
+taskId: TASK-5-3
+github:
+  issues:
+    - #107
+stories:
+  - USER-STORY-9
+  - USER-STORY-10
+filesChanged:
+  - src/MediaIngest.Workflow.Orchestrator
+  - src/MediaIngest.Workflow
+  - tests/MediaIngest.Workflow.Tests
+validation:
+  - command: make test-dotnet-workflow-summary
+    outcome: pass/fail/not-run
+  - command: git diff --check
+    outcome: pass/fail/not-run
+docsUpdated:
+  - docs/architecture/002-workflow-orchestration.md
+  - docs/status/work-log.md
+blockers:
+  - none or details
+next:
+  - Proceed to TASK-5-4 attribute-discovered workflow definition catalog.
+```

--- a/docs/plans/tasks/TASK-5-4-workflow-definition-catalog.md
+++ b/docs/plans/tasks/TASK-5-4-workflow-definition-catalog.md
@@ -1,0 +1,162 @@
+# TASK-5-4: Add Attribute-Discovered Workflow Definition Catalog
+
+## Status
+
+Planned
+
+## Linked Work
+
+- GitHub issue: #108
+- Milestone: MILESTONE-5
+- User stories:
+  - USER-STORY-9
+  - USER-STORY-10
+- Bugs:
+  - None
+
+Native GitHub relationships:
+
+- Parent issue: #19
+- Blocked by: #107
+- Blocks: #109, #110
+
+## Ownership
+
+Primary lane: Pulse
+
+Supporting lanes:
+
+- Beacon
+- Canvas
+
+## Target Files
+
+Agents may edit only these files unless they escalate:
+
+- `src/MediaIngest.Workflow.Orchestrator`
+- `src/MediaIngest.Workflow`
+- `tests/MediaIngest.Workflow.Tests`
+- `docs/architecture/002-workflow-orchestration.md`
+- `docs/architecture/004-observability-and-ui.md`
+- `docs/status/work-log.md`
+
+## Investigation Targets
+
+Read before editing:
+
+- `docs/architecture/002-workflow-orchestration.md` - workflow, child workflow, and state-boundary rules.
+- `docs/architecture/004-observability-and-ui.md` - graph node, status, drilldown, and node-detail projection expectations.
+- `src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs` - current static package graph projection behavior.
+- `src/MediaIngest.Workflow/PreparedChildWork.cs` - current stable child workflow ID contract.
+- `src/MediaIngest.Contracts/Workflow` - shared UI graph DTO contract that later projection tasks must preserve.
+
+## BDD Scenario
+
+```gherkin
+Scenario: Startup discovers package ingest workflow topology
+  Given workflow and activity code is annotated with topology metadata
+  When the orchestrator builds the workflow definition catalog at startup
+  Then the package ingest workflow definition contains stable nodes, edges, child workflows, waits, and command dispatch points
+  And duplicate or missing node identifiers fail startup validation
+```
+
+## TDD Expectations
+
+RED:
+
+```bash
+make test-dotnet-workflow-summary
+```
+
+Expected before implementation: catalog discovery tests fail because topology attributes and catalog validation do not exist.
+
+GREEN:
+
+```bash
+make test-dotnet-workflow-summary
+```
+
+Expected after implementation: workflow catalog tests pass for discovery, stable package graph metadata, child workflow IDs, and validation failures.
+
+REFACTOR:
+
+- Keep `make test-dotnet-workflow-summary` passing after cleanup.
+- Keep topology metadata readable from class or method annotations without method-body analysis.
+
+## Implementation Notes
+
+- Add attribute-based compile-time topology metadata for workflow, activity, wait, command dispatch, and child-workflow nodes.
+- Capture stable node IDs, display names, node kinds, ordering or dependency edges, wait points, command dispatch points, and child workflow references.
+- Use startup reflection to scan known orchestrator workflow assemblies into an in-memory workflow definition catalog.
+- Fail fast on missing required node IDs, duplicate node IDs within a workflow definition, duplicate definition IDs or versions, and edges that reference unknown nodes.
+- Avoid workflow method-body analysis in this slice.
+- Keep the definition source as compiled code plus attributes, not DB-authored workflows.
+- Keep the first definition package ingest, but do not hard-code catalog internals to package-only concepts.
+
+## Validation
+
+Minimal validation:
+
+```bash
+make test-dotnet-workflow-summary
+git diff --check
+```
+
+Stronger validation before PR readiness:
+
+```bash
+make validate-summary
+```
+
+## Required Documentation Updates
+
+- `docs/architecture/002-workflow-orchestration.md`
+- `docs/architecture/004-observability-and-ui.md`
+- `docs/status/work-log.md`
+- `docs/status/current-status.md` when focus or next action changes
+- `docs/product/backlog.md` when task status changes
+- `docs/plans/task-index.md` only if this local task file is renamed or deleted
+
+## Completion Checklist
+
+- [ ] Scope and ownership lane confirmed.
+- [ ] Investigation targets reviewed.
+- [ ] BDD scenario confirmed or updated.
+- [ ] Failing catalog discovery test observed before production code, unless exception documented.
+- [ ] Topology attributes added.
+- [ ] Startup reflection discovery added.
+- [ ] Catalog validation covers duplicate and missing IDs.
+- [ ] Package ingest definition contains stable nodes, edges, child workflow references, waits, and command dispatch points.
+- [ ] Validation command run and evidence recorded.
+- [ ] Required docs updated.
+- [ ] Handoff result prepared.
+
+## Handoff Result
+
+```text
+status: completed | blocked | escalation-needed
+taskId: TASK-5-4
+github:
+  issues:
+    - #108
+stories:
+  - USER-STORY-9
+  - USER-STORY-10
+filesChanged:
+  - src/MediaIngest.Workflow.Orchestrator
+  - src/MediaIngest.Workflow
+  - tests/MediaIngest.Workflow.Tests
+validation:
+  - command: make test-dotnet-workflow-summary
+    outcome: pass/fail/not-run
+  - command: git diff --check
+    outcome: pass/fail/not-run
+docsUpdated:
+  - docs/architecture/002-workflow-orchestration.md
+  - docs/architecture/004-observability-and-ui.md
+  - docs/status/work-log.md
+blockers:
+  - none or details
+next:
+  - Proceed to TASK-8-5 orchestrator-backed WorkflowGraphDto projection.
+```

--- a/docs/plans/tasks/TASK-8-5-orchestrator-workflow-graph-projection.md
+++ b/docs/plans/tasks/TASK-8-5-orchestrator-workflow-graph-projection.md
@@ -1,0 +1,176 @@
+# TASK-8-5: Generate Workflow Graph DTOs From Orchestrator Definitions
+
+## Status
+
+Planned
+
+## Linked Work
+
+- GitHub issue: #109
+- Milestone: MILESTONE-8
+- User stories:
+  - USER-STORY-12
+  - USER-STORY-14
+  - USER-STORY-15
+- Bugs:
+  - None
+
+Native GitHub relationships:
+
+- Parent issue: #22
+- Blocked by: #107, #108
+- Blocks: #110
+
+## Ownership
+
+Primary lane: Canvas
+
+Supporting lanes:
+
+- Pulse
+- Gauge
+- Beacon
+
+## Target Files
+
+Agents may edit only these files unless they escalate:
+
+- `src/MediaIngest.Workflow.Orchestrator`
+- `src/MediaIngest.Workflow`
+- `src/MediaIngest.Api`
+- `src/MediaIngest.Contracts/Workflow`
+- `tests/MediaIngest.Workflow.Tests`
+- `tests/MediaIngest.Api.Tests`
+- `web/ingest-control-plane`
+- `docs/architecture/004-observability-and-ui.md`
+- `docs/status/work-log.md`
+
+## Investigation Targets
+
+Read before editing:
+
+- `src/MediaIngest.Contracts/Workflow/WorkflowGraphDto.cs` - UI graph contract that must remain stable.
+- `src/MediaIngest.Contracts/Workflow/WorkflowNodeDto.cs` - node fields for child workflow and work-item correlation.
+- `src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs` - current graph projection that should be replaced or narrowed.
+- `src/MediaIngest.Api/IngestRuntimeService.cs` - current API-local graph construction and runtime facade.
+- `web/ingest-control-plane/src/workflowGraph.ts` - current UI graph fetch and rendering model.
+- `docs/architecture/004-observability-and-ui.md` - UI projection, drilldown, and node-detail expectations.
+
+## BDD Scenario
+
+```gherkin
+Scenario: API returns orchestrator-generated workflow graph
+  Given a package workflow instance exists
+  And the orchestrator catalog contains the package ingest workflow definition
+  When the UI facade requests the workflow graph
+  Then the API returns a WorkflowGraphDto generated from orchestrator-owned definition metadata
+  And API-local topology construction is not used
+```
+
+## TDD Expectations
+
+RED:
+
+```bash
+make test-dotnet-api-summary
+```
+
+Expected before implementation: API tests fail because the graph endpoint does not call an orchestrator-backed graph projection.
+
+GREEN:
+
+```bash
+make test-dotnet-api-summary
+make test-dotnet-workflow-summary
+```
+
+Expected after implementation: API and workflow graph tests pass with orchestrator-generated definition and instance graphs.
+
+REFACTOR:
+
+- Keep `WorkflowGraphDto` as the UI contract.
+- Keep unknown workflow instances returning not found.
+- Keep node details backed by existing timeline and log DTO paths.
+
+## Implementation Notes
+
+- Generate definition graphs from orchestrator-owned workflow definition metadata.
+- Generate instance graphs from the same topology overlaid with runtime status from Dapr workflow state and business progress projections.
+- Attach dynamic command work-item nodes at descriptor-defined command dispatch or wait sections.
+- Keep the control-plane API as the UI facade: `GET /api/workflows/{workflowInstanceId}/graph` continues to be the UI entrypoint.
+- The API should call the orchestrator service and forward or lightly overlay `WorkflowGraphDto`.
+- Remove or retire API-local hard-coded graph generation from `IngestRuntimeService`.
+- Preserve child workflow drilldown identifiers already represented by `childWorkflowInstanceId`.
+
+## Validation
+
+Minimal validation:
+
+```bash
+make test-dotnet-api-summary
+make test-dotnet-workflow-summary
+git diff --check
+```
+
+Stronger validation before PR readiness:
+
+```bash
+make validate-summary
+```
+
+## Required Documentation Updates
+
+- `docs/architecture/004-observability-and-ui.md`
+- `docs/status/work-log.md`
+- `docs/status/current-status.md` when focus or next action changes
+- `docs/product/backlog.md` when task status changes
+- `docs/plans/task-index.md` only if this local task file is renamed or deleted
+
+## Completion Checklist
+
+- [ ] Scope and ownership lane confirmed.
+- [ ] Investigation targets reviewed.
+- [ ] BDD scenario confirmed or updated.
+- [ ] Failing API graph test observed before production code, unless exception documented.
+- [ ] Orchestrator exposes definition graph projection.
+- [ ] Orchestrator exposes instance graph projection.
+- [ ] API graph endpoint uses orchestrator-backed projection.
+- [ ] API-local topology construction removed or made non-authoritative.
+- [ ] Unknown workflow instance still returns not found.
+- [ ] Validation command run and evidence recorded.
+- [ ] Required docs updated.
+- [ ] Handoff result prepared.
+
+## Handoff Result
+
+```text
+status: completed | blocked | escalation-needed
+taskId: TASK-8-5
+github:
+  issues:
+    - #109
+stories:
+  - USER-STORY-12
+  - USER-STORY-14
+  - USER-STORY-15
+filesChanged:
+  - src/MediaIngest.Workflow.Orchestrator
+  - src/MediaIngest.Workflow
+  - src/MediaIngest.Api
+  - tests/MediaIngest.Api.Tests
+  - tests/MediaIngest.Workflow.Tests
+validation:
+  - command: make test-dotnet-api-summary
+    outcome: pass/fail/not-run
+  - command: make test-dotnet-workflow-summary
+    outcome: pass/fail/not-run
+  - command: git diff --check
+    outcome: pass/fail/not-run
+docsUpdated:
+  - docs/architecture/004-observability-and-ui.md
+  - docs/status/work-log.md
+blockers:
+  - none or details
+next:
+  - Proceed to TASK-8-6 UI rendering for waits and command dependencies.
+```

--- a/docs/plans/tasks/TASK-8-6-orchestrator-wait-command-ui.md
+++ b/docs/plans/tasks/TASK-8-6-orchestrator-wait-command-ui.md
@@ -1,0 +1,167 @@
+# TASK-8-6: Show Orchestrator Wait States And Command Dependencies In UI
+
+## Status
+
+Planned
+
+## Linked Work
+
+- GitHub issue: #110
+- Milestone: MILESTONE-8
+- User stories:
+  - USER-STORY-12
+  - USER-STORY-13
+  - USER-STORY-14
+  - USER-STORY-15
+- Bugs:
+  - None
+
+Native GitHub relationships:
+
+- Parent issue: #22
+- Blocked by: #108, #109
+- Blocks: none
+
+## Ownership
+
+Primary lane: Canvas
+
+Supporting lanes:
+
+- Pulse
+- Beacon
+
+## Target Files
+
+Agents may edit only these files unless they escalate:
+
+- `web/ingest-control-plane`
+- `src/MediaIngest.Contracts/Workflow`
+- `src/MediaIngest.Api`
+- `tests/MediaIngest.Api.Tests`
+- `docs/architecture/004-observability-and-ui.md`
+- `docs/status/work-log.md`
+
+## Investigation Targets
+
+Read before editing:
+
+- `web/ingest-control-plane/src/workflowGraph.ts` - Mermaid graph rendering and UI projection code.
+- `web/ingest-control-plane/src/workflowGraph.test.ts` - focused UI graph tests.
+- `src/MediaIngest.Contracts/Workflow/WorkflowNodeKind.cs` - shared node-kind contract.
+- `src/MediaIngest.Contracts/Workflow/WorkflowNodeStatus.cs` - shared node-status contract.
+- `src/MediaIngest.Contracts/Workflow/WorkflowNodeDetailsDto.cs` - node detail contract for timeline and log drilldown.
+- `docs/architecture/004-observability-and-ui.md` - graph rendering, drilldown, back navigation, and node-detail expectations.
+
+## BDD Scenario
+
+```gherkin
+Scenario: Operator sees waits and command dependencies in the workflow graph
+  Given an orchestrator-generated package workflow graph contains activity, child workflow, wait, command dispatch, command completion, and finalization nodes
+  When the React control plane renders the graph
+  Then the Mermaid diagram displays those nodes and dependency edges
+  And selecting a node still shows timeline and log details
+  And child workflow drilldown and back navigation still work
+```
+
+## TDD Expectations
+
+RED:
+
+```bash
+make test-ui
+```
+
+Expected before implementation: UI tests fail because wait nodes, command dependency nodes, or descriptor-driven graph nodes are not rendered or asserted.
+
+GREEN:
+
+```bash
+make test-ui
+```
+
+Expected after implementation: UI tests pass for wait nodes, child workflow nodes, command nodes, drilldown, node details, and back navigation.
+
+REFACTOR:
+
+- Keep the Mermaid diagram as the single workflow graph visualization.
+- Keep UI rendering driven by `WorkflowGraphDto`; do not add UI-local topology reconstruction.
+
+## Implementation Notes
+
+- Render activity, child workflow, wait, command dispatch, command completion, and finalization nodes from orchestrator-generated graph DTOs.
+- Use existing shared node status colors and accessible node activation behavior.
+- Preserve timeline and log detail panes for selected nodes.
+- Preserve child workflow drilldown and parent back navigation.
+- Add contract changes only if existing `WorkflowNodeKind` or `WorkflowNodeStatus` cannot express waits or command dependency sections; keep changes backward-compatible for existing graph DTOs.
+- Do not add SignalR or live push in this slice; polling remains sufficient.
+
+## Validation
+
+Minimal validation:
+
+```bash
+make test-ui
+git diff --check
+```
+
+Stronger validation before PR readiness:
+
+```bash
+make validate-summary
+```
+
+## Required Documentation Updates
+
+- `docs/architecture/004-observability-and-ui.md`
+- `docs/status/work-log.md`
+- `docs/status/current-status.md` when focus or next action changes
+- `docs/product/backlog.md` when task status changes
+- `docs/plans/task-index.md` only if this local task file is renamed or deleted
+
+## Completion Checklist
+
+- [ ] Scope and ownership lane confirmed.
+- [ ] Investigation targets reviewed.
+- [ ] BDD scenario confirmed or updated.
+- [ ] Failing UI test observed before production code, unless exception documented.
+- [ ] Mermaid renders wait nodes.
+- [ ] Mermaid renders child workflow nodes.
+- [ ] Mermaid renders command dispatch and command completion dependency nodes.
+- [ ] Node details still show timeline and log DTO data.
+- [ ] Child workflow drilldown and back navigation still work.
+- [ ] Validation command run and evidence recorded.
+- [ ] Required docs updated.
+- [ ] Handoff result prepared.
+
+## Handoff Result
+
+```text
+status: completed | blocked | escalation-needed
+taskId: TASK-8-6
+github:
+  issues:
+    - #110
+stories:
+  - USER-STORY-12
+  - USER-STORY-13
+  - USER-STORY-14
+  - USER-STORY-15
+filesChanged:
+  - web/ingest-control-plane
+  - src/MediaIngest.Contracts/Workflow
+  - src/MediaIngest.Api
+  - tests/MediaIngest.Api.Tests
+validation:
+  - command: make test-ui
+    outcome: pass/fail/not-run
+  - command: git diff --check
+    outcome: pass/fail/not-run
+docsUpdated:
+  - docs/architecture/004-observability-and-ui.md
+  - docs/status/work-log.md
+blockers:
+  - none or details
+next:
+  - Use the orchestrator-backed graph as the baseline for future runtime status and diagnostics work.
+```

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -60,6 +60,9 @@ epic/story granularity; detailed implementation tasks belong in plans.
 
 - MILESTONE-2 / USER-STORY-16: plan the next Docker-first local runtime
   validation slice beyond static Compose checks.
+- MILESTONE-5 / USER-STORY-9 / USER-STORY-10 and MILESTONE-8 /
+  USER-STORY-12 through USER-STORY-15: implement the workflow orchestrator graph
+  discovery plan through TASK-5-3, TASK-5-4, TASK-8-5, and TASK-8-6.
 ## Later
 
 - MILESTONE-6 / USER-STORY-7: connect generic command runners to Azure Service

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -151,8 +151,11 @@
 
 ## Next
 
-- Plan the next runtime slice: live Azure Service Bus SDK receiving, richer
-  node log/timeline data sources, or deeper local container runtime validation.
+- Implement the workflow orchestrator graph discovery plan: TASK-5-3 adds the
+  standalone orchestrator service, TASK-5-4 adds the attribute-discovered
+  workflow definition catalog, TASK-8-5 generates `WorkflowGraphDto` from
+  orchestrator definitions, and TASK-8-6 renders orchestrator waits and command
+  dependencies in the UI.
 
 ## Update Rule
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -5,6 +5,11 @@ messages or paste command output unless it explains a decision.
 
 ## 2026-05-06
 
+- Added local planning docs for the workflow orchestrator graph discovery
+  slice: TASK-5-3, TASK-5-4, TASK-8-5, and TASK-8-6 now cover the standalone
+  orchestrator service, attribute-discovered workflow definition catalog,
+  orchestrator-backed `WorkflowGraphDto` generation, and UI rendering for waits
+  plus command dependencies.
 - Added a local Azure-shaped command-runner consumption boundary for
   USER-STORY-7 and USER-STORY-16: broker-shaped command messages now validate
   semantic topic, subscription, `executionClass`, and required envelope-shape


### PR DESCRIPTION
## Summary

- Adds local task docs for TASK-5-3, TASK-5-4, TASK-8-5, and TASK-8-6.
- Updates the local task index, backlog, current status, and work log to point at the orchestrator graph discovery plan.
- Links the local task docs to GitHub issues #107, #108, #109, and #110.

## Validation

- make docs-check passed.
- git diff --check passed.

Refs #107
Refs #108
Refs #109
Refs #110