### PR TITLE
USER-STORY-16: Prefer relative agent paths

### DIFF
--- a/docs/automation/agent-handoff.md
+++ b/docs/automation/agent-handoff.md
@@ -1,6 +1,9 @@
 # Agent Handoff
 
 Every implementation, review, or bug-fix agent should return a concise handoff.
+Use repo-relative paths in handoffs. Do not include workstation-specific
+absolute paths unless reporting an environment-specific failure where the exact
+path is evidence.
 
 ## Required Handoff Format
 

--- a/docs/automation/github-projects.md
+++ b/docs/automation/github-projects.md
@@ -89,6 +89,6 @@ needs inspection, but it is not required for every task.
 
 ## CLI Notes
 
-The GitHub CLI stores the token in `~/.config/gh/hosts.yml` because the local
-credential store is not available in this environment. Do not commit or print
-that file.
+The GitHub CLI stores the token in the user's home-directory host config because
+the local credential store is not available in this environment. Do not commit
+or print that file.

--- a/docs/automation/guardrails.md
+++ b/docs/automation/guardrails.md
@@ -10,6 +10,12 @@
 - Do not add large docs without updating the relevant index or read order.
 - Keep human and agent documentation lanes separate.
 - Keep detailed ephemeral planning in ignored `.worktrees/state/` records. Commit only compact durable plans under `docs/plans`; do not use ignored or generated planning artifacts as durable repo docs.
+- Use repo-relative paths in committed docs, scripts, handoffs, and local state
+  records. Do not write workstation-specific absolute paths, home-directory
+  shortcuts, or hypervisor/shared-folder paths unless the task is explicitly
+  documenting a local environment problem. Absolute paths are acceptable only
+  for external runtime locations such as temporary validation logs or documented
+  container mount points.
 - Preserve useful existing docs; move or summarize only when clearly misplaced, stale, duplicate, or unsafe.
 - Prefer durable business state over log scraping for UI behavior.
 - Use `workflowInstanceId`, `packageId`, `fileId`, `workItemId`, and `nodeId`

--- a/docs/automation/state-record-template.md
+++ b/docs/automation/state-record-template.md
@@ -4,6 +4,8 @@ Use one ignored local state record per active worktree:
 `.worktrees/state/<worktree-slug>.md`.
 
 State records are local coordination checkpoints. Do not commit them.
+Use repo-relative paths in state records; avoid workstation-specific absolute
+paths, home-directory shortcuts, and hypervisor/shared-folder paths.
 
 ```markdown
 # <worktree-slug>


### PR DESCRIPTION
## Summary

- Adds automation guardrails requiring repo-relative paths in committed docs, scripts, handoffs, and local state records.
- Updates state-record and handoff templates so future agents avoid workstation-specific absolute paths unless the exact local path is evidence for an environment failure.
- Removes a literal home-directory GitHub CLI config path from automation docs.

Refs #26

## Validation

- `make validate-summary` passed. Log: `/tmp/media-asset-ingest-validation-TWLIB1.log`
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Hard-path scans for workstation paths returned no matches in tracked files or `.worktrees/state`.
- `make pr-readiness-check` reported no staged, unstaged, or untracked tracked-content changes after commit.

## Risk

Low. Documentation and agent-process guidance only; no runtime code changed.

## Follow-up

- Leave documented container/runtime mount paths intact, such as ingest and work mount examples.