### PR TITLE
USER-STORY-16: Reduce public .NET surface

### DIFF
--- a/docs/status/work-log.md
+++ b/docs/status/work-log.md
@@ -15,6 +15,10 @@ messages or paste command output unless it explains a decision.
   PostgreSQL state/outbox checks document the local review path.
 - Removed remote board guidance and kept repo docs as the durable source for
   product state, plans, milestones, bugs, and status.
+- Reduced .NET public surface by adding test friend assemblies and internalizing
+  API-local DTO/services, watcher observation-loop helpers, persistence schema
+  SQL, the orchestrator package definition type, and workflow lifecycle
+  projection types that are only exercised by tests.
 
 ## 2026-05-06
 

--- a/src/MediaIngest.Api/IngestApiApplication.cs
+++ b/src/MediaIngest.Api/IngestApiApplication.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace MediaIngest.Api;
 
-public sealed class IngestApiApplication : IAsyncDisposable
+internal sealed class IngestApiApplication : IAsyncDisposable
 {
     private readonly WebApplication webApplication;
 

--- a/src/MediaIngest.Api/IngestResponses.cs
+++ b/src/MediaIngest.Api/IngestResponses.cs
@@ -1,29 +1,29 @@
 namespace MediaIngest.Api;
 
-public sealed record IngestStartResponse(
+internal sealed record IngestStartResponse(
     IReadOnlyList<StartedIngestPackageResponse> StartedPackages);
 
-public sealed record IngestStartResult(
+internal sealed record IngestStartResult(
     IngestStartResponse Response,
     bool HasConflict);
 
-public sealed record StartedIngestPackageResponse(
+internal sealed record StartedIngestPackageResponse(
     string PackageId,
     string WorkflowInstanceId);
 
-public sealed record IngestStatusResponse(
+internal sealed record IngestStatusResponse(
     IReadOnlyList<IngestPackageStatusResponse> Packages);
 
-public sealed record IngestPackageStatusResponse(
+internal sealed record IngestPackageStatusResponse(
     string PackageId,
     string WorkflowInstanceId,
     string Status,
     DateTimeOffset UpdatedAt);
 
-public sealed record WorkflowListResponse(
+internal sealed record WorkflowListResponse(
     IReadOnlyList<WorkflowListItemResponse> Workflows);
 
-public sealed record WorkflowListItemResponse(
+internal sealed record WorkflowListItemResponse(
     string WorkflowInstanceId,
     string PackageId,
     string Status,

--- a/src/MediaIngest.Api/IngestRuntimePaths.cs
+++ b/src/MediaIngest.Api/IngestRuntimePaths.cs
@@ -1,5 +1,5 @@
 namespace MediaIngest.Api;
 
-public sealed record IngestRuntimePaths(
+internal sealed record IngestRuntimePaths(
     string InputPath,
     string OutputPath);

--- a/src/MediaIngest.Api/IngestRuntimeService.cs
+++ b/src/MediaIngest.Api/IngestRuntimeService.cs
@@ -10,7 +10,7 @@ using MediaIngest.Workflow.Orchestrator;
 
 namespace MediaIngest.Api;
 
-public sealed class IngestRuntimeService(
+internal sealed class IngestRuntimeService(
     IngestRuntimePaths paths,
     IngestMountScanner scanner,
     ManifestReadinessGate readinessGate,

--- a/src/MediaIngest.Api/LocalManifestTransferConflictException.cs
+++ b/src/MediaIngest.Api/LocalManifestTransferConflictException.cs
@@ -1,6 +1,6 @@
 namespace MediaIngest.Api;
 
-public sealed class LocalManifestTransferConflictException(
+internal sealed class LocalManifestTransferConflictException(
     string packageId,
     string path)
     : InvalidOperationException($"Output file '{path}' already exists with different content for package '{packageId}'.")

--- a/src/MediaIngest.Api/LocalManifestTransferPublisher.cs
+++ b/src/MediaIngest.Api/LocalManifestTransferPublisher.cs
@@ -5,7 +5,7 @@ using MediaIngest.Worker.Outbox;
 
 namespace MediaIngest.Api;
 
-public sealed class LocalManifestTransferPublisher : IOutboxMessagePublisher
+internal sealed class LocalManifestTransferPublisher : IOutboxMessagePublisher
 {
     private static readonly string[] ManifestFileNames =
     [

--- a/src/MediaIngest.Api/LocalManifestTransferRequest.cs
+++ b/src/MediaIngest.Api/LocalManifestTransferRequest.cs
@@ -1,6 +1,6 @@
 namespace MediaIngest.Api;
 
-public sealed record LocalManifestTransferRequest(
+internal sealed record LocalManifestTransferRequest(
     string PackageId,
     string PackagePath,
     string OutputRootPath);

--- a/src/MediaIngest.Api/MediaIngest.Api.csproj
+++ b/src/MediaIngest.Api/MediaIngest.Api.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="MediaIngest.Api.Tests" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="../MediaIngest.Essence/MediaIngest.Essence.csproj" />
     <ProjectReference Include="../MediaIngest.Persistence/MediaIngest.Persistence.csproj" />

--- a/src/MediaIngest.Contracts/MediaIngest.Contracts.csproj
+++ b/src/MediaIngest.Contracts/MediaIngest.Contracts.csproj
@@ -3,4 +3,8 @@
     <RootNamespace>MediaIngest.Contracts</RootNamespace>
     <AssemblyName>MediaIngest.Contracts</AssemblyName>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="MediaIngest.Contracts.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/MediaIngest.Essence/MediaIngest.Essence.csproj
+++ b/src/MediaIngest.Essence/MediaIngest.Essence.csproj
@@ -3,4 +3,8 @@
     <RootNamespace>MediaIngest.Essence</RootNamespace>
     <AssemblyName>MediaIngest.Essence</AssemblyName>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="MediaIngest.Essence.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/MediaIngest.Foundation/FoundationMetadata.cs
+++ b/src/MediaIngest.Foundation/FoundationMetadata.cs
@@ -1,6 +1,6 @@
 namespace MediaIngest.Foundation;
 
-public static class FoundationMetadata
+internal static class FoundationMetadata
 {
     public const string SolutionName = "MediaIngest";
 }

--- a/src/MediaIngest.Foundation/MediaIngest.Foundation.csproj
+++ b/src/MediaIngest.Foundation/MediaIngest.Foundation.csproj
@@ -3,4 +3,8 @@
     <RootNamespace>MediaIngest.Foundation</RootNamespace>
     <AssemblyName>MediaIngest.Foundation</AssemblyName>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="MediaIngest.Foundation.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/MediaIngest.Observability/MediaIngest.Observability.csproj
+++ b/src/MediaIngest.Observability/MediaIngest.Observability.csproj
@@ -3,4 +3,8 @@
     <RootNamespace>MediaIngest.Observability</RootNamespace>
     <AssemblyName>MediaIngest.Observability</AssemblyName>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="MediaIngest.Observability.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/MediaIngest.Persistence/MediaIngest.Persistence.csproj
+++ b/src/MediaIngest.Persistence/MediaIngest.Persistence.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>MediaIngest.Persistence</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="MediaIngest.Persistence.Tests" />
     <PackageReference Include="Npgsql" Version="10.0.2" />
   </ItemGroup>
 </Project>

--- a/src/MediaIngest.Persistence/PostgresIngestSchema.cs
+++ b/src/MediaIngest.Persistence/PostgresIngestSchema.cs
@@ -1,6 +1,6 @@
 namespace MediaIngest.Persistence;
 
-public static class PostgresIngestSchema
+internal static class PostgresIngestSchema
 {
     public const string SchemaSql = """
         CREATE TABLE IF NOT EXISTS ingest_package_states (

--- a/src/MediaIngest.Worker.CommandRunner/MediaIngest.Worker.CommandRunner.csproj
+++ b/src/MediaIngest.Worker.CommandRunner/MediaIngest.Worker.CommandRunner.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="MediaIngest.Worker.CommandRunner.Tests" />
     <ProjectReference Include="../MediaIngest.Contracts/MediaIngest.Contracts.csproj" />
     <ProjectReference Include="../MediaIngest.Observability/MediaIngest.Observability.csproj" />
   </ItemGroup>

--- a/src/MediaIngest.Worker.Outbox/MediaIngest.Worker.Outbox.csproj
+++ b/src/MediaIngest.Worker.Outbox/MediaIngest.Worker.Outbox.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="MediaIngest.Worker.Outbox.Tests" />
     <ProjectReference Include="../MediaIngest.Contracts/MediaIngest.Contracts.csproj" />
     <ProjectReference Include="../MediaIngest.Persistence/MediaIngest.Persistence.csproj" />
   </ItemGroup>

--- a/src/MediaIngest.Worker.Watcher/CallbackIngestPackageCandidateSink.cs
+++ b/src/MediaIngest.Worker.Watcher/CallbackIngestPackageCandidateSink.cs
@@ -1,6 +1,6 @@
 namespace MediaIngest.Worker.Watcher;
 
-public sealed class CallbackIngestPackageCandidateSink(
+internal sealed class CallbackIngestPackageCandidateSink(
     Func<IngestPackageCandidate, CancellationToken, ValueTask> observe)
     : IIngestPackageCandidateSink
 {

--- a/src/MediaIngest.Worker.Watcher/IIngestPackageCandidateSink.cs
+++ b/src/MediaIngest.Worker.Watcher/IIngestPackageCandidateSink.cs
@@ -1,6 +1,6 @@
 namespace MediaIngest.Worker.Watcher;
 
-public interface IIngestPackageCandidateSink
+internal interface IIngestPackageCandidateSink
 {
     ValueTask ObserveAsync(IngestPackageCandidate candidate, CancellationToken cancellationToken);
 }

--- a/src/MediaIngest.Worker.Watcher/IngestMountObservationLoop.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestMountObservationLoop.cs
@@ -1,6 +1,6 @@
 namespace MediaIngest.Worker.Watcher;
 
-public sealed class IngestMountObservationLoop
+internal sealed class IngestMountObservationLoop
 {
     private readonly IngestMountObservationLoopOptions options;
     private readonly IIngestPackageCandidateSink sink;

--- a/src/MediaIngest.Worker.Watcher/IngestMountObservationLoopOptions.cs
+++ b/src/MediaIngest.Worker.Watcher/IngestMountObservationLoopOptions.cs
@@ -1,6 +1,6 @@
 namespace MediaIngest.Worker.Watcher;
 
-public sealed record IngestMountObservationLoopOptions
+internal sealed record IngestMountObservationLoopOptions
 {
     public IngestMountObservationLoopOptions(string ingestMountPath, TimeSpan scanInterval)
     {

--- a/src/MediaIngest.Worker.Watcher/MediaIngest.Worker.Watcher.csproj
+++ b/src/MediaIngest.Worker.Watcher/MediaIngest.Worker.Watcher.csproj
@@ -3,4 +3,8 @@
     <RootNamespace>MediaIngest.Worker.Watcher</RootNamespace>
     <AssemblyName>MediaIngest.Worker.Watcher</AssemblyName>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="MediaIngest.Worker.Watcher.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/MediaIngest.Workflow.Orchestrator/MediaIngest.Workflow.Orchestrator.csproj
+++ b/src/MediaIngest.Workflow.Orchestrator/MediaIngest.Workflow.Orchestrator.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="MediaIngest.Workflow.Tests" />
     <ProjectReference Include="../MediaIngest.Contracts/MediaIngest.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MediaIngest.Workflow.Orchestrator/PackageIngestWorkflowDefinition.cs
+++ b/src/MediaIngest.Workflow.Orchestrator/PackageIngestWorkflowDefinition.cs
@@ -26,4 +26,4 @@ namespace MediaIngest.Workflow.Orchestrator;
 [WorkflowEdge("complete-processing", "reconcile-package")]
 [WorkflowEdge("reconcile-package", "wait-done-marker")]
 [WorkflowEdge("wait-done-marker", "finalize-package")]
-public sealed class PackageIngestWorkflowDefinition;
+internal sealed class PackageIngestWorkflowDefinition;

--- a/src/MediaIngest.Workflow/MediaIngest.Workflow.csproj
+++ b/src/MediaIngest.Workflow/MediaIngest.Workflow.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="MediaIngest.Workflow.Tests" />
     <ProjectReference Include="../MediaIngest.Contracts/MediaIngest.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowGraphProjection.cs
@@ -2,7 +2,7 @@ using MediaIngest.Contracts.Workflow;
 
 namespace MediaIngest.Workflow;
 
-public static class PackageWorkflowGraphProjection
+internal static class PackageWorkflowGraphProjection
 {
     public static WorkflowGraphDto FromLifecycle(PackageWorkflowLifecycle lifecycle)
     {

--- a/src/MediaIngest.Workflow/PackageWorkflowLifecycle.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowLifecycle.cs
@@ -1,6 +1,6 @@
 namespace MediaIngest.Workflow;
 
-public sealed class PackageWorkflowLifecycle
+internal sealed class PackageWorkflowLifecycle
 {
     private readonly List<PackageWorkflowLifecycleSnapshot> events;
     private readonly PackageIngestRequest request;

--- a/src/MediaIngest.Workflow/PackageWorkflowLifecycleSnapshot.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowLifecycleSnapshot.cs
@@ -1,6 +1,6 @@
 namespace MediaIngest.Workflow;
 
-public sealed record PackageWorkflowLifecycleSnapshot(
+internal sealed record PackageWorkflowLifecycleSnapshot(
     string PackageId,
     string PackagePath,
     string CorrelationId,

--- a/src/MediaIngest.Workflow/PackageWorkflowLifecycleState.cs
+++ b/src/MediaIngest.Workflow/PackageWorkflowLifecycleState.cs
@@ -1,6 +1,6 @@
 namespace MediaIngest.Workflow;
 
-public enum PackageWorkflowLifecycleState
+internal enum PackageWorkflowLifecycleState
 {
     Observed,
     Ready,


### PR DESCRIPTION
## Summary

- Add `InternalsVisibleTo` test friend assemblies for source projects.
- Internalize API-local DTOs/services, watcher observation-loop helpers, persistence schema SQL, workflow lifecycle projection types, and the orchestrator package definition marker.
- Keep public contract and production cross-assembly boundaries public.

Refs #26

## Validation

- `make validate-summary` passed (`/tmp/media-asset-ingest-validation-etTEdE.log`)
- `git diff --cached --check` passed
- `git diff --check` passed
