### PR TITLE
TASK-8-6: Render orchestrator graph nodes in UI

### DIFF
--- a/docs/plans/tasks/TASK-8-6-orchestrator-wait-command-ui.md
+++ b/docs/plans/tasks/TASK-8-6-orchestrator-wait-command-ui.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Planned
+In Progress
 
 ## Linked Work
 
@@ -36,9 +36,9 @@ Supporting lanes:
 Agents may edit only these files unless they escalate:
 
 - `web/ingest-control-plane`
-- `src/MediaIngest.Contracts/Workflow`
-- `src/MediaIngest.Api`
-- `tests/MediaIngest.Api.Tests`
+- `web/ingest-control-plane/src/workflowGraph.ts`
+- `web/ingest-control-plane/src/workflowGraph.test.ts`
+- `web/ingest-control-plane/src/App.test.tsx`
 - `docs/architecture/004-observability-and-ui.md`
 - `docs/status/work-log.md`
 
@@ -95,6 +95,10 @@ REFACTOR:
 - Preserve child workflow drilldown and parent back navigation.
 - Add contract changes only if existing `WorkflowNodeKind` or `WorkflowNodeStatus` cannot express waits or command dependency sections; keep changes backward-compatible for existing graph DTOs.
 - Do not add SignalR or live push in this slice; polling remains sufficient.
+- The shared backend contract changes landed in TASK-5-4. This slice updates
+  the React type union, Mermaid rendering tests, and default graph fixture so
+  the UI accepts the new DTO node kinds directly instead of reconstructing
+  topology locally.
 
 ## Validation
 

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -65,14 +65,17 @@ epic/story granularity; detailed implementation tasks belong in plans.
 - MILESTONE-8 / USER-STORY-12 / USER-STORY-14 / USER-STORY-15: generate API
   workflow graph DTOs from orchestrator-owned topology metadata, with dynamic
   command work-item nodes overlaid from persisted command outbox envelopes.
+- MILESTONE-8 / USER-STORY-12 through USER-STORY-15: render orchestrator wait,
+  command dispatch, command completion, finalization, child workflow, and
+  dynamic command work nodes in the React Mermaid workflow graph without adding
+  live push.
 
 ## Ready For Planning
 
 - MILESTONE-2 / USER-STORY-16: plan the next Docker-first local runtime
   validation slice beyond static Compose checks.
-- MILESTONE-5 / USER-STORY-9 / USER-STORY-10 and MILESTONE-8 /
-  USER-STORY-12 through USER-STORY-15: continue the workflow orchestrator graph
-  discovery stack with TASK-8-6.
+- MILESTONE-5 / USER-STORY-9: plan the later dependency-approved task for real
+  Dapr Workflow SDK hosting and workflow/activity registration.
 ## Later
 
 - MILESTONE-6 / USER-STORY-7: connect generic command runners to Azure Service

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -150,6 +150,10 @@
 - TASK-8-5 added an orchestrator-backed workflow graph projector and wired the
   API workflow graph facade to project package graphs from catalog metadata
   overlaid with business package status and dynamic command work-item nodes.
+- TASK-8-6 updated the React Mermaid workflow graph model and tests so wait,
+  command dispatch, command completion, finalization, child workflow, and
+  dynamic command work nodes render from orchestrator-generated DTOs while
+  preserving node details, child workflow drilldown, and back navigation.
 - TASK-4-4 defined the Service Bus command-bus adapter boundary in the outbox
   worker. Command publish requests now map to a broker-oriented message shape
   with semantic topic, raw command body, application properties, and routed
@@ -162,8 +166,8 @@
 
 ## Next
 
-- Continue the workflow orchestrator graph discovery stack with TASK-8-6:
-  render orchestrator waits and command dependencies in the UI.
+- Plan the later dependency-approved task for real Dapr Workflow SDK hosting
+  and workflow/activity registration in the orchestrator boundary.
 
 ## Update Rule
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -17,6 +17,10 @@ messages or paste command output unless it explains a decision.
   orchestrator definition metadata plus business status and command outbox
   overlay instead of API-local static topology construction, while preserving
   not-found behavior for unknown workflow instances.
+- Added TASK-8-6 UI graph rendering support for orchestrator waits, command
+  dispatch, command completion, finalization, child workflow, and dynamic
+  command work nodes in the existing Mermaid-only workflow diagram without
+  adding SignalR or live push.
 - Added local planning docs for the workflow orchestrator graph discovery
   slice: TASK-5-3, TASK-5-4, TASK-8-5, and TASK-8-6 now cover the standalone
   orchestrator service, attribute-discovered workflow definition catalog,

--- a/web/ingest-control-plane/src/App.test.tsx
+++ b/web/ingest-control-plane/src/App.test.tsx
@@ -67,7 +67,7 @@ describe("workflow graph control plane", () => {
       screen.getByRole("heading", { name: /workflow control plane/i })
     ).toBeInTheDocument();
     expect(screen.getByText(/package PKG-2026-05-03-001/i)).toBeInTheDocument();
-    expect(screen.getByText(/5 of 7 nodes progressed/i)).toBeInTheDocument();
+    expect(screen.getByText(/6 of 11 nodes progressed/i)).toBeInTheDocument();
 
     const graph = await screen.findByRole("img", { name: /workflow diagram/i });
 
@@ -78,16 +78,20 @@ describe("workflow graph control plane", () => {
     expect(graph.innerHTML).toContain("Manifest detected");
     expect(graph.innerHTML).toContain("Classify package");
     expect(graph.innerHTML).toContain("Proxy workflow");
+    expect(graph.innerHTML).toContain("Dispatch processing work");
     expect(graph.innerHTML).toContain("Audio essence");
+    expect(graph.innerHTML).toContain("Wait for command completion");
+    expect(graph.innerHTML).toContain("Complete processing commands");
+    expect(graph.innerHTML).toContain("Finalize package");
     expect(
       screen.getByRole("combobox", { name: /inspect workflow diagram node/i })
     ).toBeInTheDocument();
 
-    expect(screen.getByText(/pending: 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/pending: 2/i)).toBeInTheDocument();
     expect(screen.getByText(/running: 1/i)).toBeInTheDocument();
     expect(screen.getByText(/failed: 1/i)).toBeInTheDocument();
-    expect(screen.getByText(/waiting: 1/i)).toBeInTheDocument();
-    expect(screen.getByText(/queued: 0/i)).toBeInTheDocument();
+    expect(screen.getByText(/waiting: 2/i)).toBeInTheDocument();
+    expect(screen.getByText(/queued: 1/i)).toBeInTheDocument();
     expect(screen.getByText(/skipped: 0/i)).toBeInTheDocument();
     expect(screen.getByText(/cancelled: 0/i)).toBeInTheDocument();
     expect(screen.getByText(/no packages reported yet/i)).toBeInTheDocument();

--- a/web/ingest-control-plane/src/workflowGraph.test.ts
+++ b/web/ingest-control-plane/src/workflowGraph.test.ts
@@ -63,6 +63,88 @@ describe("workflow graph mermaid syntax", () => {
     );
   });
 
+  it("renders orchestrator waits, command dependency nodes, and finalization", () => {
+    const diagram = buildMermaidFlowchart({
+      workflowInstanceId: "package-asset-001",
+      workflowName: "PackageIngestWorkflow",
+      packageId: "asset-001",
+      nodes: [
+        {
+          nodeId: "dispatch-processing",
+          displayName: "Dispatch processing work",
+          kind: "CommandDispatch",
+          status: "Succeeded",
+          workflowInstanceId: "package-asset-001",
+          packageId: "asset-001"
+        },
+        {
+          nodeId: "command-media-source-mov",
+          displayName: "CreateProxy source.mov",
+          kind: "WorkItem",
+          status: "Succeeded",
+          workflowInstanceId: "package-asset-001",
+          packageId: "asset-001",
+          workItemId: "command-asset-001-media-source-mov"
+        },
+        {
+          nodeId: "wait-command-completion",
+          displayName: "Wait for command completion",
+          kind: "Wait",
+          status: "Waiting",
+          workflowInstanceId: "package-asset-001",
+          packageId: "asset-001"
+        },
+        {
+          nodeId: "complete-processing",
+          displayName: "Complete processing commands",
+          kind: "CommandCompletion",
+          status: "Queued",
+          workflowInstanceId: "package-asset-001",
+          packageId: "asset-001"
+        },
+        {
+          nodeId: "finalize-package",
+          displayName: "Finalize package",
+          kind: "Finalization",
+          status: "Pending",
+          workflowInstanceId: "package-asset-001",
+          packageId: "asset-001"
+        }
+      ],
+      edges: [
+        {
+          edgeId: "dispatch-command",
+          sourceNodeId: "dispatch-processing",
+          targetNodeId: "command-media-source-mov"
+        },
+        {
+          edgeId: "command-wait",
+          sourceNodeId: "command-media-source-mov",
+          targetNodeId: "wait-command-completion"
+        },
+        {
+          edgeId: "wait-complete",
+          sourceNodeId: "wait-command-completion",
+          targetNodeId: "complete-processing"
+        },
+        {
+          edgeId: "complete-finalize",
+          sourceNodeId: "complete-processing",
+          targetNodeId: "finalize-package"
+        }
+      ]
+    });
+
+    expect(diagram).toContain('dispatch_processing["Dispatch processing work"]:::succeeded');
+    expect(diagram).toContain('wait_command_completion["Wait for command completion"]:::waiting');
+    expect(diagram).toContain('complete_processing["Complete processing commands"]:::queued');
+    expect(diagram).toContain('finalize_package["Finalize package"]:::pending');
+    expect(diagram).toContain("dispatch_processing --> command_media_source_mov");
+    expect(diagram).toContain("command_media_source_mov --> wait_command_completion");
+    expect(diagram).toContain("wait_command_completion --> complete_processing");
+    expect(diagram).toContain("complete_processing --> finalize_package");
+  });
+
   it("exposes the stable Mermaid node identifier used for SVG interaction", () => {
     expect(toMermaidNodeId("scan.package/1")).toBe("scan_package_1");
     expect(toMermaidNodeId("2026-start")).toBe("node_2026_start");

--- a/web/ingest-control-plane/src/workflowGraph.ts
+++ b/web/ingest-control-plane/src/workflowGraph.ts
@@ -12,7 +12,11 @@ export type WorkflowNodeKind =
   | "WorkflowStep"
   | "Activity"
   | "ChildWorkflow"
-  | "WorkItem";
+  | "WorkItem"
+  | "Wait"
+  | "CommandDispatch"
+  | "CommandCompletion"
+  | "Finalization";
 
 export type WorkflowNode = {
   nodeId: string;
@@ -128,6 +132,14 @@ export const mockedWorkflowGraph: WorkflowGraph = {
       childWorkflowInstanceId: "wf-proxy-2026-05-03-001"
     },
     {
+      nodeId: "dispatch",
+      displayName: "Dispatch processing work",
+      kind: "CommandDispatch",
+      status: "Succeeded",
+      workflowInstanceId: "wf-pkg-2026-05-03-001",
+      packageId: "PKG-2026-05-03-001"
+    },
+    {
       nodeId: "audio",
       displayName: "Audio essence",
       kind: "WorkItem",
@@ -144,6 +156,30 @@ export const mockedWorkflowGraph: WorkflowGraph = {
       workflowInstanceId: "wf-pkg-2026-05-03-001",
       packageId: "PKG-2026-05-03-001",
       workItemId: "work-subtitle-en"
+    },
+    {
+      nodeId: "wait-commands",
+      displayName: "Wait for command completion",
+      kind: "Wait",
+      status: "Waiting",
+      workflowInstanceId: "wf-pkg-2026-05-03-001",
+      packageId: "PKG-2026-05-03-001"
+    },
+    {
+      nodeId: "complete-commands",
+      displayName: "Complete processing commands",
+      kind: "CommandCompletion",
+      status: "Queued",
+      workflowInstanceId: "wf-pkg-2026-05-03-001",
+      packageId: "PKG-2026-05-03-001"
+    },
+    {
+      nodeId: "finalize",
+      displayName: "Finalize package",
+      kind: "Finalization",
+      status: "Pending",
+      workflowInstanceId: "wf-pkg-2026-05-03-001",
+      packageId: "PKG-2026-05-03-001"
     }
   ],
   edges: [
@@ -151,8 +187,15 @@ export const mockedWorkflowGraph: WorkflowGraph = {
     { edgeId: "scan-classify", sourceNodeId: "scan", targetNodeId: "classify" },
     { edgeId: "classify-video", sourceNodeId: "classify", targetNodeId: "video" },
     { edgeId: "classify-proxy", sourceNodeId: "classify", targetNodeId: "proxy" },
+    { edgeId: "proxy-dispatch", sourceNodeId: "proxy", targetNodeId: "dispatch" },
+    { edgeId: "dispatch-video", sourceNodeId: "dispatch", targetNodeId: "video" },
     { edgeId: "classify-audio", sourceNodeId: "classify", targetNodeId: "audio" },
-    { edgeId: "classify-subtitle", sourceNodeId: "classify", targetNodeId: "subtitle" }
+    { edgeId: "classify-subtitle", sourceNodeId: "classify", targetNodeId: "subtitle" },
+    { edgeId: "video-wait", sourceNodeId: "video", targetNodeId: "wait-commands" },
+    { edgeId: "audio-wait", sourceNodeId: "audio", targetNodeId: "wait-commands" },
+    { edgeId: "subtitle-wait", sourceNodeId: "subtitle", targetNodeId: "wait-commands" },
+    { edgeId: "wait-complete", sourceNodeId: "wait-commands", targetNodeId: "complete-commands" },
+    { edgeId: "complete-finalize", sourceNodeId: "complete-commands", targetNodeId: "finalize" }
   ]
 };
 


### PR DESCRIPTION
Summary:
- Extends the React workflow graph model for wait, command dispatch, command completion, and finalization node kinds.
- Updates Mermaid graph tests and the default graph fixture for orchestrator waits and command dependency nodes.
- Preserves Mermaid as the only graph visualization, existing node details, child workflow drilldown, and back navigation. No SignalR/live push added.

Validation:
- Red: `make test-ui` failed before implementation because the app still used the old 7-node graph fixture.
- `make test-ui` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `make validate-summary` passed on the stacked tip; log: `/tmp/media-asset-ingest-validation-9Tllir.log`.
- `make pr-readiness-check` passed on the stacked tip.

Refs #110