### PR TITLE
TASK-8-5: Project workflow graphs from orchestrator

### DIFF
--- a/docs/architecture/004-observability-and-ui.md
+++ b/docs/architecture/004-observability-and-ui.md
@@ -52,6 +52,13 @@ Orchestrator workflow definitions are the durable source for static graph
 topology; API projections overlay business status and command work-item
 instances on top of that topology.
 
+The API remains the UI facade for `GET /api/workflows/{workflowInstanceId}/graph`.
+It does not own static package workflow topology. Instead, it calls the
+orchestrator-backed graph projector and overlays local business status plus
+persisted command outbox envelopes as dynamic work-item nodes between command
+dispatch and command-completion wait points. Unknown workflow instance IDs keep
+returning not found.
+
 Node states:
 
 - pending: grey

--- a/docs/plans/tasks/TASK-8-5-orchestrator-workflow-graph-projection.md
+++ b/docs/plans/tasks/TASK-8-5-orchestrator-workflow-graph-projection.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Planned
+In Progress
 
 ## Linked Work
 
@@ -101,6 +101,9 @@ REFACTOR:
 - The API should call the orchestrator service and forward or lightly overlay `WorkflowGraphDto`.
 - Remove or retire API-local hard-coded graph generation from `IngestRuntimeService`.
 - Preserve child workflow drilldown identifiers already represented by `childWorkflowInstanceId`.
+- In the local foundation, the overlay uses business package status and
+  persisted command outbox envelopes while real Dapr workflow runtime status
+  remains deferred with SDK hosting.
 
 ## Validation
 
@@ -109,6 +112,7 @@ Minimal validation:
 ```bash
 make test-dotnet-api-summary
 make test-dotnet-workflow-summary
+make test-dotnet-contracts
 git diff --check
 ```
 

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -62,6 +62,9 @@ epic/story granularity; detailed implementation tasks belong in plans.
 - MILESTONE-5 / USER-STORY-9 / USER-STORY-10: add attribute-discovered
   orchestrator workflow topology metadata and validation for package ingest
   nodes, waits, command dispatch/completion, child workflows, and finalization.
+- MILESTONE-8 / USER-STORY-12 / USER-STORY-14 / USER-STORY-15: generate API
+  workflow graph DTOs from orchestrator-owned topology metadata, with dynamic
+  command work-item nodes overlaid from persisted command outbox envelopes.
 
 ## Ready For Planning
 
@@ -69,7 +72,7 @@ epic/story granularity; detailed implementation tasks belong in plans.
   validation slice beyond static Compose checks.
 - MILESTONE-5 / USER-STORY-9 / USER-STORY-10 and MILESTONE-8 /
   USER-STORY-12 through USER-STORY-15: continue the workflow orchestrator graph
-  discovery stack with TASK-8-5 and TASK-8-6.
+  discovery stack with TASK-8-6.
 ## Later
 
 - MILESTONE-6 / USER-STORY-7: connect generic command runners to Azure Service

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -147,6 +147,9 @@
   orchestrator boundary, including package ingest topology metadata for waits,
   command dispatch/completion, child workflows, and finalization plus catalog
   validation for duplicate nodes, invalid edges, and missing metadata.
+- TASK-8-5 added an orchestrator-backed workflow graph projector and wired the
+  API workflow graph facade to project package graphs from catalog metadata
+  overlaid with business package status and dynamic command work-item nodes.
 - TASK-4-4 defined the Service Bus command-bus adapter boundary in the outbox
   worker. Command publish requests now map to a broker-oriented message shape
   with semantic topic, raw command body, application properties, and routed
@@ -159,9 +162,8 @@
 
 ## Next
 
-- Continue the workflow orchestrator graph discovery stack: TASK-8-5 generates
-  `WorkflowGraphDto` from orchestrator definitions, and TASK-8-6 renders
-  orchestrator waits and command dependencies in the UI.
+- Continue the workflow orchestrator graph discovery stack with TASK-8-6:
+  render orchestrator waits and command dependencies in the UI.
 
 ## Update Rule
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -13,6 +13,10 @@ messages or paste command output unless it explains a decision.
   package ingest topology with attributes, validates duplicate and invalid
   metadata during reflection discovery, and extends node kinds for waits,
   command dispatch, command completion, and finalization.
+- Added TASK-8-5 orchestrator graph projection: the API graph endpoint now uses
+  orchestrator definition metadata plus business status and command outbox
+  overlay instead of API-local static topology construction, while preserving
+  not-found behavior for unknown workflow instances.
 - Added local planning docs for the workflow orchestrator graph discovery
   slice: TASK-5-3, TASK-5-4, TASK-8-5, and TASK-8-6 now cover the standalone
   orchestrator service, attribute-discovered workflow definition catalog,

--- a/src/MediaIngest.Api/IngestApiApplication.cs
+++ b/src/MediaIngest.Api/IngestApiApplication.cs
@@ -2,6 +2,7 @@ using MediaIngest.Persistence;
 using MediaIngest.Worker.Outbox;
 using MediaIngest.Worker.Watcher;
 using MediaIngest.Workflow;
+using MediaIngest.Workflow.Orchestrator;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -83,6 +84,7 @@ public sealed class IngestApiApplication : IAsyncDisposable
         services.AddSingleton<IngestMountScanner>();
         services.AddSingleton<ManifestReadinessGate>();
         services.AddSingleton<PackageWorkflowStarter>();
+        services.AddSingleton(WorkflowGraphProjector.CreateDefault());
         services.AddSingleton<InMemoryIngestPersistenceStore>();
         services.AddSingleton<IIngestPersistenceStore>(serviceProvider =>
             serviceProvider.GetRequiredService<InMemoryIngestPersistenceStore>());

--- a/src/MediaIngest.Api/IngestRuntimeService.cs
+++ b/src/MediaIngest.Api/IngestRuntimeService.cs
@@ -6,6 +6,7 @@ using MediaIngest.Persistence;
 using MediaIngest.Worker.Outbox;
 using MediaIngest.Worker.Watcher;
 using MediaIngest.Workflow;
+using MediaIngest.Workflow.Orchestrator;
 
 namespace MediaIngest.Api;
 
@@ -14,6 +15,7 @@ public sealed class IngestRuntimeService(
     IngestMountScanner scanner,
     ManifestReadinessGate readinessGate,
     PackageWorkflowStarter workflowStarter,
+    WorkflowGraphProjector workflowGraphProjector,
     InMemoryIngestPersistenceStore store,
     OutboxDispatcher outboxDispatcher) : IAsyncDisposable
 {
@@ -386,10 +388,13 @@ public sealed class IngestRuntimeService(
 
         return packageState is null
             ? null
-            : CreateWorkflowGraph(
-                packageState.PackageId,
-                packageState.WorkflowInstanceId,
-                packageState.Status);
+            : workflowGraphProjector.ProjectInstance(new WorkflowGraphProjectionRequest(
+                WorkflowName: WorkflowContractNames.PackageIngestWorkflow,
+                WorkflowInstanceId: packageState.WorkflowInstanceId,
+                PackageId: packageState.PackageId,
+                Status: MapPackageStatus(packageState.Status),
+                ParentWorkflowInstanceId: null,
+                CommandWorkItems: GetMediaCommandWorkItems(packageState.PackageId).ToArray()));
     }
 
     public WorkflowNodeDetailsDto? GetWorkflowNodeDetails(string workflowInstanceId, string nodeId)
@@ -549,44 +554,7 @@ public sealed class IngestRuntimeService(
         return $"{commandName} {packageRelativePath}";
     }
 
-    private WorkflowGraphDto CreateWorkflowGraph(
-        string packageId,
-        string workflowInstanceId,
-        string status)
-    {
-        var workflowStatus = MapPackageStatus(status);
-        var nodes = new List<WorkflowNodeDto>
-        {
-            CreateWorkflowNode("package-start", "Package ingest", WorkflowNodeKind.WorkflowStep, workflowStatus, workflowInstanceId, packageId, null),
-            CreateWorkflowNode("scan-package", "Package scan", WorkflowNodeKind.Activity, workflowStatus, workflowInstanceId, packageId, "scan-package"),
-            CreateWorkflowNode("classify-files", "Classify discovered files", WorkflowNodeKind.Activity, workflowStatus, workflowInstanceId, packageId, "classify-files"),
-            CreateWorkflowNode("dispatch-processing", "Dispatch processing work", WorkflowNodeKind.Activity, workflowStatus, workflowInstanceId, packageId, "dispatch-processing")
-        };
-
-        nodes.AddRange(GetMediaCommandEnvelopes(packageId)
-            .OrderBy(command => command.InputPaths.SingleOrDefault() ?? command.CommandId, StringComparer.Ordinal)
-            .Select(command => CreateWorkflowNode(
-                $"command-{SanitizeIdentifier(GetPackageRelativeCommandPath(command, packageId))}",
-                CreateCommandDisplayName(command),
-                WorkflowNodeKind.WorkItem,
-                workflowStatus,
-                workflowInstanceId,
-                packageId,
-                command.CommandId)));
-
-        nodes.Add(CreateWorkflowNode("reconcile-package", "Reconcile package", WorkflowNodeKind.Activity, workflowStatus, workflowInstanceId, packageId, "reconcile-package"));
-        nodes.Add(CreateWorkflowNode("finalize-package", "Finalize package", WorkflowNodeKind.Activity, workflowStatus, workflowInstanceId, packageId, "finalize-package"));
-
-        return new WorkflowGraphDto(
-            WorkflowInstanceId: workflowInstanceId,
-            WorkflowName: WorkflowContractNames.PackageIngestWorkflow,
-            PackageId: packageId,
-            ParentWorkflowInstanceId: null,
-            Nodes: nodes,
-            Edges: CreateLinearEdges(nodes));
-    }
-
-    private IEnumerable<MediaCommandEnvelope> GetMediaCommandEnvelopes(string packageId)
+    private IEnumerable<WorkflowCommandWorkItem> GetMediaCommandWorkItems(string packageId)
     {
         var correlationId = $"correlation-{packageId}";
 
@@ -596,37 +564,12 @@ public sealed class IngestRuntimeService(
                 && string.Equals(message.CorrelationId, correlationId, StringComparison.Ordinal))
             .Select(message => JsonSerializer.Deserialize<MediaCommandEnvelope>(message.PayloadJson))
             .Where(command => command is not null)
-            .Cast<MediaCommandEnvelope>();
-    }
-
-    private static WorkflowNodeDto CreateWorkflowNode(
-        string nodeId,
-        string displayName,
-        WorkflowNodeKind kind,
-        WorkflowNodeStatus status,
-        string workflowInstanceId,
-        string packageId,
-        string? workItemId)
-    {
-        return new WorkflowNodeDto(
-            NodeId: nodeId,
-            DisplayName: displayName,
-            Kind: kind,
-            Status: status,
-            WorkflowInstanceId: workflowInstanceId,
-            PackageId: packageId,
-            WorkItemId: workItemId,
-            ChildWorkflowInstanceId: null);
-    }
-
-    private static WorkflowEdgeDto[] CreateLinearEdges(IReadOnlyList<WorkflowNodeDto> nodes)
-    {
-        return nodes
-            .Zip(nodes.Skip(1), (source, target) => new WorkflowEdgeDto(
-                EdgeId: $"{source.NodeId}-{target.NodeId}",
-                SourceNodeId: source.NodeId,
-                TargetNodeId: target.NodeId))
-            .ToArray();
+            .Cast<MediaCommandEnvelope>()
+            .OrderBy(command => command.InputPaths.SingleOrDefault() ?? command.CommandId, StringComparer.Ordinal)
+            .Select(command => new WorkflowCommandWorkItem(
+                NodeId: $"command-{SanitizeIdentifier(GetPackageRelativeCommandPath(command, packageId))}",
+                DisplayName: CreateCommandDisplayName(command),
+                WorkItemId: command.CommandId));
     }
 
     private static WorkflowNodeStatus MapPackageStatus(string status)

--- a/src/MediaIngest.Api/MediaIngest.Api.csproj
+++ b/src/MediaIngest.Api/MediaIngest.Api.csproj
@@ -12,5 +12,6 @@
     <ProjectReference Include="../MediaIngest.Worker.Outbox/MediaIngest.Worker.Outbox.csproj" />
     <ProjectReference Include="../MediaIngest.Worker.Watcher/MediaIngest.Worker.Watcher.csproj" />
     <ProjectReference Include="../MediaIngest.Workflow/MediaIngest.Workflow.csproj" />
+    <ProjectReference Include="../MediaIngest.Workflow.Orchestrator/MediaIngest.Workflow.Orchestrator.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MediaIngest.Workflow.Orchestrator/WorkflowGraphProjector.cs
+++ b/src/MediaIngest.Workflow.Orchestrator/WorkflowGraphProjector.cs
@@ -1,0 +1,137 @@
+using MediaIngest.Contracts.Workflow;
+
+namespace MediaIngest.Workflow.Orchestrator;
+
+public sealed class WorkflowGraphProjector(WorkflowDefinitionCatalog catalog)
+{
+    public static WorkflowGraphProjector CreateDefault()
+    {
+        return new WorkflowGraphProjector(WorkflowDefinitionCatalog.Discover(typeof(PackageIngestWorkflowDefinition).Assembly));
+    }
+
+    public WorkflowGraphDto ProjectDefinition(string workflowName)
+    {
+        var definition = catalog.GetRequired(workflowName);
+
+        return ProjectInstance(new WorkflowGraphProjectionRequest(
+            WorkflowName: definition.WorkflowName,
+            WorkflowInstanceId: $"definition-{definition.WorkflowName}",
+            PackageId: "definition",
+            Status: WorkflowNodeStatus.Pending,
+            ParentWorkflowInstanceId: null,
+            CommandWorkItems: []));
+    }
+
+    public WorkflowGraphDto ProjectInstance(WorkflowGraphProjectionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var definition = catalog.GetRequired(request.WorkflowName);
+        var commandWorkItems = request.CommandWorkItems.ToArray();
+        var nodes = new List<WorkflowNodeDto>();
+
+        foreach (var definitionNode in definition.Nodes)
+        {
+            if (definitionNode.NodeId == "command-work")
+            {
+                nodes.AddRange(commandWorkItems.Select(item => new WorkflowNodeDto(
+                    NodeId: item.NodeId,
+                    DisplayName: item.DisplayName,
+                    Kind: WorkflowNodeKind.WorkItem,
+                    Status: request.Status,
+                    WorkflowInstanceId: request.WorkflowInstanceId,
+                    PackageId: request.PackageId,
+                    WorkItemId: item.WorkItemId,
+                    ChildWorkflowInstanceId: null)));
+                continue;
+            }
+
+            nodes.Add(new WorkflowNodeDto(
+                NodeId: definitionNode.NodeId,
+                DisplayName: definitionNode.DisplayName,
+                Kind: definitionNode.Kind,
+                Status: request.Status,
+                WorkflowInstanceId: request.WorkflowInstanceId,
+                PackageId: request.PackageId,
+                WorkItemId: CreateWorkItemId(definitionNode),
+                ChildWorkflowInstanceId: CreateChildWorkflowInstanceId(request.WorkflowInstanceId, definitionNode)));
+        }
+
+        return new WorkflowGraphDto(
+            WorkflowInstanceId: request.WorkflowInstanceId,
+            WorkflowName: definition.WorkflowName,
+            PackageId: request.PackageId,
+            ParentWorkflowInstanceId: request.ParentWorkflowInstanceId,
+            Nodes: nodes,
+            Edges: ProjectEdges(definition, commandWorkItems));
+    }
+
+    private static WorkflowEdgeDto[] ProjectEdges(
+        WorkflowDefinition definition,
+        IReadOnlyList<WorkflowCommandWorkItem> commandWorkItems)
+    {
+        var edges = new List<WorkflowEdgeDto>();
+
+        foreach (var edge in definition.Edges)
+        {
+            if (edge.SourceNodeId == "command-work" || edge.TargetNodeId == "command-work")
+            {
+                continue;
+            }
+
+            edges.Add(new WorkflowEdgeDto(
+                EdgeId: $"{edge.SourceNodeId}-{edge.TargetNodeId}",
+                SourceNodeId: edge.SourceNodeId,
+                TargetNodeId: edge.TargetNodeId));
+        }
+
+        foreach (var command in commandWorkItems)
+        {
+            edges.Add(new WorkflowEdgeDto(
+                EdgeId: $"dispatch-processing-{command.NodeId}",
+                SourceNodeId: "dispatch-processing",
+                TargetNodeId: command.NodeId));
+            edges.Add(new WorkflowEdgeDto(
+                EdgeId: $"{command.NodeId}-wait-command-completion",
+                SourceNodeId: command.NodeId,
+                TargetNodeId: "wait-command-completion"));
+        }
+
+        if (commandWorkItems.Count == 0)
+        {
+            edges.Add(new WorkflowEdgeDto(
+                EdgeId: "dispatch-processing-wait-command-completion",
+                SourceNodeId: "dispatch-processing",
+                TargetNodeId: "wait-command-completion"));
+        }
+
+        return [.. edges];
+    }
+
+    private static string? CreateWorkItemId(WorkflowDefinitionNode node)
+    {
+        return node.Kind is WorkflowNodeKind.WorkflowStep or WorkflowNodeKind.Wait
+            ? null
+            : node.NodeId;
+    }
+
+    private static string? CreateChildWorkflowInstanceId(string workflowInstanceId, WorkflowDefinitionNode node)
+    {
+        return node.Kind == WorkflowNodeKind.ChildWorkflow || node.Kind == WorkflowNodeKind.Finalization
+            ? $"{workflowInstanceId}/{node.NodeId}"
+            : null;
+    }
+}
+
+public sealed record WorkflowGraphProjectionRequest(
+    string WorkflowName,
+    string WorkflowInstanceId,
+    string PackageId,
+    WorkflowNodeStatus Status,
+    string? ParentWorkflowInstanceId,
+    IReadOnlyList<WorkflowCommandWorkItem> CommandWorkItems);
+
+public sealed record WorkflowCommandWorkItem(
+    string NodeId,
+    string DisplayName,
+    string WorkItemId);

--- a/tests/MediaIngest.Api.Tests/Program.cs
+++ b/tests/MediaIngest.Api.Tests/Program.cs
@@ -4,6 +4,7 @@ using MediaIngest.Persistence;
 using MediaIngest.Worker.Outbox;
 using MediaIngest.Worker.Watcher;
 using MediaIngest.Workflow;
+using MediaIngest.Workflow.Orchestrator;
 using System.Text.Json;
 
 var repoRoot = Path.Combine(Path.GetTempPath(), "media-ingest-api-tests", Guid.NewGuid().ToString("N"));
@@ -55,19 +56,25 @@ try
     AssertEqual("package-asset-001", graph.WorkflowInstanceId, "graph workflow instance id");
     AssertEqual("PackageIngestWorkflow", graph.WorkflowName, "graph workflow name");
     AssertEqual("asset-001", graph.PackageId, "graph package id");
-    AssertEqual(11, graph.Nodes.Count, "graph node count");
-    AssertEqual(10, graph.Edges.Count, "graph edge count");
+    AssertEqual(16, graph.Nodes.Count, "graph node count");
+    AssertEqual(19, graph.Edges.Count, "graph edge count");
     AssertEqual("package-start", graph.Nodes[0].NodeId, "graph first node id");
     AssertEqual("scan-package", graph.Nodes[1].NodeId, "graph scan node id");
     AssertEqual("classify-files", graph.Nodes[2].NodeId, "graph classify node id");
-    AssertEqual("dispatch-processing", graph.Nodes[3].NodeId, "graph dispatch node id");
+    AssertEqual("essence-group-processing", graph.Nodes[3].NodeId, "graph essence group node id");
+    AssertEqual("proxy-creation", graph.Nodes[4].NodeId, "graph proxy node id");
+    AssertEqual("dispatch-processing", graph.Nodes[5].NodeId, "graph dispatch node id");
     AssertTrue(graph.Nodes.Any(node => node.NodeId == "command-media-mix-wav"), "audio command graph node");
     AssertTrue(graph.Nodes.Any(node => node.NodeId == "command-media-late-mov"), "late video command graph node");
     AssertTrue(graph.Nodes.Any(node => node.NodeId == "command-media-source-mov"), "video command graph node");
     AssertTrue(graph.Nodes.Any(node => node.NodeId == "command-sidecars-caption-srt"), "text command graph node");
     AssertTrue(graph.Nodes.Any(node => node.NodeId == "command-notes-bin"), "other command graph node");
-    AssertEqual("reconcile-package", graph.Nodes[^2].NodeId, "graph reconcile node id");
+    AssertTrue(graph.Nodes.Any(node => node.NodeId == "wait-command-completion" && node.Kind == MediaIngest.Contracts.Workflow.WorkflowNodeKind.Wait), "graph command wait node");
+    AssertTrue(graph.Nodes.Any(node => node.NodeId == "complete-processing" && node.Kind == MediaIngest.Contracts.Workflow.WorkflowNodeKind.CommandCompletion), "graph command completion node");
+    AssertTrue(graph.Nodes.Any(node => node.NodeId == "wait-done-marker" && node.Kind == MediaIngest.Contracts.Workflow.WorkflowNodeKind.Wait), "graph done marker wait node");
+    AssertEqual("reconcile-package", graph.Nodes[^3].NodeId, "graph reconcile node id");
     AssertEqual("finalize-package", graph.Nodes[^1].NodeId, "graph finalize node id");
+    AssertEqual("package-asset-001/scan-package", graph.Nodes.Single(node => node.NodeId == "scan-package").ChildWorkflowInstanceId, "graph scan child workflow id");
     AssertEqual("Succeeded", graph.Nodes[0].Status.ToString(), "graph first node status");
 
     var mediaCommandMessages = runtime.Store.OutboxMessages
@@ -263,6 +270,7 @@ static TestRuntime CreateRuntimeService(string inputPath, string outputPath)
         new IngestMountScanner(),
         new ManifestReadinessGate(),
         new PackageWorkflowStarter(),
+        WorkflowGraphProjector.CreateDefault(),
         store,
         new OutboxDispatcher(store, publisher));
 

--- a/tests/MediaIngest.Workflow.Tests/Program.cs
+++ b/tests/MediaIngest.Workflow.Tests/Program.cs
@@ -67,6 +67,32 @@ AssertThrows<WorkflowDefinitionCatalogException>(
     () => WorkflowDefinitionCatalog.FromTypes(typeof(MissingDisplayNameWorkflow)),
     "missing catalog display name");
 
+var orchestratorProjection = new WorkflowGraphProjector(catalog);
+var definitionGraph = orchestratorProjection.ProjectDefinition(WorkflowContractNames.PackageIngestWorkflow);
+AssertEqual(WorkflowContractNames.PackageIngestWorkflow, definitionGraph.WorkflowName, "definition graph workflow name");
+AssertEqual(WorkflowNodeStatus.Pending, definitionGraph.Nodes[0].Status, "definition graph default node status");
+
+var instanceGraph = orchestratorProjection.ProjectInstance(new WorkflowGraphProjectionRequest(
+    WorkflowName: WorkflowContractNames.PackageIngestWorkflow,
+    WorkflowInstanceId: "package-package-001",
+    PackageId: "package-001",
+    Status: WorkflowNodeStatus.Succeeded,
+    ParentWorkflowInstanceId: null,
+    CommandWorkItems:
+    [
+        new WorkflowCommandWorkItem(
+            NodeId: "command-media-source-mov",
+            DisplayName: "CreateProxy source.mov",
+            WorkItemId: "command-package-001-media-source-mov")
+    ]));
+AssertEqual("package-package-001", instanceGraph.WorkflowInstanceId, "orchestrator graph workflow instance id");
+AssertEqual("package-001", instanceGraph.PackageId, "orchestrator graph package id");
+AssertEqual(12, instanceGraph.Nodes.Count, "orchestrator graph node count with command work");
+AssertEqual(11, instanceGraph.Edges.Count, "orchestrator graph edge count with command work");
+AssertTrue(instanceGraph.Nodes.Any(node => node.NodeId == "command-media-source-mov" && node.Kind == WorkflowNodeKind.WorkItem), "orchestrator command work node");
+AssertTrue(instanceGraph.Nodes.Any(node => node.NodeId == "wait-command-completion" && node.Status == WorkflowNodeStatus.Succeeded), "orchestrator wait node status");
+AssertEqual("package-package-001/scan-package", instanceGraph.Nodes.Single(node => node.NodeId == "scan-package").ChildWorkflowInstanceId, "orchestrator child workflow id");
+
 var lifecycle = PackageWorkflowLifecycle.Observe(request);
 AssertEqual(PackageWorkflowLifecycleState.Observed, lifecycle.Current.State, "observed lifecycle state");
 AssertEqual("package-001", lifecycle.Current.PackageId, "observed package id");


### PR DESCRIPTION
Summary:
- Adds an orchestrator-backed `WorkflowGraphProjector` for definition and instance graph DTO projection.
- Wires the API workflow graph facade to use orchestrator topology plus package status and persisted command outbox overlay.
- Preserves unknown workflow instance not-found behavior.

Validation:
- Red: `make test-dotnet-workflow` failed before implementation for missing projector types.
- Red: `make test-dotnet-api` failed before implementation because the API still returned the old hard-coded 11-node graph.
- `make test-dotnet-api` passed.
- `make test-dotnet-workflow` passed.
- `make test-dotnet-contracts` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `make validate-summary` passed on the stacked tip; log: `/tmp/media-asset-ingest-validation-9Tllir.log`.
- `make pr-readiness-check` passed on the stacked tip.

Refs #109