### PR TITLE
USER-STORY-16: Reduce GitHub Project drag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ help:
 	@printf '%s\n' "  make scripts-check       Syntax-check shell scripts"
 	@printf '%s\n' "  make github-projects-script-test Test GitHub tracker helper wrappers"
 	@printf '%s\n' "  make github-project-check     Verify GitHub CLI auth and project access"
-	@printf '%s\n' "  make github-project-summary   Print GitHub tracker counts"
-	@printf '%s\n' "  make github-project-hierarchy Print epic/story hierarchy"
-	@printf '%s\n' "  make github-project-active    Print in-progress project items"
-	@printf '%s\n' "  make github-project-audit-fields Verify required Project fields"
-	@printf '%s\n' "  make github-issue-body-lint   Check issue bodies for duplicated relationships"
+	@printf '%s\n' "  make github-project-summary   Print lightweight tracker counts"
+	@printf '%s\n' "  make github-project-active    Print active story board items"
+	@printf '%s\n' "  make github-project-hierarchy Legacy hierarchy inspection"
+	@printf '%s\n' "  make github-project-audit-fields Legacy detailed field audit"
+	@printf '%s\n' "  make github-issue-body-lint   Legacy relationship metadata check"
 
 agent-preflight:
 	@sh scripts/dev/agent-preflight.sh

--- a/docs/automation/commands.md
+++ b/docs/automation/commands.md
@@ -72,10 +72,10 @@ only when the mount behavior requires them:
 | `make github-projects-script-test` | Test GitHub tracker helper wrappers without network. | cheap | no | no |
 | `make github-project-check` | Verify GitHub CLI auth and project access. | cheap | no | no |
 | `make github-project-summary` | Print GitHub Project, issue, milestone, and item counts. | cheap | no | no |
-| `make github-project-hierarchy` | Print parent/child issue hierarchy when navigation needs inspection. | cheap | no | no |
-| `make github-project-active` | Print in-progress GitHub Project items. | cheap | no | no |
-| `make github-project-audit-fields` | Legacy helper for detailed Project fields; not required for lightweight tracking. | cheap | no | no |
-| `make github-issue-body-lint` | Check issue bodies avoid duplicated relationship metadata. | cheap | no | no |
+| `make github-project-active` | Print in-progress GitHub Project items for lightweight board visibility. | cheap | no | no |
+| `make github-project-hierarchy` | Legacy read-only helper for parent/child navigation when explicitly needed. | cheap | no | no |
+| `make github-project-audit-fields` | Legacy detailed Project field audit; do not use for normal lightweight tracking. | cheap | no | no |
+| `make github-issue-body-lint` | Legacy relationship metadata check; do not use for normal lightweight tracking. | cheap | no | no |
 | `npm run docs:check` | Check docs for unfinished placeholders. | cheap | no | no |
 | `npm run docs:check:summary` | Check docs with compact summary output and a full `/tmp` log. | cheap | no | no |
 | `npm run docs:fix` | Apply safe docs formatting fixes. | cheap | no | no |
@@ -88,10 +88,10 @@ only when the mount behavior requires them:
 | `npm run pr:readiness` | Print the local dry PR readiness checklist through npm. | cheap | no | no |
 | `npm run github-project:check` | Verify GitHub CLI auth and project access through npm. | cheap | no | no |
 | `npm run github-project:summary` | Print GitHub tracker counts through npm. | cheap | no | no |
-| `npm run github-project:hierarchy` | Print GitHub tracker hierarchy through npm. | cheap | no | no |
-| `npm run github-project:active` | Print in-progress GitHub tracker items through npm. | cheap | no | no |
-| `npm run github-project:audit-fields` | Legacy detailed Project field audit through npm; not required for lightweight tracking. | cheap | no | no |
-| `npm run github-project:issue-body-lint` | Check issue body relationship metadata through npm. | cheap | no | no |
+| `npm run github-project:active` | Print in-progress lightweight board items through npm. | cheap | no | no |
+| `npm run github-project:hierarchy` | Legacy hierarchy helper through npm when explicitly needed. | cheap | no | no |
+| `npm run github-project:audit-fields` | Legacy detailed Project field audit through npm; do not use for normal lightweight tracking. | cheap | no | no |
+| `npm run github-project:issue-body-lint` | Legacy relationship metadata check through npm; do not use for normal lightweight tracking. | cheap | no | no |
 | `npm run github-project:script-test` | Test GitHub tracker helper wrappers through npm. | cheap | no | no |
 | `npm run summary-validation:test` | Test the summary validation wrapper through npm. | cheap | no | no |
 | `npm run tools:check` | Verify required Linux development tools through npm. | cheap | no | no |
@@ -104,3 +104,8 @@ summary does not explain a failure.
 
 When a task adds a canonical command, update this file and
 `docs/automation/validation.md` when validation behavior changes.
+
+Normal GitHub Project workflow is limited to summary and active-story board
+visibility. Detailed Project field audits, task metadata updates, worktree or
+branch fields, validation fields, dependency helpers, and relationship linting
+are legacy compatibility surfaces unless a future task explicitly revives them.

--- a/docs/automation/definition-of-done.md
+++ b/docs/automation/definition-of-done.md
@@ -5,7 +5,8 @@
 - Acceptance themes are implemented or explicitly deferred.
 - Tests or validation cover the story behavior.
 - Linked GitHub issues are completed or deferred with rationale when they exist.
-- GitHub Project status reflects the final story state when the story is on the board.
+- GitHub Project status reflects the final story state only when the story is on
+  the lightweight board.
 - `docs/product/user-stories.md` status is updated.
 - `docs/product/milestones.md` mapping remains accurate.
 - No open bugs block the story.
@@ -18,7 +19,8 @@
 - Minimal validation passes.
 - Required docs are updated.
 - Handoff result is prepared.
-- GitHub issue or simple Project status is updated when remote tracking is used.
+- GitHub issue state is updated when remote tracking is used; simple Project
+  status changes only when story-level board visibility changes.
 - `docs/plans/task-index.md` is updated when local task files change.
 
 ## Bug Fix Done
@@ -27,7 +29,8 @@
 - Observed and expected behavior are documented.
 - Regression test fails before the fix and passes after, unless exception is approved.
 - Linked stories/tasks are updated if meaning changes.
-- GitHub bug issue and simple Project status are updated when remote tracking is used.
+- GitHub bug issue state is updated when remote tracking is used; simple Project
+  status changes only when story-level board visibility changes.
 - `docs/bugs/index.md` is updated when local bug files change.
 - Validation evidence is recorded.
 
@@ -35,8 +38,9 @@
 
 - All milestone tasks are completed or deferred.
 - Linked stories reflect current status.
-- GitHub milestone/issues and simple Project status reflect current status when
-  remote tracking is used.
+- GitHub milestone/issues reflect current status when remote tracking is used;
+  simple Project status changes only when milestone/story board visibility
+  changes.
 - Validation evidence is recorded.
 - Status/work log are updated.
 - Known bugs are filed and non-blocking.
@@ -46,7 +50,8 @@
 - ADR is added or updated when a durable decision changes.
 - Architecture docs reflect the decision.
 - Product stories and plans are updated if scope changes.
-- GitHub issues and simple Project status are updated if roadmap scope changes.
+- GitHub issues are updated if roadmap scope changes; simple Project status
+  changes only when story-level board visibility changes.
 - Validation confirms docs have no unfinished placeholders.
 
 ## Tooling Change Done
@@ -62,5 +67,9 @@
 
 - Issue state and simple Project status are updated when needed.
 - Issue bodies stay focused on problem, outcome, and implementation notes.
-- `make github-project-summary` passes.
-- `make github-project-active` reflects the intended active board state.
+- `make github-project-summary` passes when Project visibility changed.
+- `make github-project-active` reflects the intended active board state when
+  active story visibility changed.
+- Detailed field audits, task metadata fields, worktree/branch fields,
+  validation fields, dependency helpers, and relationship linting are legacy
+  checks unless a future task explicitly revives them.

--- a/docs/automation/execution-checklist.md
+++ b/docs/automation/execution-checklist.md
@@ -37,7 +37,8 @@ scope and report staged and unstaged files separately.
 - [ ] Decide whether the task has 2+ independent lanes suitable for subagents.
 - [ ] If subagents are suitable and authorized, dispatch them before deep local work.
 - [ ] Set a context budget: plan a handoff/checkpoint before long logs, broad diffs, or compaction risk.
-- [ ] Read `docs/automation/github-projects.md`.
+- [ ] Read `docs/automation/github-projects.md` when issue, PR, milestone, or
+      simple Project status may change.
 - [ ] Identify ownership lane from `docs/automation/roles.md`.
 - [ ] Identify linked GitHub issue, user stories, and milestone.
 - [ ] Check the linked GitHub issue when remote context is needed.
@@ -56,7 +57,8 @@ scope and report staged and unstaged files separately.
 - [ ] Before `make validate`, `local-runtime-smoke`, Docker validation, or other long commands, update the state record, then run a summary validation command when available.
 - [ ] Close completed subagents after their findings are integrated.
 - [ ] Follow BDD/TDD for behavior changes.
-- [ ] Update GitHub issue or simple Project status only when tracker state changes.
+- [ ] Update GitHub issue or simple story-level Project status only when
+      tracker state changes.
 - [ ] Update task, story, milestone, status, and bug docs when durable repo context changes.
 - [ ] Record validation evidence.
 
@@ -66,7 +68,8 @@ scope and report staged and unstaged files separately.
 - [ ] Prefer `*-summary` validation targets for broad commands, and report the log path.
 - [ ] Run stronger validation if the change touches runtime, contracts, infra, or tooling.
 - [ ] Run `git diff --check`.
-- [ ] Run lightweight GitHub tracker validation when tracker state changed.
+- [ ] Run lightweight GitHub tracker validation when issue, PR, milestone, or
+      simple Project status changed.
 - [ ] Update required docs.
 - [ ] Review staged and unstaged paths separately.
 - [ ] Prefer small local commits after validation when the change is ready.

--- a/docs/automation/github-projects.md
+++ b/docs/automation/github-projects.md
@@ -1,7 +1,8 @@
 # GitHub Tracking
 
 GitHub is a lightweight visibility layer. Repo-local product, architecture,
-standards, and task docs remain the durable execution context.
+standards, issues, PRs, commits, and status files remain the durable execution
+record.
 
 ## Project
 
@@ -15,7 +16,11 @@ standards, and task docs remain the durable execution context.
 - Keep parent/child issue relationships only when they improve navigation.
 - Keep the GitHub Project as a simple status board: `Todo`, `In Progress`,
   `Done`, and optionally `Blocked`.
+- Keep the Project focused on milestone/story visibility items and the current
+  active story. Task issues are useful, but they do not need Project cards.
 - Let PRs link issues naturally with `Refs #<issue>` or `Closes #<issue>`.
+- Treat `docs/status/current-status.md` as the current execution snapshot. Stale
+  Project status must not override repo docs, issues, PRs, or commits.
 
 Do not require routine maintenance of:
 
@@ -24,6 +29,10 @@ Do not require routine maintenance of:
   worktree, or validation
 - Project field audits
 - worktree/branch metadata in GitHub
+
+Completed task issues, including closed tasks such as `#107` through `#110`,
+should stay closed issues. Do not create board maintenance work just to add,
+remove, or backfill task-level Project cards.
 
 ## Agent Rules
 
@@ -57,6 +66,22 @@ make github-project-active
 
 `make github-project-hierarchy` remains available when parent/child navigation
 needs inspection, but it is not required for every task.
+
+## Legacy Helper Surface
+
+Keep `make github-project-summary` and `make github-project-active` as the
+normal Project checks. Use status updates only for simple board movement.
+
+The following helpers are legacy compatibility commands. Do not use them as
+normal workflow unless a future task explicitly revives detailed Project
+tracking:
+
+- detailed Project field audits
+- task metadata field updates, including type, lane, target files, branch,
+  worktree, PR, or validation fields
+- blocked-by dependency helpers
+- issue relationship linting
+- relationship backfills for completed task issues
 
 ## Current Milestone Story Map
 

--- a/docs/automation/guardrails.md
+++ b/docs/automation/guardrails.md
@@ -26,9 +26,9 @@
   UI infrastructure details.
 - Update status, backlog, milestone, standards, tooling, and automation docs
   when a task changes their meaning.
-- Update GitHub issues or simple Project status when issue, milestone, task,
-  bug, dependency, or PR state changes. Keep worktree state in ignored local
-  `.worktrees/state/` files.
+- Update GitHub issues when issue, milestone, task, bug, dependency, or PR state
+  changes. Update simple Project status only when story-level board visibility
+  changes. Keep worktree state in ignored local `.worktrees/state/` files.
 - Do not duplicate GitHub-native relationships in issue descriptions.
 - Update `README.md` quickstart when setup, tools, commands, validation, or
   local runtime behavior changes.

--- a/docs/automation/parallelization.md
+++ b/docs/automation/parallelization.md
@@ -4,7 +4,7 @@ Parallel agents are allowed only when file ownership is disjoint and task
 dependencies do not require sequential execution.
 
 Use GitHub issues and PRs for durable work tracking. Use the GitHub Project as
-a lightweight status board only. Use ignored local
+a lightweight story-level status board only. Use ignored local
 `.worktrees/state/<worktree-slug>.md` records for active parallel Codex
 processes.
 
@@ -72,7 +72,8 @@ Each parallel agent must receive:
 - expected handoff format
 - requirement to update `.worktrees/state/<worktree-slug>.md` while the worktree is active
 - requirement to clean up its own local worktree after the PR merges
-- requirement to update simple GitHub status when tracker state changes
+- requirement to update issue state, and simple story-level Project status only
+  when board visibility changes
 
 ## Local State Record
 
@@ -113,10 +114,11 @@ Do not merge competing edits manually without a new plan.
 1. Create worktree from current `main`.
 2. Create or update `.worktrees/state/<worktree-slug>.md`.
 3. Execute only the assigned task scope.
-4. Update only simple GitHub Project status when visibility needs it.
+4. Update only simple story-level GitHub Project status when visibility needs it.
 5. Mark the local state `Ready For PR` after validation passes.
 6. Create PR when authorized.
-7. Mark simple GitHub Project status and local state `PR Open` when tracking it.
+7. Mark local state `PR Open` when tracking it; move Project status only when
+   story-level board visibility needs it.
 8. After merge, the owning agent must remove its local worktree, then delete
    the matching `.worktrees/state/<worktree-slug>.md` file.
 
@@ -171,19 +173,20 @@ Treat context as a finite execution resource.
 
 GitHub Project commands must be serialized across terminals. Parallel agents may
 work on local files at the same time, but they must not run Project status
-writes or bulk tracker validation concurrently.
+writes or tracker validation concurrently.
 
 Recommended pattern:
 
 1. One coordinator runs tracker checks before dispatch.
 2. Each agent works locally and validates locally.
 3. Agents update local docs and prepare handoff.
-4. The coordinator serially updates simple GitHub status and opens PRs, or one
-   agent at a time performs those steps after confirming no other tracker
-   command is running.
+4. The coordinator serially updates issues, simple story-level Project status,
+   and PRs, or one agent at a time performs those steps after confirming no
+   other tracker command is running.
 5. The coordinator runs one lightweight tracker check after tracker writes complete.
 
 Prefer the GitHub plugin for structured repository, issue, PR, review, diff,
 commit, CI, comment, label, and merge operations. Reserve `gh project`,
-`make github-project-*`, and `scripts/dev/github-projects.sh` for checkpoint
-updates because those commands consume the shared GitHub GraphQL budget.
+`make github-project-summary`, `make github-project-active`, and simple
+`scripts/dev/github-projects.sh set-status` calls for lightweight board
+visibility because those commands consume the shared GitHub GraphQL budget.

--- a/docs/automation/pr-checklist.md
+++ b/docs/automation/pr-checklist.md
@@ -19,7 +19,8 @@ Automatic PR creation still requires all checks in this file.
 - [ ] `make docs-fix` was run when docs formatting/link checks reported fixable issues.
 - [ ] `make validate` passes.
 - [ ] `git diff --check` passes.
-- [ ] GitHub issue state or simple Project status is updated when tracker state changed.
+- [ ] GitHub issue state is updated when tracker state changed.
+- [ ] Simple Project status is updated only when story-level board visibility changed.
 - [ ] Lightweight GitHub tracker validation runs when issues or board status changed.
 - [ ] Product docs, status, and work log are updated when durable repo context changes.
 - [ ] Local task and bug mirrors are updated when local task or bug files change.
@@ -42,8 +43,8 @@ The PR body must include:
 - risk
 - follow-up notes
 
-After creating the PR, update the issue or simple Project status only when that
-status is meaningful for visibility.
+After creating the PR, update the issue state when useful. Update simple Project
+status only when story-level board visibility changes.
 
 ## PR Readiness Gate
 

--- a/docs/automation/validation.md
+++ b/docs/automation/validation.md
@@ -8,7 +8,7 @@
 | Automation process docs only | `make docs-check` and `git diff --check` | `make validate` before PR when command docs, scripts, or Makefile targets also changed | no | no | cheap |
 | Standards change | `make docs-check` and the relevant focused validation target | `make validate` and review affected automation docs and task workflow | no | no | cheap |
 | Tooling change | `make validate-summary` and `make check-tools` when host tools are expected | `make validate`, then `make print-install-tools` review | no | no | cheap |
-| GitHub tracker change | GitHub plugin inspection, `make github-project-summary`, and `make github-project-active` | targeted GitHub plugin issue/PR inspection, `make github-project-hierarchy` only when parent/child navigation changed | no | no | cheap |
+| GitHub tracker change | GitHub plugin inspection plus `make github-project-summary` or `make github-project-active` when Project visibility changed | targeted GitHub plugin issue/PR inspection, `make github-project-hierarchy` only when parent/child navigation changed | no | no | cheap |
 | .NET code change | focused `make test-dotnet-*` target for the touched component | `make test-dotnet`, then `make validate` before PR | yes when host `dotnet` is unavailable | no | moderate |
 | Generic command runner change | `make test-dotnet-command-runner` | `make test-dotnet`, then `make validate` before PR | yes when host `dotnet` is unavailable | no | moderate |
 | React control-plane change | `make test-ui` | `make test-ui` plus `make validate` before PR when backend contracts also changed | no | no | cheap |
@@ -44,3 +44,8 @@ code, key success or failure lines, and log path.
 
 Run `make pr-readiness-check` before reporting PR readiness to print the local
 changed-path summary, state-record status, and validation reminders.
+
+For Project-only visibility changes, prefer `make github-project-summary` and
+`make github-project-active`. Do not run legacy Project field audits,
+relationship linting, or dependency helper checks unless the task explicitly
+revives detailed tracker maintenance.

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -34,7 +34,7 @@
 - GitHub Projects roadmap created with milestone epics and numbered user-story
   issues.
 - Initial GitHub issue hierarchy, dependencies, issue bodies, and Project fields
-  refined; later simplified to lightweight board tracking.
+  refined; later simplified to lightweight story-level board tracking.
 - Read-only GitHub tracker helper commands added for agent verification.
 - Local task, bug, checklist, and definition-of-done docs aligned with the
   lightweight GitHub tracker model.
@@ -42,11 +42,11 @@
   naming conventions were merged in PR #29.
 - Task issues #30 through #37 were created for the first parallel execution
   lanes, with #30 and #32 active as the foundation worktrees.
-- GitHub tracker helper commands were added for Project field updates, native
-  sub-issue links, and native blocked-by dependency links.
-- GitHub tracker helper commands now also cover required Project field audits,
-  issue-body relationship linting, and PR creation with Project plus local
-  worktree-state updates.
+- Legacy GitHub tracker helper commands exist for Project field updates, native
+  sub-issue links, blocked-by dependency links, field audits, issue-body
+  relationship linting, and PR creation with local worktree-state updates, but
+  normal Project workflow is limited to lightweight summary, active-story
+  visibility, and simple status movement.
 - TASK-2-1 added the initial buildable .NET solution skeleton and canonical
   `make test-dotnet` validation entrypoint.
 - TASK-2-2 defined initial shared workflow graph, node detail, status, and
@@ -65,8 +65,8 @@
 - The tracked active worktree ledger was removed from planning docs to avoid
   conflicts across parallel PRs.
 - GitHub tracker state for task issues #31 and #33 through #37 was reconciled
-  to closed, `status:complete`, and Project `Done`; future tracking is
-  lightweight status only.
+  to closed. Future Project tracking is lightweight story-level status only;
+  task issues do not require Project cards.
 - Command routing now uses semantic command topics and light, medium, or heavy
   execution classes instead of media-specific command runner projects.
 - Agent execution tooling now includes focused .NET smoke-test targets, focused
@@ -163,6 +163,10 @@
   `/tmp` while printing command, exit code, key success or failure lines, and
   log path. Current task capsules live in ignored `.worktrees/state/` records
   for compact resume context.
+- GitHub Project guidance now treats the Project as a simple visibility board:
+  repo docs, issues, PRs, commits, and status files are authoritative; detailed
+  Project fields, task-card backfills, validation fields, dependency helpers,
+  and relationship linting are legacy unless explicitly revived.
 
 ## Next
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -3,6 +3,14 @@
 Use this log for concise human-readable progress notes. Do not duplicate commit
 messages or paste command output unless it explains a decision.
 
+## 2026-05-09
+
+- Reduced GitHub Project guidance to a lightweight story-level visibility board:
+  repo docs, GitHub issues, PRs, commits, and status files remain the durable
+  record, while detailed Project fields, task-card backfills, validation fields,
+  dependency helpers, and relationship linting are legacy unless explicitly
+  revived.
+
 ## 2026-05-06
 
 - Added TASK-5-3 workflow orchestrator boundary: the new

--- a/scripts/dev/github-projects.sh
+++ b/scripts/dev/github-projects.sh
@@ -12,18 +12,18 @@ Usage: scripts/dev/github-projects.sh <command>
 Commands:
   check-auth       Verify GitHub CLI auth and project access.
   summary          Print project, milestone, issue, and item counts.
-  hierarchy        Print epic sub-issue hierarchy.
-  active           Print in-progress project items.
-  audit-fields     Verify required Project fields are populated.
-  lint-issue-bodies Verify issue bodies avoid duplicated relationship metadata.
-  open-pr          Create a PR and update tracker/worktree PR state.
+  active           Print active story board items.
+  hierarchy        Legacy: print epic sub-issue hierarchy.
+  audit-fields     Legacy: verify detailed Project fields are populated.
+  lint-issue-bodies Legacy: check duplicated relationship metadata.
+  open-pr          Legacy: create a PR and update tracker/worktree PR state.
   set-status       Set GitHub Project Status for an issue.
-  set-type         Set GitHub Project Type for an issue.
-  set-lane         Set GitHub Project Lane for an issue.
-  set-text         Set a GitHub Project text field for an issue.
-  set-task-fields  Set common task Project fields in one serialized call.
-  add-sub-issue    Add a native GitHub sub-issue relationship.
-  add-blocked-by   Add a native GitHub blocked-by dependency.
+  set-type         Legacy: set GitHub Project Type for an issue.
+  set-lane         Legacy: set GitHub Project Lane for an issue.
+  set-text         Legacy: set a GitHub Project text field for an issue.
+  set-task-fields  Legacy: set common task Project fields.
+  add-sub-issue    Legacy: add a native GitHub sub-issue relationship.
+  add-blocked-by   Legacy: add a native GitHub blocked-by dependency.
 
 Environment overrides:
   GITHUB_PROJECT_OWNER
@@ -31,6 +31,8 @@ Environment overrides:
   GITHUB_PROJECT_NUMBER
 
 Write operations require explicit agent approval before running the command.
+Use only summary, active, and simple status movement for normal lightweight
+tracking unless a future task explicitly revives detailed Project maintenance.
 USAGE
 }
 


### PR DESCRIPTION
## Summary

- Demotes the GitHub Project to a lightweight story-level visibility board in automation guidance.
- Marks detailed Project field audits, task metadata fields, worktree/branch fields, validation fields, dependency helpers, and relationship linting as legacy unless explicitly revived.
- Updates Makefile/help and GitHub helper usage text so normal workflow points at summary/active board visibility instead of legacy maintenance.

Refs #26

## Validation

- `make validate-summary` passed in a clean detached worktree at commit `567e285`; log: `/tmp/media-asset-ingest-validation-WWPnEv.log`
- `git diff HEAD~1..HEAD --check` passed in the same clean detached worktree

## Risk

Low. This is documentation and helper usage text only; no tracker writes or remote Project state changes were made.

## Notes

The source/test/runtime edits currently present in the shared local checkout were intentionally left unstaged and are not part of this PR.