### PR TITLE
USER-STORY-16: Add reviewable local durable ingest slice

### DIFF
--- a/MediaIngest.sln
+++ b/MediaIngest.sln
@@ -43,6 +43,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaIngest.Workflow.Orchestrator", "src\MediaIngest.Workflow.Orchestrator\MediaIngest.Workflow.Orchestrator.csproj", "{BEE9C200-DB47-4575-8D21-9290024CBF18}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaIngest.Worker.Outbox.Host", "src\MediaIngest.Worker.Outbox.Host\MediaIngest.Worker.Outbox.Host.csproj", "{ED4C668F-4551-4689-B032-53E0C85B3B24}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaIngest.Worker.CommandRunner.Host", "src\MediaIngest.Worker.CommandRunner.Host\MediaIngest.Worker.CommandRunner.Host.csproj", "{2A96F249-E32C-458F-B438-84EA19E22680}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -281,11 +285,37 @@ Global
 		{BEE9C200-DB47-4575-8D21-9290024CBF18}.Release|x64.Build.0 = Release|Any CPU
 		{BEE9C200-DB47-4575-8D21-9290024CBF18}.Release|x86.ActiveCfg = Release|Any CPU
 		{BEE9C200-DB47-4575-8D21-9290024CBF18}.Release|x86.Build.0 = Release|Any CPU
+		{ED4C668F-4551-4689-B032-53E0C85B3B24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED4C668F-4551-4689-B032-53E0C85B3B24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED4C668F-4551-4689-B032-53E0C85B3B24}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ED4C668F-4551-4689-B032-53E0C85B3B24}.Debug|x64.Build.0 = Debug|Any CPU
+		{ED4C668F-4551-4689-B032-53E0C85B3B24}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ED4C668F-4551-4689-B032-53E0C85B3B24}.Debug|x86.Build.0 = Debug|Any CPU
+		{ED4C668F-4551-4689-B032-53E0C85B3B24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED4C668F-4551-4689-B032-53E0C85B3B24}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED4C668F-4551-4689-B032-53E0C85B3B24}.Release|x64.ActiveCfg = Release|Any CPU
+		{ED4C668F-4551-4689-B032-53E0C85B3B24}.Release|x64.Build.0 = Release|Any CPU
+		{ED4C668F-4551-4689-B032-53E0C85B3B24}.Release|x86.ActiveCfg = Release|Any CPU
+		{ED4C668F-4551-4689-B032-53E0C85B3B24}.Release|x86.Build.0 = Release|Any CPU
+		{2A96F249-E32C-458F-B438-84EA19E22680}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A96F249-E32C-458F-B438-84EA19E22680}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A96F249-E32C-458F-B438-84EA19E22680}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2A96F249-E32C-458F-B438-84EA19E22680}.Debug|x64.Build.0 = Debug|Any CPU
+		{2A96F249-E32C-458F-B438-84EA19E22680}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2A96F249-E32C-458F-B438-84EA19E22680}.Debug|x86.Build.0 = Debug|Any CPU
+		{2A96F249-E32C-458F-B438-84EA19E22680}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A96F249-E32C-458F-B438-84EA19E22680}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A96F249-E32C-458F-B438-84EA19E22680}.Release|x64.ActiveCfg = Release|Any CPU
+		{2A96F249-E32C-458F-B438-84EA19E22680}.Release|x64.Build.0 = Release|Any CPU
+		{2A96F249-E32C-458F-B438-84EA19E22680}.Release|x86.ActiveCfg = Release|Any CPU
+		{2A96F249-E32C-458F-B438-84EA19E22680}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{BEE9C200-DB47-4575-8D21-9290024CBF18} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{ED4C668F-4551-4689-B032-53E0C85B3B24} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{2A96F249-E32C-458F-B438-84EA19E22680} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Use Docker Compose for the current runnable local system:
 make up
 ```
 
-That target builds and starts the local API, UI, and PostgreSQL services with:
+That target builds and starts the local API, UI, PostgreSQL, outbox worker, and
+light/medium/heavy command-runner worker services with:
 
 ```bash
 docker compose -f deploy/docker/compose.yaml up --build
@@ -99,26 +100,29 @@ static Compose validation:
 make local-runtime-smoke
 ```
 
-That target starts the API, UI, and PostgreSQL Compose stack, waits for local
-API and UI HTTP responses, runs the scripted manifest ingest smoke against the
-containerized API, and stops the stack. The smoke expects the copied manifest
-pair plus workflow command-node evidence for media, sidecar, and metadata
-files. It uses only local containers, repo-root `input/` and `output/` bind
-mounts, and local HTTP endpoints. Override `LOCAL_COMPOSE_API_PORT`,
-`LOCAL_COMPOSE_UI_PORT`, or `LOCAL_COMPOSE_POSTGRES_PORT` if another local
-process already owns the default ports. The smoke script runs the API container
-with the current host UID/GID so bind-mounted smoke output remains writable by
-the host user.
+That target starts the API, UI, PostgreSQL, outbox worker, and command-runner
+Compose stack, waits for local API and UI HTTP responses, runs the scripted
+manifest ingest smoke against the containerized API, queries PostgreSQL for
+durable package and dispatched command outbox rows, and stops the stack. The
+smoke expects the copied manifest pair plus workflow command-node evidence for
+media, sidecar, and metadata files. It uses only local containers, repo-root
+`input/` and `output/` bind mounts, local HTTP endpoints, and PostgreSQL inside
+Compose. Override `LOCAL_COMPOSE_API_PORT`, `LOCAL_COMPOSE_UI_PORT`, or
+`LOCAL_COMPOSE_POSTGRES_PORT` if another local process already owns the default
+ports. The smoke script runs the API container with the current host UID/GID so
+bind-mounted smoke output remains writable by the host user.
 
 ## Local Manifest Ingest Demo
 
-This local workflow exercises the manifest start path through the API, React
-control plane, and repo-root runtime folders. It still runs in process for local
-development and does not use the real Dapr Workflow runtime, PostgreSQL, Azure
-Service Bus, or command runner services. Ready packages are scanned recursively;
-the manifest pair is copied to local output, and each non-metadata file becomes
-a locally accepted command envelope with a semantic topic and `executionClass`
-for the workflow graph demo.
+This host workflow exercises the manifest start path through the API, React
+control plane, and repo-root runtime folders. The direct `dotnet run` path uses
+in-memory persistence by default for focused local development. The Docker
+Compose path uses PostgreSQL through raw Npgsql and runs the review worker
+containers. Neither path uses the real Dapr Workflow runtime, Azure Service Bus,
+or paid cloud resources. Ready packages are scanned recursively; the manifest
+pair is copied to local output, and each non-metadata file becomes a locally
+accepted command envelope with a semantic topic and `executionClass` for the
+workflow graph demo.
 
 Start the local ingest API on a fixed development port:
 
@@ -173,6 +177,16 @@ To validate the smoke plan without starting the API or touching files:
 ```bash
 sh scripts/dev/local-e2e-smoke.sh --dry-run
 ```
+
+For the reviewable durable slice, prefer:
+
+```bash
+make local-runtime-smoke
+```
+
+Reviewer notes and source anchors live in
+[docs/review/local-durable-ingest-review-guide.md](docs/review/local-durable-ingest-review-guide.md).
+The current API contract lives in [docs/api/openapi.yaml](docs/api/openapi.yaml).
 
 ## Agent Tooling
 

--- a/deploy/docker/compose.yaml
+++ b/deploy/docker/compose.yaml
@@ -7,6 +7,9 @@ services:
       ASPNETCORE_URLS: http://+:8080
       Ingest__InputPath: /mnt/ingest/input
       Ingest__OutputPath: /mnt/ingest/output
+      Persistence__Provider: Postgres
+      Persistence__ConnectionString: Host=postgres;Port=5432;Database=media_ingest;Username=postgres
+      Persistence__CreateSchemaOnStartup: "true"
     user: "${LOCAL_COMPOSE_UID:-1000}:${LOCAL_COMPOSE_GID:-1000}"
     ports:
       - "${LOCAL_COMPOSE_API_PORT:-5000}:8080"
@@ -16,6 +19,90 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+
+  outbox-worker:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/dotnet-worker.Dockerfile
+      args:
+        PROJECT_PATH: src/MediaIngest.Worker.Outbox.Host/MediaIngest.Worker.Outbox.Host.csproj
+        DLL_NAME: MediaIngest.Worker.Outbox.Host.dll
+    environment:
+      Persistence__ConnectionString: Host=postgres;Port=5432;Database=media_ingest;Username=postgres
+      Worker__IntervalMilliseconds: "1000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      api:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /app/MediaIngest.Worker.Outbox.Host.dll"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  command-runner-light:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/dotnet-worker.Dockerfile
+      args:
+        PROJECT_PATH: src/MediaIngest.Worker.CommandRunner.Host/MediaIngest.Worker.CommandRunner.Host.csproj
+        DLL_NAME: MediaIngest.Worker.CommandRunner.Host.dll
+    environment:
+      Worker__ExecutionClass: light
+      Worker__IntervalMilliseconds: "1000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      outbox-worker:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /app/MediaIngest.Worker.CommandRunner.Host.dll"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  command-runner-medium:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/dotnet-worker.Dockerfile
+      args:
+        PROJECT_PATH: src/MediaIngest.Worker.CommandRunner.Host/MediaIngest.Worker.CommandRunner.Host.csproj
+        DLL_NAME: MediaIngest.Worker.CommandRunner.Host.dll
+    environment:
+      Worker__ExecutionClass: medium
+      Worker__IntervalMilliseconds: "1000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      outbox-worker:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /app/MediaIngest.Worker.CommandRunner.Host.dll"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  command-runner-heavy:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/dotnet-worker.Dockerfile
+      args:
+        PROJECT_PATH: src/MediaIngest.Worker.CommandRunner.Host/MediaIngest.Worker.CommandRunner.Host.csproj
+        DLL_NAME: MediaIngest.Worker.CommandRunner.Host.dll
+    environment:
+      Worker__ExecutionClass: heavy
+      Worker__IntervalMilliseconds: "1000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      outbox-worker:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /app/MediaIngest.Worker.CommandRunner.Host.dll"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
 
   ui:
     build:

--- a/deploy/docker/dotnet-worker.Dockerfile
+++ b/deploy/docker/dotnet-worker.Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+ARG PROJECT_PATH
+COPY . .
+RUN dotnet publish "$PROJECT_PATH" \
+    --configuration Release \
+    --output /app/publish \
+    --no-self-contained
+
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS runtime
+WORKDIR /app
+
+ARG DLL_NAME
+ENV DOTNET_WORKER_DLL=$DLL_NAME
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["/bin/sh", "-c", "dotnet \"$DOTNET_WORKER_DLL\""]

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,9 @@ Start here for durable project documentation.
 - [adr](adr/README.md) - architecture decision records.
 - [product](product/user-stories.md) - user stories and milestones.
 - [plans](plans/README.md) - milestone plans, task plans, and planning workflow.
+- [api](api/openapi.yaml) - current local control-plane HTTP contract.
+- [review](review/local-durable-ingest-review-guide.md) - local durable ingest
+  review path, source anchors, and known gaps.
 - [bugs](bugs/README.md) - bug reports and defect tracking.
 - [standards](standards/dotnet.md) - implementation, testing, domain, and tooling standards.
 - [status](status/current-status.md) - current project state, decisions, and work log.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,242 @@
+openapi: 3.1.0
+info:
+  title: Media Asset Ingest Local Control Plane API
+  version: 0.1.0
+  description: >
+    Current local review API for starting the ingest watcher, reading package
+    status, listing workflows, and inspecting workflow graph/node details.
+servers:
+  - url: http://127.0.0.1:5000
+paths:
+  /api/ingest/start:
+    post:
+      summary: Start local ingest scanning
+      responses:
+        "202":
+          description: Ingest scan accepted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestStartResponse"
+        "409":
+          description: A ready package could not be started because local output already exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+  /api/ingest/status:
+    get:
+      summary: List current package ingest states
+      responses:
+        "200":
+          description: Current package status list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestStatusResponse"
+  /api/workflows:
+    get:
+      summary: List package workflow instances
+      responses:
+        "200":
+          description: Current workflow list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowListResponse"
+  /api/workflows/{workflowInstanceId}/graph:
+    get:
+      summary: Get a workflow graph
+      parameters:
+        - $ref: "#/components/parameters/WorkflowInstanceId"
+      responses:
+        "200":
+          description: Workflow graph.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowGraph"
+        "404":
+          description: Workflow graph not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+  /api/workflows/{workflowInstanceId}/nodes/{nodeId}:
+    get:
+      summary: Get workflow node diagnostics
+      parameters:
+        - $ref: "#/components/parameters/WorkflowInstanceId"
+        - name: nodeId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Node timeline and diagnostic logs.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowNodeDetails"
+        "404":
+          description: Workflow node details not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+components:
+  parameters:
+    WorkflowInstanceId:
+      name: workflowInstanceId
+      in: path
+      required: true
+      schema:
+        type: string
+  schemas:
+    IngestStartResponse:
+      type: object
+      required: [startedPackages]
+      properties:
+        startedPackages:
+          type: array
+          items:
+            type: object
+            required: [packageId, workflowInstanceId]
+            properties:
+              packageId:
+                type: string
+              workflowInstanceId:
+                type: string
+    IngestStatusResponse:
+      type: object
+      required: [packages]
+      properties:
+        packages:
+          type: array
+          items:
+            $ref: "#/components/schemas/PackageStatus"
+    PackageStatus:
+      type: object
+      required: [packageId, workflowInstanceId, status, updatedAt]
+      properties:
+        packageId:
+          type: string
+        workflowInstanceId:
+          type: string
+        status:
+          type: string
+          enum: [Started, Succeeded, Failed]
+        updatedAt:
+          type: string
+          format: date-time
+    WorkflowListResponse:
+      type: object
+      required: [workflows]
+      properties:
+        workflows:
+          type: array
+          items:
+            $ref: "#/components/schemas/PackageStatus"
+    WorkflowGraph:
+      type: object
+      required: [workflowInstanceId, workflowName, packageId, nodes, edges]
+      properties:
+        workflowInstanceId:
+          type: string
+        workflowName:
+          type: string
+        packageId:
+          type: string
+        parentWorkflowInstanceId:
+          type: [string, "null"]
+        nodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowNode"
+        edges:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowEdge"
+    WorkflowNode:
+      type: object
+      required: [nodeId, displayName, kind, status]
+      properties:
+        nodeId:
+          type: string
+        displayName:
+          type: string
+        kind:
+          type: integer
+        status:
+          type: integer
+        childWorkflowInstanceId:
+          type: [string, "null"]
+    WorkflowEdge:
+      type: object
+      required: [sourceNodeId, targetNodeId]
+      properties:
+        sourceNodeId:
+          type: string
+        targetNodeId:
+          type: string
+    WorkflowNodeDetails:
+      type: object
+      required: [workflowInstanceId, nodeId, timeline, logs]
+      properties:
+        workflowInstanceId:
+          type: string
+        nodeId:
+          type: string
+        timeline:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowTimelineEntry"
+        logs:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowNodeLogEntry"
+    WorkflowTimelineEntry:
+      type: object
+      required: [occurredAt, status, message, correlationId]
+      properties:
+        occurredAt:
+          type: string
+          format: date-time
+        status:
+          type: integer
+        message:
+          type: string
+        correlationId:
+          type: string
+    WorkflowNodeLogEntry:
+      type: object
+      required: [occurredAt, level, message, correlationId]
+      properties:
+        occurredAt:
+          type: string
+          format: date-time
+        level:
+          type: string
+        message:
+          type: string
+        correlationId:
+          type: string
+        traceId:
+          type: [string, "null"]
+        spanId:
+          type: [string, "null"]
+    ProblemDetails:
+      type: object
+      required: [title, status, traceId]
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+        traceId:
+          type: string

--- a/docs/automation/commands.md
+++ b/docs/automation/commands.md
@@ -37,10 +37,10 @@ only when the mount behavior requires them:
 | `make install-optional-tools` | Install optional host runtime and cloud CLIs after local confirmation. | moderate | no | no |
 | `make print-install-tools` | Print installation commands without running them. | cheap | no | no |
 | `make print-install-optional-tools` | Print optional host tool installation commands without running them. | cheap | no | no |
-| `make up` | Start the local API, UI, and PostgreSQL Docker Compose runtime with image builds. | moderate | yes | no |
+| `make up` | Start the local API, UI, PostgreSQL, outbox worker, and command-runner Docker Compose runtime with image builds. | moderate | yes | no |
 | `make down` | Stop the local Docker Compose runtime. | cheap | yes | no |
 | `make local-compose-check` | Validate `deploy/docker/compose.yaml` with `docker compose config` without starting containers. | cheap | yes | no |
-| `make local-runtime-smoke` | Start the local Compose API, UI, and PostgreSQL runtime, wait for API/UI HTTP responses, run the local ingest smoke script, and stop the stack. | moderate | yes | no |
+| `make local-runtime-smoke` | Start the local Compose API, UI, PostgreSQL, outbox worker, and command-runner runtime, wait for API/UI HTTP responses, run the local ingest smoke script, query PostgreSQL durable state/outbox evidence, and stop the stack. | moderate | yes | no |
 | `make validate` | Run cheap repository validation. | cheap | no | no |
 | `make validate-summary` | Run `make validate`, capture the full log under `/tmp`, and print only the command, exit code, key success or failure lines, and log path. Prefer this before broad validation in agent sessions. | cheap | no | no |
 | `make validate-docs` | Run documentation validation only. | cheap | no | no |
@@ -52,9 +52,9 @@ only when the mount behavior requires them:
 | `cd web/ingest-control-plane && npm run dev` | Start the React control plane with Vite `/api` proxying to the local API. | cheap | no | no |
 | `sh scripts/dev/local-e2e-smoke.sh --dry-run` | Print the local manifest ingest E2E smoke plan without changing files or calling the API. Use `SMOKE_EXPECT_COPIED_FILES=manifest` to plan manifest-only copied output assertions with command-node evidence. | cheap | no | no |
 | `sh scripts/dev/local-e2e-smoke.sh` | Post local ingest start, create a smoke package, assert copied output files, and verify the workflow graph exposes routed command nodes. Requires the API to be running locally. Use `SMOKE_EXPECT_COPIED_FILES=manifest` when the runtime should assert only the copied manifest pair plus command-node evidence. | cheap | no | no |
-| `sh scripts/dev/local-compose-check.sh --dry-run` | Print the API/UI/PostgreSQL Compose validation plan without changing files or starting containers. | cheap | no | no |
+| `sh scripts/dev/local-compose-check.sh --dry-run` | Print the API/UI/PostgreSQL/outbox/command-runner Compose validation plan without changing files or starting containers. | cheap | no | no |
 | `sh scripts/dev/local-compose-check.sh` | Run `docker compose -f deploy/docker/compose.yaml config` and report resolved local services. | cheap | yes | no |
-| `sh scripts/dev/local-compose-check.sh --runtime-smoke` | Start the local Compose runtime with project name `media-asset-ingest-local`, wait for API/UI HTTP responses, run `scripts/dev/local-e2e-smoke.sh` with manifest-output assertions and command-node evidence, and stop the stack. Override `LOCAL_COMPOSE_API_PORT`, `LOCAL_COMPOSE_UI_PORT`, or `LOCAL_COMPOSE_POSTGRES_PORT` when default local ports are busy; the script exports the current UID/GID for host-writable smoke output. | moderate | yes | no |
+| `sh scripts/dev/local-compose-check.sh --runtime-smoke` | Start the local Compose runtime with project name `media-asset-ingest-local`, wait for API/UI HTTP responses, run `scripts/dev/local-e2e-smoke.sh` with manifest-output assertions and command-node evidence, query PostgreSQL for persisted package state and dispatched command outbox rows, and stop the stack. Override `LOCAL_COMPOSE_API_PORT`, `LOCAL_COMPOSE_UI_PORT`, `LOCAL_COMPOSE_POSTGRES_PORT`, or `SMOKE_PACKAGE_ID` when needed; the script exports the current UID/GID for host-writable smoke output. | moderate | yes | no |
 | `sh scripts/dev/local-compose-check.sh --runtime-smoke --dry-run` | Print the local Compose runtime smoke plan without requiring Docker, changing files, starting containers, or calling local HTTP endpoints. | cheap | no | no |
 | `make test-dotnet` | Build and smoke-test the .NET solution using host `dotnet` or the .NET SDK container. | moderate | yes when host `dotnet` is unavailable | no |
 | `make test-dotnet-summary` | Run .NET solution validation with compact summary output and a full `/tmp` log. | moderate | yes when host `dotnet` is unavailable | no |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -10,6 +10,7 @@ Planning artifacts turn product stories into executable implementation work.
 - `docs/plans/parallel-system-components.md` - current parallel
   system-component track plan.
 - `docs/plans/milestones/` - milestone-level implementation plans.
+- `docs/plans/slices/` - cross-milestone review slice plans.
 - `docs/plans/tasks/` - small task files created from milestone plans.
 - `docs/bugs/` - defect reports and bug-fix tracking.
 - `docs/plans/templates/` - copyable plan and task templates.

--- a/docs/plans/slices/reviewable-local-durable-ingest-slice.md
+++ b/docs/plans/slices/reviewable-local-durable-ingest-slice.md
@@ -1,0 +1,43 @@
+# Reviewable Local Durable Ingest Slice
+
+## Intent
+
+Make the current local media ingest implementation externally reviewable as a
+small product slice: API, UI, PostgreSQL state, outbox evidence, workflow graph,
+node diagnostics, and local Docker Compose startup should all run without Azure
+resources, secrets, or paid cloud actions.
+
+## Scope
+
+- Docker Compose runs API, UI, PostgreSQL, an outbox worker host, and
+  light/medium/heavy command-runner host processes.
+- `MediaIngest.Api` selects persistence by configuration:
+  - `Persistence:Provider=InMemory` or unset keeps focused tests lightweight.
+  - `Persistence:Provider=Postgres` uses raw Npgsql and requires an explicit
+    connection string.
+- Local Compose sets `Persistence:CreateSchemaOnStartup=true` so the API can
+  create the current review schema before serving requests.
+- API missing workflow and node-detail responses use Problem Details with the
+  ASP.NET trace identifier.
+- The local runtime smoke asserts HTTP behavior plus durable PostgreSQL package
+  state and dispatched command outbox rows.
+
+## Non-Goals
+
+- No Azure Service Bus SDK integration.
+- No real Dapr Workflow SDK hosting.
+- No cloud resources, Terraform apply, production deployment, load balancers,
+  secrets, or paid cloud actions.
+- No Entity Framework Core migration workflow in this slice; PostgreSQL access
+  remains raw Npgsql behind `IIngestPersistenceStore`.
+
+## Review Evidence
+
+- `make local-compose-check` validates the Compose graph.
+- `make local-runtime-smoke` starts the local runtime, posts an ingest package,
+  verifies API/UI HTTP readiness, checks workflow command-node evidence, and
+  queries PostgreSQL for durable state/outbox evidence.
+- `make test-dotnet-api`, `make test-dotnet-persistence`,
+  `make test-dotnet-outbox`, and `make test-dotnet-command-runner` cover the
+  focused backend boundaries.
+- `docs/api/openapi.yaml` documents the current HTTP contract.

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -69,13 +69,19 @@ epic/story granularity; detailed implementation tasks belong in plans.
   command dispatch, command completion, finalization, child workflow, and
   dynamic command work nodes in the React Mermaid workflow graph without adding
   live push.
+- MILESTONE-2/4/6/8 / USER-STORY-16: add the reviewable local durable ingest
+  slice with raw Npgsql-backed PostgreSQL persistence in Compose, guarded local
+  schema creation, runnable outbox and command-runner host containers, static
+  OpenAPI documentation, Problem Details API errors, reviewer guide, and
+  runtime smoke evidence for durable package state plus dispatched command
+  outbox rows.
 
 ## Ready For Planning
 
-- MILESTONE-2 / USER-STORY-16: plan the next Docker-first local runtime
-  validation slice beyond static Compose checks.
 - MILESTONE-5 / USER-STORY-9: plan the later dependency-approved task for real
   Dapr Workflow SDK hosting and workflow/activity registration.
+- MILESTONE-6 / USER-STORY-7: plan Azure Service Bus SDK worker integration
+  after the local command-bus host and contract boundary are reviewed.
 ## Later
 
 - MILESTONE-6 / USER-STORY-7: connect generic command runners to Azure Service

--- a/docs/product/milestones.md
+++ b/docs/product/milestones.md
@@ -65,9 +65,11 @@ Components:
 
 - `src`
 - `deploy/docker`
-- `docker-compose.yml`
+- `deploy/docker/compose.yaml`
 - `Makefile`
 - `scripts/dev`
+- `docs/api`
+- `docs/review`
 
 ## MILESTONE-3: Ingest Package Lifecycle
 
@@ -131,6 +133,7 @@ Ownership lanes:
 Components:
 
 - `src/MediaIngest.Worker.Outbox`
+- `src/MediaIngest.Worker.Outbox.Host`
 - `src/MediaIngest.Contracts`
 - `src/MediaIngest.Persistence`
 - `deploy/dapr`
@@ -195,6 +198,8 @@ Components:
 
 - `src/MediaIngest.Contracts`
 - `src/MediaIngest.Observability`
+- `src/MediaIngest.Worker.CommandRunner`
+- `src/MediaIngest.Worker.CommandRunner.Host`
 
 ## MILESTONE-7: Observability
 

--- a/docs/review/local-durable-ingest-review-guide.md
+++ b/docs/review/local-durable-ingest-review-guide.md
@@ -1,0 +1,54 @@
+# Local Durable Ingest Review Guide
+
+## Current Status
+
+This repository now presents a local, Docker-first ingest slice with durable
+PostgreSQL business state, transactional outbox rows, a runnable API, a React
+workflow UI, an outbox worker host, and light/medium/heavy command-runner host
+processes. The slice is intentionally local and cloud-free.
+
+## 10-Minute Review Path
+
+1. Run `make local-compose-check`.
+2. Run `make local-runtime-smoke`.
+3. Open the UI at `http://127.0.0.1:5173`.
+4. Inspect the API at `http://127.0.0.1:5000/api/ingest/status`.
+5. Read the API contract in `docs/api/openapi.yaml`.
+
+## What Works Today
+
+- Compose starts API, UI, PostgreSQL, outbox worker, and command-runner worker
+  containers.
+- The API uses raw Npgsql-backed PostgreSQL persistence when Compose sets
+  `Persistence__Provider=Postgres`.
+- The API can create the local schema on startup when
+  `Persistence__CreateSchemaOnStartup=true`.
+- The local smoke posts an ingest start, creates a manifest-ready package,
+  verifies copied manifest outputs, reads workflow graph command nodes, and
+  queries PostgreSQL for package and outbox evidence.
+- Missing workflow graph and node detail requests return Problem Details with a
+  trace identifier.
+
+## Known Gaps
+
+- The command-runner hosts are runnable local review processes; real broker
+  consumption remains represented by the command-runner library tests.
+- The outbox worker validates command-bus message shape locally and marks rows
+  dispatched; it does not publish to Azure Service Bus.
+- Dapr Workflow SDK hosting and activity registration remain deferred.
+- PostgreSQL schema management is guarded startup DDL for local Compose, not an
+  EF Core or migration workflow.
+- Node diagnostics are local persisted records, not production log aggregation
+  or OpenTelemetry trace linkage.
+
+## Source Anchors
+
+- API runtime: `src/MediaIngest.Api/IngestApiApplication.cs`
+- Runtime service: `src/MediaIngest.Api/IngestRuntimeService.cs`
+- PostgreSQL store: `src/MediaIngest.Persistence/PostgresIngestPersistenceStore.cs`
+- Schema DDL: `src/MediaIngest.Persistence/PostgresIngestSchema.cs`
+- Outbox worker host: `src/MediaIngest.Worker.Outbox.Host/Program.cs`
+- Command-runner host: `src/MediaIngest.Worker.CommandRunner.Host/Program.cs`
+- Compose runtime: `deploy/docker/compose.yaml`
+- Runtime smoke: `scripts/dev/local-compose-check.sh`
+- API contract: `docs/api/openapi.yaml`

--- a/docs/status/current-status.md
+++ b/docs/status/current-status.md
@@ -4,14 +4,15 @@
 
 - Phase: local implementation foundation.
 - Current branch: `main`.
-- Current focus: local `main` contains the first implementation foundations
-  across watcher, persistence/outbox, workflow, command routing, observability,
-  a local generic command runner foundation, and the React control plane. The
-  local ingest demo now waits for a zero-byte `done.marker` before terminal
-  success, routes command publish metadata for local outbox dispatch, lets the
-  UI select among multiple package workflow graphs, renders interactive Mermaid
-  graph nodes, and carries static Kubernetes/Dapr readiness assets for the
-  intended container runtime.
+- Current focus: local `main` contains the first reviewable durable ingest
+  slice across watcher, raw Npgsql/PostgreSQL persistence, transactional
+  outbox, workflow graph projection, command routing, observability, runnable
+  worker host processes, and the React control plane. Docker Compose now starts
+  API, UI, PostgreSQL, outbox worker, and light/medium/heavy command-runner
+  host containers. The local runtime smoke verifies API/UI readiness, manifest
+  output, workflow command-node evidence, persisted PostgreSQL package state,
+  and dispatched command outbox rows without Azure resources or real Dapr
+  Workflow hosting.
 
 ## Completed
 
@@ -167,11 +168,18 @@
   repo docs, issues, PRs, commits, and status files are authoritative; detailed
   Project fields, task-card backfills, validation fields, dependency helpers,
   and relationship linting are legacy unless explicitly revived.
+- The reviewable local durable ingest slice now uses raw Npgsql-backed
+  PostgreSQL persistence in Compose, guarded local startup schema creation,
+  Problem Details for not-found and conflict API responses, static OpenAPI
+  documentation, runnable outbox and command-runner host processes, and a
+  reviewer guide with honest local/cloud boundaries.
 
 ## Next
 
 - Plan the later dependency-approved task for real Dapr Workflow SDK hosting
   and workflow/activity registration in the orchestrator boundary.
+- Plan the later Azure Service Bus SDK worker integration after the local
+  command-bus boundary and host processes are reviewed.
 
 ## Update Rule
 

--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -5,6 +5,11 @@ messages or paste command output unless it explains a decision.
 
 ## 2026-05-09
 
+- Added the reviewable local durable ingest slice: Compose now runs API, UI,
+  PostgreSQL, outbox worker, and light/medium/heavy command-runner hosts; the
+  API selects raw Npgsql PostgreSQL persistence in Compose with guarded schema
+  creation; OpenAPI, Problem Details errors, reviewer guide, and runtime smoke
+  PostgreSQL state/outbox checks document the local review path.
 - Reduced GitHub Project guidance to a lightweight story-level visibility board:
   repo docs, GitHub issues, PRs, commits, and status files remain the durable
   record, while detailed Project fields, task-card backfills, validation fields,

--- a/scripts/dev/local-compose-check.sh
+++ b/scripts/dev/local-compose-check.sh
@@ -16,6 +16,7 @@ timeout_seconds="${LOCAL_COMPOSE_TIMEOUT_SECONDS:-60}"
 interval_seconds="${LOCAL_COMPOSE_INTERVAL_SECONDS:-2}"
 project_name="${LOCAL_COMPOSE_PROJECT_NAME:-media-asset-ingest-local}"
 keep_running="${LOCAL_COMPOSE_KEEP_RUNNING:-0}"
+smoke_package_id="${SMOKE_PACKAGE_ID:-asset-smoke-$(date +%Y%m%d%H%M%S)}"
 dry_run=0
 runtime_smoke=0
 runtime_started=0
@@ -38,6 +39,7 @@ Environment overrides:
   LOCAL_COMPOSE_API_PORT          API host port. Default: 5000
   LOCAL_COMPOSE_UI_PORT           UI host port. Default: 5173
   LOCAL_COMPOSE_POSTGRES_PORT     PostgreSQL host port. Default: 5432
+  SMOKE_PACKAGE_ID                Package ID for runtime smoke. Default: timestamped asset-smoke-*
   LOCAL_COMPOSE_UID               API container user ID. Default: current user
   LOCAL_COMPOSE_GID               API container group ID. Default: current group
   LOCAL_COMPOSE_TIMEOUT_SECONDS   HTTP wait timeout. Default: 60
@@ -65,12 +67,18 @@ Runtime services:
   postgres
     Uses postgres:17-alpine with local trust auth, exposes host port
     $postgres_port, and stores data in a named volume.
+  outbox-worker
+    Runs the executable outbox worker host against PostgreSQL and validates
+    local command-bus message shape without Azure SDK integration.
+  command-runner-light, command-runner-medium, command-runner-heavy
+    Run executable command-runner host processes for the local review runtime.
 
 Runtime validation:
   docker compose -p $project_name -f deploy/docker/compose.yaml up --build -d
   wait for $api_url/api/ingest/status
   wait for $ui_url
   SMOKE_EXPECT_COPIED_FILES=manifest MEDIA_INGEST_API_URL=$api_url sh scripts/dev/local-e2e-smoke.sh
+  query PostgreSQL for persisted package state and dispatched command outbox rows
   docker compose -p $project_name -f deploy/docker/compose.yaml down
 
 Boundary:
@@ -96,6 +104,10 @@ Resolved local services:
   postgres
     Uses postgres:17-alpine with local trust auth, exposes 127.0.0.1:5432,
     and stores data in the postgres-data named volume.
+  outbox-worker
+    Builds deploy/docker/dotnet-worker.Dockerfile for the outbox host.
+  command-runner-light, command-runner-medium, command-runner-heavy
+    Build deploy/docker/dotnet-worker.Dockerfile for each execution class.
 
 Default validation:
   docker compose -f deploy/docker/compose.yaml config
@@ -146,6 +158,13 @@ validate_settings() {
   case "$ui_url" in
     '')
       printf '%s\n' "LOCAL_COMPOSE_UI_URL must not be empty." >&2
+      exit 2
+      ;;
+  esac
+
+  case "$smoke_package_id" in
+    ''|*[!A-Za-z0-9._-]*)
+      printf 'SMOKE_PACKAGE_ID must contain only letters, numbers, dots, underscores, and hyphens: %s\n' "$smoke_package_id" >&2
       exit 2
       ;;
   esac
@@ -254,9 +273,31 @@ run_runtime_smoke() {
   wait_for_http "UI" "$ui_url"
 
   printf '%s\n' "Running local ingest smoke against Compose API..."
-  SMOKE_EXPECT_COPIED_FILES=manifest MEDIA_INGEST_API_URL="$api_url" sh scripts/dev/local-e2e-smoke.sh
+  SMOKE_PACKAGE_ID="$smoke_package_id" SMOKE_EXPECT_COPIED_FILES=manifest MEDIA_INGEST_API_URL="$api_url" sh scripts/dev/local-e2e-smoke.sh
+
+  printf '%s\n' "Checking PostgreSQL durable package state..."
+  package_status=$(compose exec -T postgres psql -U postgres -d media_ingest -tAc \
+    "select status from ingest_package_states where package_id = '$smoke_package_id';")
+  if [ "$package_status" != "Started" ] && [ "$package_status" != "Succeeded" ]; then
+    printf 'Expected durable package state for %s, got: %s\n' "$smoke_package_id" "$package_status" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "Checking PostgreSQL outbox command evidence..."
+  command_outbox_count=$(compose exec -T postgres psql -U postgres -d media_ingest -tAc \
+    "select count(*) from outbox_messages where correlation_id = 'correlation-$smoke_package_id' and message_type = 'MediaCommandEnvelope';")
+  dispatched_command_count=$(compose exec -T postgres psql -U postgres -d media_ingest -tAc \
+    "select count(*) from outbox_messages where correlation_id = 'correlation-$smoke_package_id' and message_type = 'MediaCommandEnvelope' and dispatched_at is not null;")
+  if [ "$command_outbox_count" -lt 4 ] || [ "$dispatched_command_count" -lt 4 ]; then
+    printf 'Expected at least 4 dispatched command outbox rows, got total=%s dispatched=%s\n' \
+      "$command_outbox_count" "$dispatched_command_count" >&2
+    exit 1
+  fi
 
   printf '%s\n' "Local Compose runtime smoke passed."
+  printf '  package_state: %s\n' "$package_status"
+  printf '  command_outbox_rows: %s\n' "$command_outbox_count"
+  printf '  dispatched_command_outbox_rows: %s\n' "$dispatched_command_count"
 }
 
 while [ "$#" -gt 0 ]; do

--- a/src/MediaIngest.Api/IngestApiApplication.cs
+++ b/src/MediaIngest.Api/IngestApiApplication.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -28,15 +29,21 @@ public sealed class IngestApiApplication : IAsyncDisposable
     public static async Task<IngestApiApplication> StartAsync(
         string inputPath,
         string outputPath,
+        IReadOnlyDictionary<string, string?>? configuration = null,
         CancellationToken cancellationToken = default)
     {
         var builder = WebApplication.CreateSlimBuilder();
         builder.WebHost.UseUrls("http://127.0.0.1:0");
+        if (configuration is not null)
+        {
+            builder.Configuration.AddInMemoryCollection(configuration);
+        }
 
-        ConfigureServices(builder.Services, inputPath, outputPath);
+        ConfigureServices(builder.Services, builder.Configuration, inputPath, outputPath);
 
         var app = builder.Build();
         MapEndpoints(app);
+        await CreateSchemaOnStartupAsync(app.Services, builder.Configuration, cancellationToken);
 
         await app.StartAsync(cancellationToken);
 
@@ -62,10 +69,13 @@ public sealed class IngestApiApplication : IAsyncDisposable
         var outputPath = builder.Configuration["Ingest:OutputPath"]
             ?? Path.Combine(repoRoot, "output");
 
-        ConfigureServices(builder.Services, inputPath, outputPath);
+        ConfigureServices(builder.Services, builder.Configuration, inputPath, outputPath);
 
         var app = builder.Build();
         MapEndpoints(app);
+        CreateSchemaOnStartupAsync(app.Services, builder.Configuration, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
 
         return app.RunAsync(cancellationToken);
     }
@@ -76,7 +86,11 @@ public sealed class IngestApiApplication : IAsyncDisposable
         await webApplication.DisposeAsync();
     }
 
-    private static void ConfigureServices(IServiceCollection services, string inputPath, string outputPath)
+    private static void ConfigureServices(
+        IServiceCollection services,
+        IConfiguration configuration,
+        string inputPath,
+        string outputPath)
     {
         services.AddSingleton(new IngestRuntimePaths(
             Path.GetFullPath(inputPath),
@@ -85,12 +99,60 @@ public sealed class IngestApiApplication : IAsyncDisposable
         services.AddSingleton<ManifestReadinessGate>();
         services.AddSingleton<PackageWorkflowStarter>();
         services.AddSingleton(WorkflowGraphProjector.CreateDefault());
-        services.AddSingleton<InMemoryIngestPersistenceStore>();
-        services.AddSingleton<IIngestPersistenceStore>(serviceProvider =>
-            serviceProvider.GetRequiredService<InMemoryIngestPersistenceStore>());
+        ConfigurePersistence(services, configuration);
         services.AddSingleton<IOutboxMessagePublisher, LocalManifestTransferPublisher>();
         services.AddSingleton<OutboxDispatcher>();
         services.AddSingleton<IngestRuntimeService>();
+    }
+
+    private static void ConfigurePersistence(IServiceCollection services, IConfiguration configuration)
+    {
+        var provider = configuration["Persistence:Provider"];
+        if (string.IsNullOrWhiteSpace(provider) || string.Equals(provider, "InMemory", StringComparison.OrdinalIgnoreCase))
+        {
+            services.AddSingleton<InMemoryIngestPersistenceStore>();
+            services.AddSingleton<IIngestPersistenceStore>(serviceProvider =>
+                serviceProvider.GetRequiredService<InMemoryIngestPersistenceStore>());
+            return;
+        }
+
+        if (string.Equals(provider, "Postgres", StringComparison.OrdinalIgnoreCase))
+        {
+            var connectionString = configuration["Persistence:ConnectionString"]
+                ?? configuration.GetConnectionString("MediaIngest");
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new InvalidOperationException(
+                    "Persistence:ConnectionString or ConnectionStrings:MediaIngest is required when Persistence:Provider is Postgres.");
+            }
+
+            services.AddSingleton<IIngestPersistenceStore>(_ =>
+                PostgresIngestPersistenceStore.Create(connectionString));
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Unsupported persistence provider '{provider}'. Use InMemory or Postgres.");
+    }
+
+    private static async Task CreateSchemaOnStartupAsync(
+        IServiceProvider services,
+        IConfiguration configuration,
+        CancellationToken cancellationToken)
+    {
+        if (!bool.TryParse(configuration["Persistence:CreateSchemaOnStartup"], out var createSchemaOnStartup) ||
+            !createSchemaOnStartup)
+        {
+            return;
+        }
+
+        var store = services.GetRequiredService<IIngestPersistenceStore>();
+        if (store is not PostgresIngestPersistenceStore postgresStore)
+        {
+            return;
+        }
+
+        await postgresStore.CreateSchemaAsync(cancellationToken);
     }
 
     private static void MapEndpoints(WebApplication app)
@@ -104,46 +166,86 @@ public sealed class IngestApiApplication : IAsyncDisposable
 
     private static async Task<IResult> StartIngestAsync(
         IngestRuntimeService runtimeService,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         var result = await runtimeService.StartAsync(cancellationToken);
 
         return result.HasConflict
-            ? Results.Conflict(result.Response)
+            ? Problem(
+                httpContext,
+                StatusCodes.Status409Conflict,
+                "Ingest start conflict",
+                "One or more ready packages could not be started because output already exists.")
             : Results.Accepted(value: result.Response);
     }
 
-    private static IngestStatusResponse GetStatus(IngestRuntimeService runtimeService)
+    private static Task<IngestStatusResponse> GetStatus(
+        IngestRuntimeService runtimeService,
+        CancellationToken cancellationToken)
     {
-        return runtimeService.GetStatus();
+        return runtimeService.GetStatusAsync(cancellationToken);
     }
 
-    private static WorkflowListResponse ListWorkflows(IngestRuntimeService runtimeService)
+    private static Task<WorkflowListResponse> ListWorkflows(
+        IngestRuntimeService runtimeService,
+        CancellationToken cancellationToken)
     {
-        return runtimeService.ListWorkflows();
+        return runtimeService.ListWorkflowsAsync(cancellationToken);
     }
 
-    private static IResult GetWorkflowGraph(
+    private static async Task<IResult> GetWorkflowGraph(
         string workflowInstanceId,
-        IngestRuntimeService runtimeService)
+        IngestRuntimeService runtimeService,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
     {
-        var graph = runtimeService.GetWorkflowGraph(workflowInstanceId);
+        var graph = await runtimeService.GetWorkflowGraphAsync(workflowInstanceId, cancellationToken);
 
         return graph is null
-            ? Results.NotFound()
+            ? Problem(
+                httpContext,
+                StatusCodes.Status404NotFound,
+                "Workflow graph not found",
+                $"Workflow graph '{workflowInstanceId}' was not found.")
             : Results.Ok(graph);
     }
 
-    private static IResult GetWorkflowNodeDetails(
+    private static async Task<IResult> GetWorkflowNodeDetails(
         string workflowInstanceId,
         string nodeId,
-        IngestRuntimeService runtimeService)
+        IngestRuntimeService runtimeService,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
     {
-        var details = runtimeService.GetWorkflowNodeDetails(workflowInstanceId, nodeId);
+        var details = await runtimeService.GetWorkflowNodeDetailsAsync(
+            workflowInstanceId,
+            nodeId,
+            cancellationToken);
 
         return details is null
-            ? Results.NotFound()
+            ? Problem(
+                httpContext,
+                StatusCodes.Status404NotFound,
+                "Workflow node details not found",
+                $"Workflow node '{nodeId}' was not found in workflow '{workflowInstanceId}'.")
             : Results.Ok(details);
+    }
+
+    private static IResult Problem(
+        HttpContext httpContext,
+        int statusCode,
+        string title,
+        string detail)
+    {
+        return Results.Problem(
+            title: title,
+            detail: detail,
+            statusCode: statusCode,
+            extensions: new Dictionary<string, object?>
+            {
+                ["traceId"] = httpContext.TraceIdentifier
+            });
     }
 
     private static string FindRepoRoot()

--- a/src/MediaIngest.Api/IngestRuntimeService.cs
+++ b/src/MediaIngest.Api/IngestRuntimeService.cs
@@ -16,7 +16,7 @@ public sealed class IngestRuntimeService(
     ManifestReadinessGate readinessGate,
     PackageWorkflowStarter workflowStarter,
     WorkflowGraphProjector workflowGraphProjector,
-    InMemoryIngestPersistenceStore store,
+    IIngestPersistenceStore store,
     OutboxDispatcher outboxDispatcher) : IAsyncDisposable
 {
     private static readonly TimeSpan WatchInterval = TimeSpan.FromMilliseconds(100);
@@ -83,7 +83,7 @@ public sealed class IngestRuntimeService(
             foreach (var candidate in candidates.Where(readinessGate.IsReady))
             {
                 var packageId = Path.GetFileName(candidate.PackagePath);
-                var latestState = GetLatestPackageState(packageId);
+                var latestState = await store.GetPackageStateAsync(packageId, cancellationToken);
 
                 if (terminalPackageIds.Contains(packageId) || IsTerminal(latestState?.Status))
                 {
@@ -277,7 +277,9 @@ public sealed class IngestRuntimeService(
         }
         catch (LocalManifestTransferConflictException)
         {
-            var messageId = GetPendingLocalTransferMessageId(workflowStart.PackageId);
+            var messageId = await GetPendingLocalTransferMessageIdAsync(
+                workflowStart.PackageId,
+                cancellationToken);
 
             if (messageId is null)
             {
@@ -314,9 +316,13 @@ public sealed class IngestRuntimeService(
         }
     }
 
-    private string? GetPendingLocalTransferMessageId(string packageId)
+    private async Task<string?> GetPendingLocalTransferMessageIdAsync(
+        string packageId,
+        CancellationToken cancellationToken)
     {
-        return store.OutboxMessages
+        var messages = await store.ListOutboxMessagesAsync($"correlation-{packageId}", cancellationToken);
+
+        return messages
             .Where(message =>
                 message.MessageType == nameof(LocalManifestTransferRequest)
                 && string.Equals(message.CorrelationId, $"correlation-{packageId}", StringComparison.Ordinal)
@@ -327,23 +333,16 @@ public sealed class IngestRuntimeService(
             .FirstOrDefault();
     }
 
-    private IngestPackageState? GetLatestPackageState(string packageId)
-    {
-        return store.PackageStates
-            .Where(packageState => string.Equals(packageState.PackageId, packageId, StringComparison.Ordinal))
-            .OrderBy(packageState => packageState.UpdatedAt)
-            .LastOrDefault();
-    }
-
     private static bool IsTerminal(string? status)
     {
         return string.Equals(status, "Succeeded", StringComparison.Ordinal)
             || string.Equals(status, "Failed", StringComparison.Ordinal);
     }
 
-    public IngestStatusResponse GetStatus()
+    public async Task<IngestStatusResponse> GetStatusAsync(CancellationToken cancellationToken = default)
     {
-        var packages = store.PackageStates
+        var packageStates = await store.ListPackageStatesAsync(cancellationToken);
+        var packages = packageStates
             .GroupBy(packageState => packageState.PackageId, StringComparer.Ordinal)
             .Select(group => group.Last())
             .OrderBy(packageState => packageState.PackageId, StringComparer.Ordinal)
@@ -357,9 +356,15 @@ public sealed class IngestRuntimeService(
         return new IngestStatusResponse(packages);
     }
 
-    public WorkflowListResponse ListWorkflows()
+    public IngestStatusResponse GetStatus()
     {
-        var workflows = store.PackageStates
+        return GetStatusAsync().GetAwaiter().GetResult();
+    }
+
+    public async Task<WorkflowListResponse> ListWorkflowsAsync(CancellationToken cancellationToken = default)
+    {
+        var packageStates = await store.ListPackageStatesAsync(cancellationToken);
+        var workflows = packageStates
             .GroupBy(packageState => packageState.PackageId, StringComparer.Ordinal)
             .Select(group => group.Last())
             .OrderBy(packageState => packageState.PackageId, StringComparer.Ordinal)
@@ -373,14 +378,22 @@ public sealed class IngestRuntimeService(
         return new WorkflowListResponse(workflows);
     }
 
-    public WorkflowGraphDto? GetWorkflowGraph(string workflowInstanceId)
+    public WorkflowListResponse ListWorkflows()
+    {
+        return ListWorkflowsAsync().GetAwaiter().GetResult();
+    }
+
+    public async Task<WorkflowGraphDto?> GetWorkflowGraphAsync(
+        string workflowInstanceId,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(workflowInstanceId))
         {
             return null;
         }
 
-        var packageState = store.PackageStates
+        var packageStates = await store.ListPackageStatesAsync(cancellationToken);
+        var packageState = packageStates
             .GroupBy(packageState => packageState.PackageId, StringComparer.Ordinal)
             .Select(group => group.Last())
             .SingleOrDefault(packageState =>
@@ -394,17 +407,27 @@ public sealed class IngestRuntimeService(
                 PackageId: packageState.PackageId,
                 Status: MapPackageStatus(packageState.Status),
                 ParentWorkflowInstanceId: null,
-                CommandWorkItems: GetMediaCommandWorkItems(packageState.PackageId).ToArray()));
+                CommandWorkItems: (await GetMediaCommandWorkItemsAsync(
+                    packageState.PackageId,
+                    cancellationToken)).ToArray()));
     }
 
-    public WorkflowNodeDetailsDto? GetWorkflowNodeDetails(string workflowInstanceId, string nodeId)
+    public WorkflowGraphDto? GetWorkflowGraph(string workflowInstanceId)
+    {
+        return GetWorkflowGraphAsync(workflowInstanceId).GetAwaiter().GetResult();
+    }
+
+    public async Task<WorkflowNodeDetailsDto?> GetWorkflowNodeDetailsAsync(
+        string workflowInstanceId,
+        string nodeId,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(workflowInstanceId) || string.IsNullOrWhiteSpace(nodeId))
         {
             return null;
         }
 
-        var graph = GetWorkflowGraph(workflowInstanceId);
+        var graph = await GetWorkflowGraphAsync(workflowInstanceId, cancellationToken);
         var node = graph?.Nodes.SingleOrDefault(candidate =>
             string.Equals(candidate.NodeId, nodeId, StringComparison.Ordinal));
 
@@ -413,12 +436,11 @@ public sealed class IngestRuntimeService(
             return null;
         }
 
-        var timeline = store.TimelineRecords
-            .Where(record =>
-                string.Equals(record.WorkflowInstanceId, workflowInstanceId, StringComparison.Ordinal) &&
-                string.Equals(record.NodeId, nodeId, StringComparison.Ordinal))
-            .OrderBy(record => record.OccurredAt)
-            .ThenBy(record => record.EventId, StringComparer.Ordinal)
+        var timelineRecords = await store.GetWorkflowNodeTimelineAsync(
+            workflowInstanceId,
+            nodeId,
+            cancellationToken);
+        var timeline = timelineRecords
             .Select(record => new WorkflowTimelineEntryDto(
                 OccurredAt: record.OccurredAt,
                 Status: MapTimelineStatus(record.Status),
@@ -426,12 +448,11 @@ public sealed class IngestRuntimeService(
                 CorrelationId: record.CorrelationId))
             .ToArray();
 
-        var logs = store.NodeDiagnosticLogs
-            .Where(record =>
-                string.Equals(record.WorkflowInstanceId, workflowInstanceId, StringComparison.Ordinal) &&
-                string.Equals(record.NodeId, nodeId, StringComparison.Ordinal))
-            .OrderBy(record => record.OccurredAt)
-            .ThenBy(record => record.LogId, StringComparer.Ordinal)
+        var logRecords = await store.GetWorkflowNodeLogsAsync(
+            workflowInstanceId,
+            nodeId,
+            cancellationToken);
+        var logs = logRecords
             .Select(record => new WorkflowNodeLogEntryDto(
                 OccurredAt: record.OccurredAt,
                 Level: record.Level,
@@ -446,6 +467,11 @@ public sealed class IngestRuntimeService(
             NodeId: node.NodeId,
             Timeline: timeline,
             Logs: logs);
+    }
+
+    public WorkflowNodeDetailsDto? GetWorkflowNodeDetails(string workflowInstanceId, string nodeId)
+    {
+        return GetWorkflowNodeDetailsAsync(workflowInstanceId, nodeId).GetAwaiter().GetResult();
     }
 
     public async ValueTask DisposeAsync()
@@ -554,11 +580,14 @@ public sealed class IngestRuntimeService(
         return $"{commandName} {packageRelativePath}";
     }
 
-    private IEnumerable<WorkflowCommandWorkItem> GetMediaCommandWorkItems(string packageId)
+    private async Task<IReadOnlyList<WorkflowCommandWorkItem>> GetMediaCommandWorkItemsAsync(
+        string packageId,
+        CancellationToken cancellationToken)
     {
         var correlationId = $"correlation-{packageId}";
+        var messages = await store.ListOutboxMessagesAsync(correlationId, cancellationToken);
 
-        return store.OutboxMessages
+        return messages
             .Where(message =>
                 message.MessageType == nameof(MediaCommandEnvelope)
                 && string.Equals(message.CorrelationId, correlationId, StringComparison.Ordinal))
@@ -569,7 +598,8 @@ public sealed class IngestRuntimeService(
             .Select(command => new WorkflowCommandWorkItem(
                 NodeId: $"command-{SanitizeIdentifier(GetPackageRelativeCommandPath(command, packageId))}",
                 DisplayName: CreateCommandDisplayName(command),
-                WorkItemId: command.CommandId));
+                WorkItemId: command.CommandId))
+            .ToArray();
     }
 
     private static WorkflowNodeStatus MapPackageStatus(string status)

--- a/src/MediaIngest.Persistence/IIngestPersistenceStore.cs
+++ b/src/MediaIngest.Persistence/IIngestPersistenceStore.cs
@@ -8,6 +8,12 @@ public interface IIngestPersistenceStore
         string packageId,
         CancellationToken cancellationToken = default);
 
+    Task<IReadOnlyList<IngestPackageState>> ListPackageStatesAsync(CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<OutboxMessage>> ListOutboxMessagesAsync(
+        string correlationId,
+        CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<OutboxMessage>> GetPendingOutboxMessagesAsync(CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<OutboxMessage>> ClaimPendingOutboxMessagesAsync(

--- a/src/MediaIngest.Persistence/InMemoryIngestPersistenceStore.cs
+++ b/src/MediaIngest.Persistence/InMemoryIngestPersistenceStore.cs
@@ -125,6 +125,47 @@ public sealed class InMemoryIngestPersistenceStore : IIngestPersistenceStore
         return Task.FromResult(packageState);
     }
 
+    public Task<IReadOnlyList<IngestPackageState>> ListPackageStatesAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IReadOnlyList<IngestPackageState> states;
+
+        lock (storeLock)
+        {
+            states = packageStates
+                .OrderBy(state => state.PackageId, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        return Task.FromResult(states);
+    }
+
+    public Task<IReadOnlyList<OutboxMessage>> ListOutboxMessagesAsync(
+        string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            throw new ArgumentException("Correlation id is required.", nameof(correlationId));
+        }
+
+        IReadOnlyList<OutboxMessage> messages;
+
+        lock (storeLock)
+        {
+            messages = outboxMessages
+                .Where(message => string.Equals(message.CorrelationId, correlationId, StringComparison.Ordinal))
+                .OrderBy(message => message.CreatedAt)
+                .ThenBy(message => message.MessageId, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        return Task.FromResult(messages);
+    }
+
     public Task<IReadOnlyList<BusinessTimelineRecord>> GetWorkflowNodeTimelineAsync(
         string workflowInstanceId,
         string nodeId,

--- a/src/MediaIngest.Persistence/MediaIngest.Persistence.csproj
+++ b/src/MediaIngest.Persistence/MediaIngest.Persistence.csproj
@@ -3,4 +3,7 @@
     <RootNamespace>MediaIngest.Persistence</RootNamespace>
     <AssemblyName>MediaIngest.Persistence</AssemblyName>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Npgsql" Version="10.0.2" />
+  </ItemGroup>
 </Project>

--- a/src/MediaIngest.Persistence/PostgresIngestPersistenceStore.cs
+++ b/src/MediaIngest.Persistence/PostgresIngestPersistenceStore.cs
@@ -1,11 +1,20 @@
 using System.Data;
 using System.Data.Common;
+using Npgsql;
 
 namespace MediaIngest.Persistence;
 
 public sealed class PostgresIngestPersistenceStore(
     Func<CancellationToken, ValueTask<DbConnection>> openConnection) : IIngestPersistenceStore
 {
+    public static PostgresIngestPersistenceStore Create(string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        return new PostgresIngestPersistenceStore(
+            _ => ValueTask.FromResult<DbConnection>(new NpgsqlConnection(connectionString)));
+    }
+
     public async Task CreateSchemaAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -83,7 +92,7 @@ public sealed class PostgresIngestPersistenceStore(
                     @message_id,
                     @destination,
                     @message_type,
-                    @payload_json,
+                    @payload_json::jsonb,
                     @correlation_id,
                     @created_at,
                     @dispatched_at,
@@ -232,6 +241,73 @@ public sealed class PostgresIngestPersistenceStore(
             WorkflowInstanceId: reader.GetString(1),
             Status: reader.GetString(2),
             UpdatedAt: ReadDateTimeOffset(reader, 3));
+    }
+
+    public async Task<IReadOnlyList<IngestPackageState>> ListPackageStatesAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await using var connection = await openConnection(cancellationToken);
+        await OpenIfNeededAsync(connection, cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT
+                package_id,
+                workflow_instance_id,
+                status,
+                updated_at
+            FROM ingest_package_states
+            ORDER BY package_id;
+            """;
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        var states = new List<IngestPackageState>();
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            states.Add(new IngestPackageState(
+                PackageId: reader.GetString(0),
+                WorkflowInstanceId: reader.GetString(1),
+                Status: reader.GetString(2),
+                UpdatedAt: ReadDateTimeOffset(reader, 3)));
+        }
+
+        return states;
+    }
+
+    public async Task<IReadOnlyList<OutboxMessage>> ListOutboxMessagesAsync(
+        string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            throw new ArgumentException("Correlation id is required.", nameof(correlationId));
+        }
+
+        await using var connection = await openConnection(cancellationToken);
+        await OpenIfNeededAsync(connection, cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT
+                message_id,
+                destination,
+                message_type,
+                payload_json,
+                correlation_id,
+                created_at,
+                dispatched_at,
+                dispatch_claim_expires_at
+            FROM outbox_messages
+            WHERE correlation_id = @correlation_id
+            ORDER BY created_at, message_id;
+            """;
+        AddParameter(command, "@correlation_id", correlationId);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        return await ReadOutboxMessagesAsync(reader, cancellationToken);
     }
 
     public async Task<IReadOnlyList<OutboxMessage>> GetPendingOutboxMessagesAsync(CancellationToken cancellationToken = default)

--- a/src/MediaIngest.Worker.CommandRunner.Host/MediaIngest.Worker.CommandRunner.Host.csproj
+++ b/src/MediaIngest.Worker.CommandRunner.Host/MediaIngest.Worker.CommandRunner.Host.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MediaIngest.Worker.CommandRunner.Host</RootNamespace>
+    <AssemblyName>MediaIngest.Worker.CommandRunner.Host</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../MediaIngest.Contracts/MediaIngest.Contracts.csproj" />
+    <ProjectReference Include="../MediaIngest.Worker.CommandRunner/MediaIngest.Worker.CommandRunner.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/MediaIngest.Worker.CommandRunner.Host/Program.cs
+++ b/src/MediaIngest.Worker.CommandRunner.Host/Program.cs
@@ -1,0 +1,53 @@
+using MediaIngest.Contracts.Commands;
+
+var executionClassValue = ReadSetting("Worker__ExecutionClass") ?? "light";
+var executionClass = ExecutionClassProperties.FromPropertyValue(executionClassValue);
+var interval = TimeSpan.FromMilliseconds(ReadPositiveInt("Worker__IntervalMilliseconds", 1000));
+
+Console.WriteLine(
+    $"Media ingest command runner started. executionClass={executionClass.ToPropertyValue()} interval={interval}");
+Console.WriteLine(
+    "Local review mode: command bus consumption is represented by library tests; " +
+    "this host keeps the light/medium/heavy worker processes runnable in Compose.");
+
+using var cancellation = new CancellationTokenSource();
+Console.CancelKeyPress += (_, eventArgs) =>
+{
+    eventArgs.Cancel = true;
+    cancellation.Cancel();
+};
+AppDomain.CurrentDomain.ProcessExit += (_, _) => cancellation.Cancel();
+
+try
+{
+    while (!cancellation.IsCancellationRequested)
+    {
+        await Task.Delay(interval, cancellation.Token);
+    }
+}
+catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+{
+}
+
+static string? ReadSetting(string name)
+{
+    var value = Environment.GetEnvironmentVariable(name);
+
+    return string.IsNullOrWhiteSpace(value) ? null : value;
+}
+
+static int ReadPositiveInt(string name, int defaultValue)
+{
+    var value = ReadSetting(name);
+    if (value is null)
+    {
+        return defaultValue;
+    }
+
+    if (int.TryParse(value, out var parsed) && parsed > 0)
+    {
+        return parsed;
+    }
+
+    throw new InvalidOperationException($"{name} must be a positive integer.");
+}

--- a/src/MediaIngest.Worker.Outbox.Host/MediaIngest.Worker.Outbox.Host.csproj
+++ b/src/MediaIngest.Worker.Outbox.Host/MediaIngest.Worker.Outbox.Host.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MediaIngest.Worker.Outbox.Host</RootNamespace>
+    <AssemblyName>MediaIngest.Worker.Outbox.Host</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../MediaIngest.Persistence/MediaIngest.Persistence.csproj" />
+    <ProjectReference Include="../MediaIngest.Worker.Outbox/MediaIngest.Worker.Outbox.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/MediaIngest.Worker.Outbox.Host/Program.cs
+++ b/src/MediaIngest.Worker.Outbox.Host/Program.cs
@@ -1,0 +1,93 @@
+using MediaIngest.Contracts.Commands;
+using MediaIngest.Persistence;
+using MediaIngest.Worker.Outbox;
+
+var connectionString = ReadSetting("Persistence__ConnectionString")
+    ?? ReadSetting("ConnectionStrings__MediaIngest")
+    ?? throw new InvalidOperationException(
+        "Persistence__ConnectionString or ConnectionStrings__MediaIngest is required.");
+var createSchemaOnStartup = bool.TryParse(
+    ReadSetting("Persistence__CreateSchemaOnStartup"),
+    out var createSchema) && createSchema;
+var interval = TimeSpan.FromMilliseconds(ReadPositiveInt("Worker__IntervalMilliseconds", 1000));
+
+var store = PostgresIngestPersistenceStore.Create(connectionString);
+if (createSchemaOnStartup)
+{
+    await store.CreateSchemaAsync();
+}
+
+var dispatcher = new OutboxDispatcher(
+    store,
+    new LocalReviewOutboxMessagePublisher(new ServiceBusCommandBusAdapter()));
+
+Console.WriteLine($"Media ingest outbox worker started. interval={interval}");
+
+using var cancellation = new CancellationTokenSource();
+Console.CancelKeyPress += (_, eventArgs) =>
+{
+    eventArgs.Cancel = true;
+    cancellation.Cancel();
+};
+AppDomain.CurrentDomain.ProcessExit += (_, _) => cancellation.Cancel();
+
+try
+{
+    while (!cancellation.IsCancellationRequested)
+    {
+        var dispatched = await dispatcher.DispatchPendingAsync(cancellation.Token);
+        if (dispatched > 0)
+        {
+            Console.WriteLine($"Dispatched {dispatched} outbox message(s).");
+        }
+
+        await Task.Delay(interval, cancellation.Token);
+    }
+}
+catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+{
+}
+
+static string? ReadSetting(string name)
+{
+    var value = Environment.GetEnvironmentVariable(name);
+
+    return string.IsNullOrWhiteSpace(value) ? null : value;
+}
+
+static int ReadPositiveInt(string name, int defaultValue)
+{
+    var value = ReadSetting(name);
+    if (value is null)
+    {
+        return defaultValue;
+    }
+
+    if (int.TryParse(value, out var parsed) && parsed > 0)
+    {
+        return parsed;
+    }
+
+    throw new InvalidOperationException($"{name} must be a positive integer.");
+}
+
+internal sealed class LocalReviewOutboxMessagePublisher(
+    ServiceBusCommandBusAdapter serviceBusAdapter) : IOutboxMessagePublisher
+{
+    public Task PublishAsync(OutboxPublishRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.Equals(request.Message.MessageType, nameof(MediaCommandEnvelope), StringComparison.Ordinal))
+        {
+            var message = serviceBusAdapter.CreateMessage(request);
+            Console.WriteLine(
+                $"Validated command outbox message {request.Message.MessageId} for " +
+                $"{message.TopicName}/{message.RoutedSubscriptionName}.");
+            return Task.CompletedTask;
+        }
+
+        Console.WriteLine(
+            $"Observed local outbox message {request.Message.MessageId} " +
+            $"of type {request.Message.MessageType}.");
+        return Task.CompletedTask;
+    }
+}

--- a/tests/MediaIngest.Api.Tests/Program.cs
+++ b/tests/MediaIngest.Api.Tests/Program.cs
@@ -239,6 +239,31 @@ try
 
     using var missingGraphResponse = await apiHost.HttpClient.GetAsync("/api/workflows/missing-workflow/graph");
     AssertEqual(System.Net.HttpStatusCode.NotFound, missingGraphResponse.StatusCode, "missing graph endpoint status");
+    AssertEqual("application/problem+json", missingGraphResponse.Content.Headers.ContentType?.MediaType, "missing graph problem details content type");
+    using var missingGraphProblemJson = JsonDocument.Parse(await missingGraphResponse.Content.ReadAsStringAsync());
+    AssertEqual(404, missingGraphProblemJson.RootElement.GetProperty("status").GetInt32(), "missing graph problem details status");
+    AssertEqual("Workflow graph not found", missingGraphProblemJson.RootElement.GetProperty("title").GetString(), "missing graph problem details title");
+    AssertTrue(missingGraphProblemJson.RootElement.TryGetProperty("traceId", out _), "missing graph problem details trace id");
+
+    var missingPostgresConnectionRejected = false;
+
+    try
+    {
+        await using var _ = await IngestApiApplication.StartAsync(
+            Path.Combine(repoRoot, "postgres-input"),
+            Path.Combine(repoRoot, "postgres-output"),
+            new Dictionary<string, string?>
+            {
+                ["Persistence:Provider"] = "Postgres",
+                ["Persistence:CreateSchemaOnStartup"] = "true"
+            });
+    }
+    catch (InvalidOperationException ex) when (ex.Message.Contains("Persistence:ConnectionString", StringComparison.Ordinal))
+    {
+        missingPostgresConnectionRejected = true;
+    }
+
+    AssertTrue(missingPostgresConnectionRejected, "postgres provider requires explicit connection string");
 
     var stateCountAfterFailure = conflictRuntime.Store.PackageStates.Count;
     var messageCountAfterFailure = conflictRuntime.Store.OutboxMessages.Count;

--- a/tests/MediaIngest.Persistence.Tests/Program.cs
+++ b/tests/MediaIngest.Persistence.Tests/Program.cs
@@ -35,8 +35,10 @@ await store.SaveAsync(new PersistenceBatch([updatedPackageState], []));
 
 var savedPackageState = await store.GetPackageStateAsync("package-001");
 var missingPackageState = await store.GetPackageStateAsync("missing-package");
+var listedPackageStates = await store.ListPackageStatesAsync();
 
 AssertEqual(1, store.PackageStates.Count, "package state upsert count");
+AssertSequenceEqual(["package-001"], listedPackageStates.Select(state => state.PackageId).ToArray(), "listed package state ids");
 AssertEqual("WorkDispatched", savedPackageState?.Status, "queried package state status");
 AssertEqual(updatedPackageState.UpdatedAt, savedPackageState?.UpdatedAt, "queried package state updated at");
 AssertEqual(null, missingPackageState, "missing package state");
@@ -64,9 +66,11 @@ var logRecord = new NodeDiagnosticLogRecord(
     SpanId: "span-001");
 
 await store.SaveAsync(new PersistenceBatch([], [command], [timelineRecord], [logRecord]));
+var listedOutboxMessages = await store.ListOutboxMessagesAsync("correlation-001");
 
 AssertEqual(1, store.OutboxMessages.Count, "duplicate outbox message id is idempotent");
 AssertEqual("message-001", store.OutboxMessages[0].MessageId, "idempotent outbox message id");
+AssertSequenceEqual(["message-001"], listedOutboxMessages.Select(message => message.MessageId).ToArray(), "listed outbox message ids");
 AssertEqual(1, store.TimelineRecords.Count, "saved timeline record count");
 AssertEqual(1, store.NodeDiagnosticLogs.Count, "saved node diagnostic log count");
 


### PR DESCRIPTION
## Summary
- Adds the reviewable local durable ingest slice with PostgreSQL-backed Compose runtime wiring, persistence/API updates, and worker host containers.
- Documents reviewer flow, runtime contracts, and validation evidence for the local durable slice.
- Keeps the slice cloud-free while preserving the planned Azure Service Bus and Dapr boundaries for later work.

## Linked Work
Refs #26

## Validation
- `make validate-summary` passed; wrapper ran `make validate` successfully. Log: `/tmp/media-asset-ingest-validation-sL8qzY.log`
- `git diff --check` passed.
- `git diff --cached --check` passed.

## Risk
- Local Docker/runtime behavior is covered by prior smoke evidence in the state record; this PR gate reran repo validation but did not rerun the heavier local runtime smoke.

## Follow-up
- Continue with cloud adapter/runtime hardening tasks after this reviewable local foundation is merged.