### PR TITLE
TASK-5-4: Add workflow definition catalog

### DIFF
--- a/docs/architecture/002-workflow-orchestration.md
+++ b/docs/architecture/002-workflow-orchestration.md
@@ -16,6 +16,15 @@ marker used by later catalog discovery work. Real Dapr Workflow SDK hosting and
 workflow/activity registration remain deferred until a dependency-approved
 task adds the runtime package references.
 
+Workflow topology is code-first metadata in the orchestrator assembly. Workflow
+definition attributes declare stable workflow names and display names; node and
+edge attributes declare graph topology, child workflow references, wait points,
+command dispatch points, command completion points, and finalization. Startup
+catalog discovery uses reflection over known orchestrator assemblies and fails
+fast when required metadata is missing, node IDs are duplicated, definition IDs
+are duplicated, or edges reference unknown nodes. The catalog describes topology
+only; it does not analyze method bodies or store database-authored workflows.
+
 ## Root Workflow
 
 The root workflow is `PackageIngestWorkflow`. It owns the package lifecycle:
@@ -54,6 +63,11 @@ workflow instance ID, and parent workflow instance ID before runtime execution.
 The stable child ID format is `<parent-workflow-instance-id>/<child-node-id>`.
 Graph projections must use these prepared references when they are available so
 operator drilldown matches the identifiers used to start child workflows.
+
+The package ingest topology currently contains stable nodes for package start,
+package scan, file classification, essence-group processing, proxy creation,
+command dispatch, command work, command-completion wait, command completion,
+reconciliation, done-marker wait, and finalization.
 
 ## Parallelism
 

--- a/docs/architecture/004-observability-and-ui.md
+++ b/docs/architecture/004-observability-and-ui.md
@@ -38,7 +38,8 @@ metadata or trace state, but they should not rename these fields.
 ## Workflow UI
 
 The UI renders a graph model, not a generated bitmap. Nodes represent workflow
-steps, child workflows, or work items. Edges represent execution flow and
+steps, child workflows, work items, waits, command dispatch points, command
+completion points, or finalization points. Edges represent execution flow and
 dependencies.
 
 Shared backend/UI contracts live in `MediaIngest.Contracts.Workflow`.
@@ -47,6 +48,9 @@ optional parent workflow instance, graph nodes, and graph edges. `WorkflowNodeDt
 uses stable node IDs, display names, node kinds, business statuses, workflow and
 package correlation, optional work item IDs, and optional child workflow
 instance IDs for drilldown. `WorkflowEdgeDto` links source and target node IDs.
+Orchestrator workflow definitions are the durable source for static graph
+topology; API projections overlay business status and command work-item
+instances on top of that topology.
 
 Node states:
 

--- a/docs/plans/tasks/TASK-5-4-workflow-definition-catalog.md
+++ b/docs/plans/tasks/TASK-5-4-workflow-definition-catalog.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Planned
+In Progress
 
 ## Linked Work
 
@@ -34,8 +34,9 @@ Supporting lanes:
 Agents may edit only these files unless they escalate:
 
 - `src/MediaIngest.Workflow.Orchestrator`
-- `src/MediaIngest.Workflow`
+- `src/MediaIngest.Contracts/Workflow/WorkflowNodeKind.cs`
 - `tests/MediaIngest.Workflow.Tests`
+- `tests/MediaIngest.Contracts.Tests`
 - `docs/architecture/002-workflow-orchestration.md`
 - `docs/architecture/004-observability-and-ui.md`
 - `docs/status/work-log.md`
@@ -92,6 +93,10 @@ REFACTOR:
 - Avoid workflow method-body analysis in this slice.
 - Keep the definition source as compiled code plus attributes, not DB-authored workflows.
 - Keep the first definition package ingest, but do not hard-code catalog internals to package-only concepts.
+- Extend the shared `WorkflowNodeKind` contract with `Wait`,
+  `CommandDispatch`, `CommandCompletion`, and `Finalization` so downstream API
+  and UI graph projections can render orchestrator-defined waits and command
+  dependency points without private enum mappings.
 
 ## Validation
 
@@ -99,6 +104,7 @@ Minimal validation:
 
 ```bash
 make test-dotnet-workflow-summary
+make test-dotnet-contracts
 git diff --check
 ```
 

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -59,6 +59,9 @@ epic/story granularity; detailed implementation tasks belong in plans.
   orchestrator bounded-context assembly and public marker for future catalog
   discovery, while deferring real Dapr Workflow SDK registration to a later
   dependency-approved task.
+- MILESTONE-5 / USER-STORY-9 / USER-STORY-10: add attribute-discovered
+  orchestrator workflow topology metadata and validation for package ingest
+  nodes, waits, command dispatch/completion, child workflows, and finalization.
 
 ## Ready For Planning
 
@@ -66,7 +69,7 @@ epic/story granularity; detailed implementation tasks belong in plans.
   validation slice beyond static Compose checks.
 - MILESTONE-5 / USER-STORY-9 / USER-STORY-10 and MILESTONE-8 /
   USER-STORY-12 through USER-STORY-15: continue the workflow orchestrator graph
-  discovery stack with TASK-5-4, TASK-8-5, and TASK-8-6.
+  discovery stack with TASK-8-5 and TASK-8-6.
 ## Later
 
 - MILESTONE-6 / USER-STORY-7: connect generic command runners to Azure Service

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -143,6 +143,10 @@
   bounded-context assembly and public marker for future catalog discovery.
   Real Dapr Workflow SDK hosting remains deferred to a later
   dependency-approved task.
+- TASK-5-4 added the attribute-discovered workflow definition catalog in the
+  orchestrator boundary, including package ingest topology metadata for waits,
+  command dispatch/completion, child workflows, and finalization plus catalog
+  validation for duplicate nodes, invalid edges, and missing metadata.
 - TASK-4-4 defined the Service Bus command-bus adapter boundary in the outbox
   worker. Command publish requests now map to a broker-oriented message shape
   with semantic topic, raw command body, application properties, and routed
@@ -155,8 +159,7 @@
 
 ## Next
 
-- Continue the workflow orchestrator graph discovery stack: TASK-5-4 adds the
-  attribute-discovered workflow definition catalog, TASK-8-5 generates
+- Continue the workflow orchestrator graph discovery stack: TASK-8-5 generates
   `WorkflowGraphDto` from orchestrator definitions, and TASK-8-6 renders
   orchestrator waits and command dependencies in the UI.
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -9,6 +9,10 @@ messages or paste command output unless it explains a decision.
   `MediaIngest.Workflow.Orchestrator` assembly exposes a public marker for
   later definition catalog discovery, with real Dapr Workflow SDK registration
   deferred to a dependency-approved task.
+- Added TASK-5-4 workflow definition catalog: orchestrator code now declares
+  package ingest topology with attributes, validates duplicate and invalid
+  metadata during reflection discovery, and extends node kinds for waits,
+  command dispatch, command completion, and finalization.
 - Added local planning docs for the workflow orchestrator graph discovery
   slice: TASK-5-3, TASK-5-4, TASK-8-5, and TASK-8-6 now cover the standalone
   orchestrator service, attribute-discovered workflow definition catalog,

--- a/src/MediaIngest.Contracts/Workflow/WorkflowNodeKind.cs
+++ b/src/MediaIngest.Contracts/Workflow/WorkflowNodeKind.cs
@@ -5,5 +5,9 @@ public enum WorkflowNodeKind
     WorkflowStep,
     Activity,
     ChildWorkflow,
-    WorkItem
+    WorkItem,
+    Wait,
+    CommandDispatch,
+    CommandCompletion,
+    Finalization
 }

--- a/src/MediaIngest.Workflow.Orchestrator/MediaIngest.Workflow.Orchestrator.csproj
+++ b/src/MediaIngest.Workflow.Orchestrator/MediaIngest.Workflow.Orchestrator.csproj
@@ -3,4 +3,8 @@
     <RootNamespace>MediaIngest.Workflow.Orchestrator</RootNamespace>
     <AssemblyName>MediaIngest.Workflow.Orchestrator</AssemblyName>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../MediaIngest.Contracts/MediaIngest.Contracts.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/MediaIngest.Workflow.Orchestrator/PackageIngestWorkflowDefinition.cs
+++ b/src/MediaIngest.Workflow.Orchestrator/PackageIngestWorkflowDefinition.cs
@@ -1,0 +1,29 @@
+using MediaIngest.Contracts.Workflow;
+
+namespace MediaIngest.Workflow.Orchestrator;
+
+[WorkflowDefinition(WorkflowContractNames.PackageIngestWorkflow, "Package ingest workflow")]
+[WorkflowNode("package-start", "Package ingest", WorkflowNodeKind.WorkflowStep)]
+[WorkflowNode("scan-package", "Package scan", WorkflowNodeKind.ChildWorkflow, WorkflowContractNames.PackageScanWorkflow)]
+[WorkflowNode("classify-files", "Classify discovered files", WorkflowNodeKind.ChildWorkflow, WorkflowContractNames.FileClassificationWorkflow)]
+[WorkflowNode("essence-group-processing", "Essence group processing", WorkflowNodeKind.ChildWorkflow, WorkflowContractNames.EssenceGroupProcessingWorkflow)]
+[WorkflowNode("proxy-creation", "Proxy creation", WorkflowNodeKind.ChildWorkflow, WorkflowContractNames.ProxyCreationWorkflow)]
+[WorkflowNode("dispatch-processing", "Dispatch processing work", WorkflowNodeKind.CommandDispatch)]
+[WorkflowNode("command-work", "Command work", WorkflowNodeKind.WorkItem)]
+[WorkflowNode("wait-command-completion", "Wait for command completion", WorkflowNodeKind.Wait)]
+[WorkflowNode("complete-processing", "Complete processing commands", WorkflowNodeKind.CommandCompletion)]
+[WorkflowNode("reconcile-package", "Reconcile package", WorkflowNodeKind.ChildWorkflow, WorkflowContractNames.ReconciliationWorkflow)]
+[WorkflowNode("wait-done-marker", "Wait for done marker", WorkflowNodeKind.Wait)]
+[WorkflowNode("finalize-package", "Finalize package", WorkflowNodeKind.Finalization, WorkflowContractNames.FinalizationWorkflow)]
+[WorkflowEdge("package-start", "scan-package")]
+[WorkflowEdge("scan-package", "classify-files")]
+[WorkflowEdge("classify-files", "essence-group-processing")]
+[WorkflowEdge("essence-group-processing", "proxy-creation")]
+[WorkflowEdge("proxy-creation", "dispatch-processing")]
+[WorkflowEdge("dispatch-processing", "command-work")]
+[WorkflowEdge("command-work", "wait-command-completion")]
+[WorkflowEdge("wait-command-completion", "complete-processing")]
+[WorkflowEdge("complete-processing", "reconcile-package")]
+[WorkflowEdge("reconcile-package", "wait-done-marker")]
+[WorkflowEdge("wait-done-marker", "finalize-package")]
+public sealed class PackageIngestWorkflowDefinition;

--- a/src/MediaIngest.Workflow.Orchestrator/WorkflowDefinition.cs
+++ b/src/MediaIngest.Workflow.Orchestrator/WorkflowDefinition.cs
@@ -1,0 +1,21 @@
+using MediaIngest.Contracts.Workflow;
+
+namespace MediaIngest.Workflow.Orchestrator;
+
+public sealed record WorkflowDefinition(
+    string WorkflowName,
+    string DisplayName,
+    IReadOnlyList<WorkflowDefinitionNode> Nodes,
+    IReadOnlyList<WorkflowDefinitionEdge> Edges);
+
+public sealed record WorkflowDefinitionNode(
+    string NodeId,
+    string DisplayName,
+    WorkflowNodeKind Kind,
+    string? ChildWorkflowName);
+
+public sealed record WorkflowDefinitionEdge(
+    string SourceNodeId,
+    string TargetNodeId);
+
+public sealed class WorkflowDefinitionCatalogException(string message) : Exception(message);

--- a/src/MediaIngest.Workflow.Orchestrator/WorkflowDefinitionAttribute.cs
+++ b/src/MediaIngest.Workflow.Orchestrator/WorkflowDefinitionAttribute.cs
@@ -1,0 +1,35 @@
+using MediaIngest.Contracts.Workflow;
+
+namespace MediaIngest.Workflow.Orchestrator;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class WorkflowDefinitionAttribute(string workflowName, string displayName) : Attribute
+{
+    public string WorkflowName { get; } = workflowName;
+
+    public string DisplayName { get; } = displayName;
+}
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+public sealed class WorkflowNodeAttribute(
+    string nodeId,
+    string displayName,
+    WorkflowNodeKind kind,
+    string? childWorkflowName = null) : Attribute
+{
+    public string NodeId { get; } = nodeId;
+
+    public string DisplayName { get; } = displayName;
+
+    public WorkflowNodeKind Kind { get; } = kind;
+
+    public string? ChildWorkflowName { get; } = childWorkflowName;
+}
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+public sealed class WorkflowEdgeAttribute(string sourceNodeId, string targetNodeId) : Attribute
+{
+    public string SourceNodeId { get; } = sourceNodeId;
+
+    public string TargetNodeId { get; } = targetNodeId;
+}

--- a/src/MediaIngest.Workflow.Orchestrator/WorkflowDefinitionCatalog.cs
+++ b/src/MediaIngest.Workflow.Orchestrator/WorkflowDefinitionCatalog.cs
@@ -1,0 +1,143 @@
+using System.Reflection;
+
+namespace MediaIngest.Workflow.Orchestrator;
+
+public sealed class WorkflowDefinitionCatalog
+{
+    private readonly IReadOnlyDictionary<string, WorkflowDefinition> definitions;
+
+    private WorkflowDefinitionCatalog(IReadOnlyDictionary<string, WorkflowDefinition> definitions)
+    {
+        this.definitions = definitions;
+    }
+
+    public IReadOnlyCollection<WorkflowDefinition> Definitions => definitions.Values.ToArray();
+
+    public static WorkflowDefinitionCatalog Discover(params Assembly[] assemblies)
+    {
+        if (assemblies.Length == 0)
+        {
+            throw new WorkflowDefinitionCatalogException("At least one workflow definition assembly is required.");
+        }
+
+        return FromTypes(assemblies.SelectMany(assembly => assembly.DefinedTypes).ToArray());
+    }
+
+    public static WorkflowDefinitionCatalog FromTypes(params Type[] workflowDefinitionTypes)
+    {
+        var discovered = workflowDefinitionTypes
+            .Select(type => CreateDefinition(type.GetTypeInfo()))
+            .Where(definition => definition is not null)
+            .Cast<WorkflowDefinition>()
+            .ToArray();
+
+        var duplicate = discovered
+            .GroupBy(definition => definition.WorkflowName, StringComparer.Ordinal)
+            .FirstOrDefault(group => group.Count() > 1)
+            ?.Key;
+
+        if (duplicate is not null)
+        {
+            throw new WorkflowDefinitionCatalogException($"Duplicate workflow definition id '{duplicate}'.");
+        }
+
+        return new WorkflowDefinitionCatalog(discovered.ToDictionary(
+            definition => definition.WorkflowName,
+            StringComparer.Ordinal));
+    }
+
+    public WorkflowDefinition? Find(string workflowName)
+    {
+        return definitions.GetValueOrDefault(workflowName);
+    }
+
+    public WorkflowDefinition GetRequired(string workflowName)
+    {
+        return Find(workflowName)
+            ?? throw new WorkflowDefinitionCatalogException($"Workflow definition '{workflowName}' was not found.");
+    }
+
+    private static WorkflowDefinition? CreateDefinition(TypeInfo type)
+    {
+        var definitionAttribute = type.GetCustomAttribute<WorkflowDefinitionAttribute>();
+        if (definitionAttribute is null)
+        {
+            return null;
+        }
+
+        RequireValue(definitionAttribute.WorkflowName, "Workflow definition id is required.");
+        RequireValue(
+            definitionAttribute.DisplayName,
+            $"Workflow definition '{definitionAttribute.WorkflowName}' display name is required.");
+
+        var nodeAttributes = type.GetCustomAttributes<WorkflowNodeAttribute>().ToArray();
+        if (nodeAttributes.Length == 0)
+        {
+            throw new WorkflowDefinitionCatalogException(
+                $"Workflow definition '{definitionAttribute.WorkflowName}' must declare at least one node.");
+        }
+
+        var nodes = nodeAttributes
+            .Select(attribute =>
+            {
+                RequireValue(attribute.NodeId, $"Workflow definition '{definitionAttribute.WorkflowName}' contains a node without an id.");
+                RequireValue(attribute.DisplayName, $"Workflow node '{attribute.NodeId}' display name is required.");
+
+                return new WorkflowDefinitionNode(
+                    attribute.NodeId,
+                    attribute.DisplayName,
+                    attribute.Kind,
+                    attribute.ChildWorkflowName);
+            })
+            .ToArray();
+
+        var duplicateNodeId = nodes
+            .GroupBy(node => node.NodeId, StringComparer.Ordinal)
+            .FirstOrDefault(group => group.Count() > 1)
+            ?.Key;
+
+        if (duplicateNodeId is not null)
+        {
+            throw new WorkflowDefinitionCatalogException(
+                $"Workflow definition '{definitionAttribute.WorkflowName}' contains duplicate node id '{duplicateNodeId}'.");
+        }
+
+        var edges = type.GetCustomAttributes<WorkflowEdgeAttribute>()
+            .Select(attribute =>
+            {
+                RequireValue(
+                    attribute.SourceNodeId,
+                    $"Workflow definition '{definitionAttribute.WorkflowName}' contains an edge without a source node id.");
+                RequireValue(
+                    attribute.TargetNodeId,
+                    $"Workflow definition '{definitionAttribute.WorkflowName}' contains an edge without a target node id.");
+
+                return new WorkflowDefinitionEdge(attribute.SourceNodeId, attribute.TargetNodeId);
+            })
+            .ToArray();
+
+        var nodeIds = nodes.Select(node => node.NodeId).ToHashSet(StringComparer.Ordinal);
+        foreach (var edge in edges)
+        {
+            if (!nodeIds.Contains(edge.SourceNodeId) || !nodeIds.Contains(edge.TargetNodeId))
+            {
+                throw new WorkflowDefinitionCatalogException(
+                    $"Workflow definition '{definitionAttribute.WorkflowName}' contains an edge that references an unknown node.");
+            }
+        }
+
+        return new WorkflowDefinition(
+            definitionAttribute.WorkflowName,
+            definitionAttribute.DisplayName,
+            nodes,
+            edges);
+    }
+
+    private static void RequireValue(string? value, string message)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new WorkflowDefinitionCatalogException(message);
+        }
+    }
+}

--- a/tests/MediaIngest.Contracts.Tests/Program.cs
+++ b/tests/MediaIngest.Contracts.Tests/Program.cs
@@ -145,7 +145,11 @@ AssertEnumValues<WorkflowNodeKind>(
         (WorkflowNodeKind.WorkflowStep, 0, "WorkflowStep"),
         (WorkflowNodeKind.Activity, 1, "Activity"),
         (WorkflowNodeKind.ChildWorkflow, 2, "ChildWorkflow"),
-        (WorkflowNodeKind.WorkItem, 3, "WorkItem")
+        (WorkflowNodeKind.WorkItem, 3, "WorkItem"),
+        (WorkflowNodeKind.Wait, 4, "Wait"),
+        (WorkflowNodeKind.CommandDispatch, 5, "CommandDispatch"),
+        (WorkflowNodeKind.CommandCompletion, 6, "CommandCompletion"),
+        (WorkflowNodeKind.Finalization, 7, "Finalization")
     ],
     "workflow node kind values");
 AssertEqual(WorkflowNodeStatus.Running, graph.Nodes[1].Status, "node status");

--- a/tests/MediaIngest.Workflow.Tests/Program.cs
+++ b/tests/MediaIngest.Workflow.Tests/Program.cs
@@ -44,6 +44,29 @@ AssertEqual("package-package-001/scan-package", startGraph.Nodes[1].ChildWorkflo
 
 AssertEqual("MediaIngest.Workflow.Orchestrator", WorkflowOrchestratorAssembly.MarkerName, "orchestrator boundary marker name");
 
+var catalog = WorkflowDefinitionCatalog.Discover(typeof(PackageIngestWorkflowDefinition).Assembly);
+var packageDefinition = catalog.GetRequired(WorkflowContractNames.PackageIngestWorkflow);
+AssertEqual(WorkflowContractNames.PackageIngestWorkflow, packageDefinition.WorkflowName, "catalog package workflow name");
+AssertEqual("Package ingest workflow", packageDefinition.DisplayName, "catalog package display name");
+AssertEqual(12, packageDefinition.Nodes.Count, "catalog package node count");
+AssertTrue(packageDefinition.Nodes.Any(node => node.NodeId == "scan-package" && node.Kind == WorkflowNodeKind.ChildWorkflow && node.ChildWorkflowName == WorkflowContractNames.PackageScanWorkflow), "catalog scan child workflow node");
+AssertTrue(packageDefinition.Nodes.Any(node => node.NodeId == "wait-command-completion" && node.Kind == WorkflowNodeKind.Wait), "catalog command wait node");
+AssertTrue(packageDefinition.Nodes.Any(node => node.NodeId == "dispatch-processing" && node.Kind == WorkflowNodeKind.CommandDispatch), "catalog dispatch node");
+AssertTrue(packageDefinition.Nodes.Any(node => node.NodeId == "complete-processing" && node.Kind == WorkflowNodeKind.CommandCompletion), "catalog completion node");
+AssertTrue(packageDefinition.Nodes.Any(node => node.NodeId == "finalize-package" && node.Kind == WorkflowNodeKind.Finalization), "catalog finalization node");
+AssertEqual(11, packageDefinition.Edges.Count, "catalog package edge count");
+AssertEqual("package-start", packageDefinition.Edges[0].SourceNodeId, "catalog first edge source");
+AssertEqual("scan-package", packageDefinition.Edges[0].TargetNodeId, "catalog first edge target");
+AssertThrows<WorkflowDefinitionCatalogException>(
+    () => WorkflowDefinitionCatalog.FromTypes(typeof(DuplicateNodeWorkflow)),
+    "duplicate catalog node id");
+AssertThrows<WorkflowDefinitionCatalogException>(
+    () => WorkflowDefinitionCatalog.FromTypes(typeof(InvalidEdgeWorkflow)),
+    "invalid catalog edge");
+AssertThrows<WorkflowDefinitionCatalogException>(
+    () => WorkflowDefinitionCatalog.FromTypes(typeof(MissingDisplayNameWorkflow)),
+    "missing catalog display name");
+
 var lifecycle = PackageWorkflowLifecycle.Observe(request);
 AssertEqual(PackageWorkflowLifecycleState.Observed, lifecycle.Current.State, "observed lifecycle state");
 AssertEqual("package-001", lifecycle.Current.PackageId, "observed package id");
@@ -190,6 +213,14 @@ static void AssertThrows<TException>(Action action, string name)
     throw new InvalidOperationException($"{name}: expected {typeof(TException).Name}.");
 }
 
+static void AssertTrue(bool condition, string name)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException(name);
+    }
+}
+
 static void AssertAll<T>(IEnumerable<T> values, Func<T, bool> predicate, string name)
 {
     var index = 0;
@@ -203,3 +234,17 @@ static void AssertAll<T>(IEnumerable<T> values, Func<T, bool> predicate, string 
         index++;
     }
 }
+
+[WorkflowDefinition("DuplicateNodeWorkflow", "Duplicate node workflow")]
+[WorkflowNode("start", "Start", WorkflowNodeKind.WorkflowStep)]
+[WorkflowNode("start", "Duplicate start", WorkflowNodeKind.Activity)]
+internal sealed class DuplicateNodeWorkflow;
+
+[WorkflowDefinition("InvalidEdgeWorkflow", "Invalid edge workflow")]
+[WorkflowNode("start", "Start", WorkflowNodeKind.WorkflowStep)]
+[WorkflowEdge("start", "missing")]
+internal sealed class InvalidEdgeWorkflow;
+
+[WorkflowDefinition("MissingDisplayNameWorkflow", "")]
+[WorkflowNode("start", "Start", WorkflowNodeKind.WorkflowStep)]
+internal sealed class MissingDisplayNameWorkflow;


### PR DESCRIPTION
Summary:
- Adds orchestrator workflow topology attributes, definition records, and reflection catalog validation.
- Adds the package ingest workflow definition with waits, command dispatch/completion, child workflows, and finalization.
- Extends `WorkflowNodeKind` with `Wait`, `CommandDispatch`, `CommandCompletion`, and `Finalization`.

Validation:
- Red: `make test-dotnet-contracts` failed before implementation for missing enum values.
- Red: `make test-dotnet-workflow` failed before implementation for missing catalog/topology types.
- `make test-dotnet-workflow` passed.
- `make test-dotnet-contracts` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `make validate-summary` passed on the stacked tip; log: `/tmp/media-asset-ingest-validation-9Tllir.log`.
- `make pr-readiness-check` passed on the stacked tip.

Refs #108